### PR TITLE
fix: CS-6841: code-health-rules.json support

### DIFF
--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -23,6 +23,10 @@
                 {
                     "name": "String Heavy Function Arguments",
                     "weight": 0.0
+                },
+                {
+                    "name": "Bumpy Road Ahead",
+                    "weight": 0.0
                 }
             ],
             "thresholds": [

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/BenchmarkSupport.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/BenchmarkSupport.cs
@@ -1,12 +1,7 @@
 // Copyright (c) CodeScene. All rights reserved.
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using Codescene.VSExtension.Core.Application.Cache.Review;
 using Codescene.VSExtension.Core.Application.Cli;
 using Codescene.VSExtension.Core.Interfaces;
@@ -42,7 +37,7 @@ internal sealed class BenchmarkEnvironment : IDisposable
         Directory.CreateDirectory(CacheDirectory);
         System.IO.File.WriteAllText(ExistingFilePath, BenchmarkInputs.CurrentCode);
 
-        _cacheStorageService = new BenchmarkCacheStorageService(CacheDirectory);
+        _cacheStorageService = new BenchmarkCacheStorageService(CacheDirectory, RootDirectory);
         _commandProvider = new CliCommandProvider(new CliObjectScoreCreator(_logger));
         _processExecutor = CreateProcessExecutor(_cliSettingsProvider, _logger);
     }
@@ -176,12 +171,15 @@ internal sealed class BenchmarkCliServices : ICliServices
 
 internal sealed class BenchmarkCacheStorageService : ICacheStorageService
 {
-    public BenchmarkCacheStorageService(string cacheDirectory)
+    public BenchmarkCacheStorageService(string cacheDirectory, string workspaceDirectory)
     {
         CacheDirectory = cacheDirectory;
+        WorkspaceDirectory = workspaceDirectory;
     }
 
     public string CacheDirectory { get; }
+
+    public string WorkspaceDirectory { get; }
 
     public Task InitializeAsync(CancellationToken cancellationToken = default)
     {
@@ -190,6 +188,8 @@ internal sealed class BenchmarkCacheStorageService : ICacheStorageService
     }
 
     public string GetSolutionReviewCacheLocation() => CacheDirectory;
+
+    public string GetWorkspaceDirectory() => WorkspaceDirectory ?? string.Empty;
 
     public void RemoveOldReviewCacheEntries(int nrOfDays = 30)
     {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/CliExecutorBenchmarks.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/CliExecutorBenchmarks.cs
@@ -1,8 +1,5 @@
 // Copyright (c) CodeScene. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Codescene.VSExtension.Core.Application.Cli;
 using Codescene.VSExtension.Core.Models.Cli.Delta;
@@ -27,8 +24,8 @@ public class CliExecutorBenchmarks
         _environment = new BenchmarkEnvironment();
         _cliExecutor = _environment.CreateCliExecutor();
 
-        var baselineReview = _cliExecutor.ReviewContentAsync(BenchmarkInputs.FileName, BenchmarkInputs.BaselineCode).GetAwaiter().GetResult();
-        var currentReview = _cliExecutor.ReviewContentAsync(BenchmarkInputs.FileName, BenchmarkInputs.CurrentCode).GetAwaiter().GetResult();
+        var baselineReview = _cliExecutor.ReviewContentAsync(_environment.ExistingFilePath, BenchmarkInputs.BaselineCode).GetAwaiter().GetResult();
+        var currentReview = _cliExecutor.ReviewContentAsync(_environment.ExistingFilePath, BenchmarkInputs.CurrentCode).GetAwaiter().GetResult();
         if (string.IsNullOrWhiteSpace(baselineReview?.RawScore) || string.IsNullOrWhiteSpace(currentReview?.RawScore))
         {
             throw new InvalidOperationException("Unable to obtain review raw scores for delta benchmarks.");
@@ -64,7 +61,7 @@ public class CliExecutorBenchmarks
     [Benchmark]
     public Task<CliReviewModel> ReviewContentAsync()
     {
-        return _cliExecutor.ReviewContentAsync(BenchmarkInputs.FileName, BenchmarkInputs.CurrentCode);
+        return _cliExecutor.ReviewContentAsync(_environment.ExistingFilePath, BenchmarkInputs.CurrentCode);
     }
 
     [Benchmark]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/CodeReviewerBenchmarks.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/CodeReviewerBenchmarks.cs
@@ -1,12 +1,9 @@
 // Copyright (c) CodeScene. All rights reserved.
 
-using System.IO;
-using System.Threading;
 using BenchmarkDotNet.Attributes;
 using Codescene.VSExtension.Core.Application.Cache.Review;
 using Codescene.VSExtension.Core.Application.Cli;
 using Codescene.VSExtension.Core.Models;
-using Codescene.VSExtension.Core.Models.Cli.Refactor;
 
 namespace Codescene.VSExtension.Core.Benchmarks;
 
@@ -38,7 +35,7 @@ public class CodeReviewerBenchmarks
 
         _codeReviewerWithPreflight = _environment.CreateCodeReviewer(_gitService, new FixedPreflightManager(preflightResponse));
 
-        var currentReview = _environment.CreateCliExecutor().ReviewContentAsync(BenchmarkInputs.FileName, BenchmarkInputs.CurrentCode).GetAwaiter().GetResult();
+        var currentReview = _environment.CreateCliExecutor().ReviewContentAsync(_environment.ExistingFilePath, BenchmarkInputs.CurrentCode).GetAwaiter().GetResult();
         if (string.IsNullOrWhiteSpace(currentReview?.RawScore))
         {
             throw new InvalidOperationException("Unable to obtain a review raw score for CodeReviewer benchmarks.");

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/CliExecutor/BaseCliExecutorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/CliExecutor/BaseCliExecutorTests.cs
@@ -19,6 +19,8 @@ namespace Codescene.VSExtension.Core.IntegrationTests.CliExecutor
 
             mockCacheStorageService.Setup(x => x.GetSolutionReviewCacheLocation())
                 .Returns(tempCacheDir);
+            mockCacheStorageService.Setup(x => x.GetWorkspaceDirectory())
+                .Returns(string.Empty);
         }
 
         public virtual void Cleanup()

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/CliExecutor/CodeHealthRulesReviewTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/CliExecutor/CodeHealthRulesReviewTests.cs
@@ -338,27 +338,11 @@ public static class SixParams
 
             public static bool HasSmellCategoryContaining(CliReviewModel r, string substring)
             {
-                foreach (var s in r.FileLevelCodeSmells ?? new List<CliCodeSmellModel>())
+                foreach (var s in EnumerateAllSmells(r))
                 {
-                    if (s.Category != null && s.Category.Contains(substring, StringComparison.OrdinalIgnoreCase))
+                    if (CategoryContainsSubstring(s, substring))
                     {
                         return true;
-                    }
-                }
-
-                foreach (var fn in r.FunctionLevelCodeSmells ?? new List<CliReviewFunctionModel>())
-                {
-                    if (fn.CodeSmells == null)
-                    {
-                        continue;
-                    }
-
-                    foreach (var s in fn.CodeSmells)
-                    {
-                        if (s.Category != null && s.Category.Contains(substring, StringComparison.OrdinalIgnoreCase))
-                        {
-                            return true;
-                        }
                     }
                 }
 
@@ -377,6 +361,41 @@ public static class SixParams
                     Assert.Fail(
                         $"code-health-rules-error: {r.CodeHealthRulesError.Description} remedy: {r.CodeHealthRulesError.Remedy}");
                 }
+            }
+
+            private static IEnumerable<CliCodeSmellModel> EnumerateAllSmells(CliReviewModel r)
+            {
+                if (r.FileLevelCodeSmells != null)
+                {
+                    foreach (var s in r.FileLevelCodeSmells)
+                    {
+                        yield return s;
+                    }
+                }
+
+                if (r.FunctionLevelCodeSmells == null)
+                {
+                    yield break;
+                }
+
+                foreach (var fn in r.FunctionLevelCodeSmells)
+                {
+                    if (fn.CodeSmells == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var s in fn.CodeSmells)
+                    {
+                        yield return s;
+                    }
+                }
+            }
+
+            private static bool CategoryContainsSubstring(CliCodeSmellModel smell, string substring)
+            {
+                return smell.Category != null
+                    && smell.Category.Contains(substring, StringComparison.OrdinalIgnoreCase);
             }
         }
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/CliExecutor/CodeHealthRulesReviewTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/CliExecutor/CodeHealthRulesReviewTests.cs
@@ -1,0 +1,383 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using Codescene.VSExtension.Core.Models.Cli.Review;
+using LibGit2Sharp;
+
+namespace Codescene.VSExtension.Core.IntegrationTests.CliExecutor
+{
+    [TestClass]
+    public class CodeHealthRulesReviewTests : BaseCliExecutorTests
+    {
+        private const string BumpyRoadSource = """
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Codescene.VSExtension.CodeSmells.Issues.CSharp
+{
+    class BumpyRoadExample
+    {
+        public void ProcessDirectory(string path)
+        {
+            var files = new List<string>();
+            var directory = new DirectoryInfo(path);
+
+            foreach (FileInfo fileInfo in directory.GetFiles())
+            {
+                if (Regex.IsMatch(fileInfo.Name, @"^data\d+\.csv$"))
+                {
+                    files.Add(fileInfo.FullName);
+                }
+            }
+
+            var sb = new StringBuilder();
+            foreach (string filePath in files)
+            {
+                using (var reader = new StreamReader(filePath))
+                {
+                    string line;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        sb.Append(line);
+                    }
+                }
+            }
+
+            using (var writer = new StreamWriter("data.csv"))
+            {
+                writer.Write(sb.ToString());
+            }
+        }
+    }
+}
+""";
+
+        private const string RulesBumpyRoadWeight0 = """
+{
+  "rule_sets": [
+    {
+      "matching_content_path": "**/*",
+      "rules": [
+        {
+          "name": "Bumpy Road Ahead",
+          "weight": 0.0
+        }
+      ]
+    }
+  ]
+}
+""";
+
+        private const string RulesBumpyRoadWeight1 = """
+{
+  "rule_sets": [
+    {
+      "matching_content_path": "**/*",
+      "rules": [
+        {
+          "name": "Bumpy Road Ahead",
+          "weight": 1.0
+        }
+      ]
+    }
+  ]
+}
+""";
+
+        private const string RulesFunctionMaxArguments7 = """
+{
+  "rule_sets": [
+    {
+      "matching_content_path": "**/*",
+      "rules": [],
+      "thresholds": [
+        {
+          "name": "function_max_arguments",
+          "value": "7"
+        }
+      ]
+    }
+  ]
+}
+""";
+
+        private const string EightParameterMethodSource = """
+namespace ArgsThreshold;
+
+public static class EightParams
+{
+    public static void M(int a, int b, int c, int d, int e, int f, int g, int h)
+    {
+    }
+}
+""";
+
+        private const string SixParameterMethodSource = """
+namespace ArgsThreshold;
+
+public static class SixParams
+{
+    public static void M(int a, int b, int c, int d, int e, int f)
+    {
+    }
+}
+""";
+
+        private string? _gitRepoRoot;
+
+        [TestInitialize]
+        public override void Initialize() => base.Initialize();
+
+        [TestCleanup]
+        public override void Cleanup()
+        {
+            TryDeleteGitRepo();
+            base.Cleanup();
+        }
+
+        [TestMethod]
+        public async Task ReviewContentAsync_BumpyRoadWeightZero_ScoreTenNoFunctionLevelSmells()
+        {
+            var filePath = PrepareGitRepoWithRules(RulesBumpyRoadWeight0, "src/BumpyRoad.cs", BumpyRoadSource);
+            try
+            {
+                var result = await cliExecutor.ReviewContentAsync(filePath, BumpyRoadSource);
+
+                Assert.IsNotNull(result);
+                Helpers.AssertNoCodeHealthRulesError(result);
+                Assert.AreEqual(10f, result.Score!.Value, 0.01f);
+                Assert.IsTrue(
+                    result.FunctionLevelCodeSmells == null || result.FunctionLevelCodeSmells.Count == 0,
+                    "Bumpy Road weight 0 should yield no function-level code smells");
+            }
+            finally
+            {
+                TryDeleteGitRepo();
+            }
+        }
+
+        [TestMethod]
+        public async Task ReviewContentAsync_BumpyRoadWeightOne_RetainsSmell()
+        {
+            var filePath = PrepareGitRepoWithRules(RulesBumpyRoadWeight1, "src/BumpyRoad.cs", BumpyRoadSource);
+            try
+            {
+                var result = await cliExecutor.ReviewContentAsync(filePath, BumpyRoadSource);
+
+                Assert.IsNotNull(result);
+                Helpers.AssertNoCodeHealthRulesError(result);
+                Assert.IsTrue(
+                    Helpers.TotalSmellCount(result) > 0 || Helpers.HasSmellCategoryContaining(result, "Bumpy Road"),
+                    "Bumpy Road should contribute when weight is 1.0");
+            }
+            finally
+            {
+                TryDeleteGitRepo();
+            }
+        }
+
+        [TestMethod]
+        public async Task ReviewContentAsync_NoCodeHealthRules_BumpyRoadNotSuppressed()
+        {
+            var filePath = PrepareGitRepoWithoutRules("src/BumpyRoad.cs", BumpyRoadSource);
+            try
+            {
+                var result = await cliExecutor.ReviewContentAsync(filePath, BumpyRoadSource);
+
+                Assert.IsNotNull(result);
+                Helpers.AssertNoCodeHealthRulesError(result);
+                Assert.IsTrue(
+                    Helpers.TotalSmellCount(result) > 0 || result.Score < 10,
+                    "Default rules should surface complexity / Bumpy Road for this fixture");
+            }
+            finally
+            {
+                TryDeleteGitRepo();
+            }
+        }
+
+        [TestMethod]
+        public async Task ReviewContentAsync_FunctionMaxArgumentsThreshold_ExceedingLimit_Reported()
+        {
+            var filePath = PrepareGitRepoWithRules(RulesFunctionMaxArguments7, "src/Args.cs", EightParameterMethodSource);
+            try
+            {
+                var result = await cliExecutor.ReviewContentAsync(filePath, EightParameterMethodSource);
+
+                Assert.IsNotNull(result);
+                Helpers.AssertNoCodeHealthRulesError(result);
+                Assert.IsTrue(
+                    Helpers.HasTooManyArgumentsSmell(result),
+                    "Eight parameters should exceed function_max_arguments threshold of 7");
+            }
+            finally
+            {
+                TryDeleteGitRepo();
+            }
+        }
+
+        [TestMethod]
+        public async Task ReviewContentAsync_FunctionMaxArgumentsThreshold_UnderLimit_NotReported()
+        {
+            var filePath = PrepareGitRepoWithRules(RulesFunctionMaxArguments7, "src/Args.cs", SixParameterMethodSource);
+            try
+            {
+                var result = await cliExecutor.ReviewContentAsync(filePath, SixParameterMethodSource);
+
+                Assert.IsNotNull(result);
+                Helpers.AssertNoCodeHealthRulesError(result);
+                Assert.IsFalse(
+                    Helpers.HasTooManyArgumentsSmell(result),
+                    "Six parameters should not exceed function_max_arguments threshold of 7");
+            }
+            finally
+            {
+                TryDeleteGitRepo();
+            }
+        }
+
+        private string PrepareGitRepoWithRules(string rulesJson, string sourceRelativePath, string sourceContent)
+        {
+            TryDeleteGitRepo();
+            _gitRepoRoot = Path.Combine(Path.GetTempPath(), "codescene-ch-rules", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_gitRepoRoot);
+            Repository.Init(_gitRepoRoot);
+            using (var repo = new Repository(_gitRepoRoot))
+            {
+                repo.Config.Set("user.email", "test@example.com");
+                repo.Config.Set("user.name", "Test User");
+            }
+
+            WriteRepoFile(".codescene/code-health-rules.json", rulesJson);
+            WriteRepoFile(sourceRelativePath, sourceContent);
+            StageAndCommit(new[] { ".codescene/code-health-rules.json", sourceRelativePath });
+
+            return Path.GetFullPath(Path.Combine(_gitRepoRoot, sourceRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+        }
+
+        private string PrepareGitRepoWithoutRules(string sourceRelativePath, string sourceContent)
+        {
+            TryDeleteGitRepo();
+            _gitRepoRoot = Path.Combine(Path.GetTempPath(), "codescene-ch-rules", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_gitRepoRoot);
+            Repository.Init(_gitRepoRoot);
+            using (var repo = new Repository(_gitRepoRoot))
+            {
+                repo.Config.Set("user.email", "test@example.com");
+                repo.Config.Set("user.name", "Test User");
+            }
+
+            WriteRepoFile(sourceRelativePath, sourceContent);
+            StageAndCommit(new[] { sourceRelativePath });
+
+            return Path.GetFullPath(Path.Combine(_gitRepoRoot, sourceRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+        }
+
+        private void WriteRepoFile(string relativePath, string content)
+        {
+            var fullPath = Path.Combine(_gitRepoRoot!, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            var dir = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            File.WriteAllText(fullPath, content);
+        }
+
+        private void StageAndCommit(string[] relativePaths)
+        {
+            using var repo = new Repository(_gitRepoRoot!);
+            foreach (var p in relativePaths)
+            {
+                Commands.Stage(repo, p);
+            }
+
+            var sig = new Signature("Test User", "test@example.com", DateTimeOffset.Now);
+            repo.Commit("test", sig, sig);
+        }
+
+        private void TryDeleteGitRepo()
+        {
+            if (string.IsNullOrEmpty(_gitRepoRoot) || !Directory.Exists(_gitRepoRoot))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(_gitRepoRoot, recursive: true);
+            }
+            catch
+            {
+            }
+
+            _gitRepoRoot = null;
+        }
+
+        private static class Helpers
+        {
+            public static int TotalSmellCount(CliReviewModel r)
+            {
+                var n = r.FileLevelCodeSmells?.Count ?? 0;
+                if (r.FunctionLevelCodeSmells != null)
+                {
+                    foreach (var fn in r.FunctionLevelCodeSmells)
+                    {
+                        if (fn.CodeSmells != null)
+                        {
+                            n += fn.CodeSmells.Length;
+                        }
+                    }
+                }
+
+                return n;
+            }
+
+            public static bool HasSmellCategoryContaining(CliReviewModel r, string substring)
+            {
+                foreach (var s in r.FileLevelCodeSmells ?? new List<CliCodeSmellModel>())
+                {
+                    if (s.Category != null && s.Category.Contains(substring, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+
+                foreach (var fn in r.FunctionLevelCodeSmells ?? new List<CliReviewFunctionModel>())
+                {
+                    if (fn.CodeSmells == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var s in fn.CodeSmells)
+                    {
+                        if (s.Category != null && s.Category.Contains(substring, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+
+            public static bool HasTooManyArgumentsSmell(CliReviewModel r)
+            {
+                return HasSmellCategoryContaining(r, "argument");
+            }
+
+            public static void AssertNoCodeHealthRulesError(CliReviewModel r)
+            {
+                if (r.CodeHealthRulesError != null)
+                {
+                    Assert.Fail(
+                        $"code-health-rules-error: {r.CodeHealthRulesError.Description} remedy: {r.CodeHealthRulesError.Remedy}");
+                }
+            }
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/CliExecutor/ReviewContentTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/CliExecutor/ReviewContentTests.cs
@@ -14,7 +14,6 @@ namespace Codescene.VSExtension.Core.IntegrationTests.CliExecutor
         [TestMethod]
         public async Task ReviewContentAsync_ValidCSharpCode_ReturnsValidReview()
         {
-            // Arrange
             var filename = "Test.cs";
             var content = @"
 public class Calculator
@@ -24,21 +23,29 @@ public class Calculator
         return a + b;
     }
 }";
+            var dir = Path.Combine(Path.GetTempPath(), "codescene-cli-it", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            var filePath = Path.GetFullPath(Path.Combine(dir, filename));
+            try
+            {
+                File.WriteAllText(filePath, content);
 
-            // Act
-            var result = await cliExecutor.ReviewContentAsync(filename, content);
+                var result = await cliExecutor.ReviewContentAsync(filePath, content);
 
-            // Assert
-            Assert.IsNotNull(result, "CLI should return a review result for valid code");
-            Assert.IsTrue(result.Score.HasValue, "Review should have a score");
-            Assert.IsTrue(result.Score >= 0 && result.Score <= 10, "Score should be between 0 and 10");
-            Assert.IsFalse(string.IsNullOrEmpty(result.RawScore), "Review should have a raw score for delta calculations");
+                Assert.IsNotNull(result, "CLI should return a review result for valid code");
+                Assert.IsTrue(result.Score.HasValue, "Review should have a score");
+                Assert.IsTrue(result.Score >= 0 && result.Score <= 10, "Score should be between 0 and 10");
+                Assert.IsFalse(string.IsNullOrEmpty(result.RawScore), "Review should have a raw score for delta calculations");
+            }
+            finally
+            {
+                TryDeleteDirectory(dir);
+            }
         }
 
         [TestMethod]
         public async Task ReviewContentAsync_ValidJavaScriptCode_ReturnsValidReview()
         {
-            // Arrange
             var filename = "test.js";
             var content = @"
 function calculateSum(numbers) {
@@ -47,19 +54,27 @@ function calculateSum(numbers) {
 
 module.exports = { calculateSum };
 ";
+            var dir = Path.Combine(Path.GetTempPath(), "codescene-cli-it", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            var filePath = Path.GetFullPath(Path.Combine(dir, filename));
+            try
+            {
+                File.WriteAllText(filePath, content);
 
-            // Act
-            var result = await cliExecutor.ReviewContentAsync(filename, content);
+                var result = await cliExecutor.ReviewContentAsync(filePath, content);
 
-            // Assert
-            Assert.IsNotNull(result, "CLI should return a review result for valid JavaScript code");
-            Assert.IsTrue(result.Score.HasValue, "Review should have a score");
+                Assert.IsNotNull(result, "CLI should return a review result for valid JavaScript code");
+                Assert.IsTrue(result.Score.HasValue, "Review should have a score");
+            }
+            finally
+            {
+                TryDeleteDirectory(dir);
+            }
         }
 
         [TestMethod]
         public async Task ReviewContentAsync_ComplexCode_ReturnsCodeSmells()
         {
-            // Arrange - Code with intentional complexity
             var filename = "Complex.cs";
             var content = @"
 public class ComplexProcessor
@@ -84,13 +99,38 @@ public class ComplexProcessor
         }
     }
 }";
+            var dir = Path.Combine(Path.GetTempPath(), "codescene-cli-it", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            var filePath = Path.GetFullPath(Path.Combine(dir, filename));
+            try
+            {
+                File.WriteAllText(filePath, content);
 
-            // Act
-            var result = await cliExecutor.ReviewContentAsync(filename, content);
+                var result = await cliExecutor.ReviewContentAsync(filePath, content);
 
-            // Assert
-            Assert.IsNotNull(result, "CLI should return a review result");
-            Assert.IsTrue(result.Score.HasValue, "Review should have a score");
+                Assert.IsNotNull(result, "CLI should return a review result");
+                Assert.IsTrue(result.Score.HasValue, "Review should have a score");
+            }
+            finally
+            {
+                TryDeleteDirectory(dir);
+            }
+        }
+
+        private static void TryDeleteDirectory(string dir)
+        {
+            if (!Directory.Exists(dir))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+            catch
+            {
+            }
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/CliExecutor/ReviewDeltaTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/CliExecutor/ReviewDeltaTests.cs
@@ -16,7 +16,6 @@ namespace Codescene.VSExtension.Core.IntegrationTests.CliExecutor
         [TestMethod]
         public async Task ReviewDeltaAsync_WithValidScores_ReturnsDeltaResponse()
         {
-            // Arrange
             var filename = "Test.cs";
             var simpleCode = @"
 public class Simple
@@ -39,21 +38,47 @@ public class Complex
     }
 }";
 
-            var simpleReview = await cliExecutor.ReviewContentAsync(filename, simpleCode);
-            var complexReview = await cliExecutor.ReviewContentAsync(filename, complexCode);
-
-            // Skip test if we couldn't get raw scores
-            if (string.IsNullOrEmpty(simpleReview?.RawScore) || string.IsNullOrEmpty(complexReview?.RawScore))
+            var dir = Path.Combine(Path.GetTempPath(), "codescene-cli-it", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            var filePath = Path.GetFullPath(Path.Combine(dir, filename));
+            try
             {
-                Assert.Inconclusive("Could not obtain raw scores for delta comparison");
+                File.WriteAllText(filePath, simpleCode);
+                var simpleReview = await cliExecutor.ReviewContentAsync(filePath, simpleCode);
+
+                File.WriteAllText(filePath, complexCode);
+                var complexReview = await cliExecutor.ReviewContentAsync(filePath, complexCode);
+
+                if (string.IsNullOrEmpty(simpleReview?.RawScore) || string.IsNullOrEmpty(complexReview?.RawScore))
+                {
+                    Assert.Inconclusive("Could not obtain raw scores for delta comparison");
+                    return;
+                }
+
+                var delta = await cliExecutor.ReviewDeltaAsync(new ReviewDeltaRequest { OldScore = simpleReview!.RawScore!, NewScore = complexReview!.RawScore! });
+
+                Assert.IsNotNull(delta, "CLI should return a delta response");
+            }
+            finally
+            {
+                TryDeleteDirectory(dir);
+            }
+        }
+
+        private static void TryDeleteDirectory(string dir)
+        {
+            if (!Directory.Exists(dir))
+            {
                 return;
             }
 
-            // Act
-            var delta = await cliExecutor.ReviewDeltaAsync(new ReviewDeltaRequest { OldScore = simpleReview!.RawScore!, NewScore = complexReview!.RawScore! });
-
-            // Assert
-            Assert.IsNotNull(delta, "CLI should return a delta response");
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+            catch
+            {
+            }
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/Codescene.VSExtension.Core.IntegrationTests.csproj
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/Codescene.VSExtension.Core.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net48</TargetFramework>
@@ -16,6 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4" />
+		<PackageReference Include="LibGit2Sharp" Version="0.31.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="MSTest" Version="4.0.2" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118" Condition="'$(RunStyleCopAnalyzers)' == 'true'">

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestCacheStorageService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestCacheStorageService.cs
@@ -1,7 +1,6 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using System.ComponentModel.Composition;
-using System.Threading;
 using Codescene.VSExtension.Core.Interfaces.Cli;
 using Moq;
 
@@ -14,6 +13,8 @@ namespace Codescene.VSExtension.Core.IntegrationTests.TestImplementations
         internal Mock<ICacheStorageService> Mock = new Mock<ICacheStorageService>();
 
         public string GetSolutionReviewCacheLocation() => Mock.Object.GetSolutionReviewCacheLocation();
+
+        public string GetWorkspaceDirectory() => Mock.Object.GetWorkspaceDirectory();
 
         public Task InitializeAsync(CancellationToken cancellationToken = default) => Mock.Object.InitializeAsync(cancellationToken);
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingCliExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingCliExecutor.cs
@@ -50,18 +50,18 @@ public sealed class RecordingCliExecutor : ICliExecutor
         }
     }
 
-    public async Task<CliReviewModel> ReviewContentAsync(string filename, string content, bool isBaseLine = false, CancellationToken cancellationToken = default)
+    public async Task<CliReviewModel> ReviewContentAsync(string filePath, string content, bool isBaseLine = false, CancellationToken cancellationToken = default)
     {
-        _journal.Record("cli.review.started", filename, $"baseline={isBaseLine}");
+        _journal.Record("cli.review.started", filePath, $"baseline={isBaseLine}");
         try
         {
-            var result = await _inner.ReviewContentAsync(filename, content, isBaseLine, cancellationToken);
-            _journal.Record("cli.review.completed", filename, $"result={result != null};baseline={isBaseLine}");
+            var result = await _inner.ReviewContentAsync(filePath, content, isBaseLine, cancellationToken);
+            _journal.Record("cli.review.completed", filePath, $"result={result != null};baseline={isBaseLine}");
             return result!;
         }
         catch (OperationCanceledException)
         {
-            _journal.Record("cli.review.canceled", filename, $"baseline={isBaseLine}");
+            _journal.Record("cli.review.canceled", filePath, $"baseline={isBaseLine}");
             throw;
         }
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/TestHarnessServices.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/TestHarnessServices.cs
@@ -147,6 +147,11 @@ public sealed class TestCacheStorageService : ICacheStorageService
         return _cacheDirectory;
     }
 
+    public string GetWorkspaceDirectory()
+    {
+        return string.Empty;
+    }
+
     public void RemoveOldReviewCacheEntries(int nrOfDays = 30)
     {
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliCommandProviderTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliCommandProviderTests.cs
@@ -14,6 +14,7 @@ namespace Codescene.VSExtension.Core.Tests
     public class CliCommandProviderTests
     {
         private const string TestFileName = "js";
+        private const string TestReviewFilePath = "/home/user/project/src/app.js";
         private const string TestFileContent = "content";
         private const string TestCachePath = "/home/user/cache";
 
@@ -38,9 +39,9 @@ namespace Codescene.VSExtension.Core.Tests
         [TestMethod]
         public void GetReviewFileContentPayload_ReturnsCorrectJson()
         {
-            var payload = _commandProvider.GetReviewFileContentPayload(TestFileName, TestFileContent, TestCachePath);
+            var payload = _commandProvider.GetReviewFileContentPayload(TestReviewFilePath, TestFileContent, TestCachePath);
 
-            Assert.AreEqual($"{{\"path\":\"{TestFileName}\",\"file-content\":\"{TestFileContent}\",\"cache-path\":\"{TestCachePath}\"}}", payload);
+            Assert.AreEqual($"{{\"path\":\"{TestReviewFilePath}\",\"file-content\":\"{TestFileContent}\",\"cache-path\":\"{TestCachePath}\"}}", payload);
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorRefactorDeviceTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorRefactorDeviceTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) CodeScene. All rights reserved.
 
-using System.Threading;
 using Codescene.VSExtension.Core.Application.Cli;
 using Codescene.VSExtension.Core.Exceptions;
 using Codescene.VSExtension.Core.Interfaces;
@@ -43,6 +42,7 @@ namespace Codescene.VSExtension.Core.Tests
             _mockCliServices.Setup(x => x.ProcessExecutor).Returns(_mockProcessExecutor.Object);
             _mockCliServices.Setup(x => x.CacheStorage).Returns(_mockCacheStorage.Object);
             _mockCacheStorage.Setup(x => x.GetSolutionReviewCacheLocation()).Returns(TestCachePath);
+            _mockCacheStorage.Setup(x => x.GetWorkspaceDirectory()).Returns(string.Empty);
 
             _cliExecutor = new CliExecutor(_mockLogger.Object, _mockCliServices.Object, _mockSettingsProvider.Object, null);
         }
@@ -56,7 +56,7 @@ namespace Codescene.VSExtension.Core.Tests
             var token = "test-token";
             _mockSettingsProvider.Setup(x => x.AuthToken).Returns(token);
             _mockCommandProvider.Setup(x => x.GetRefactorPostCommand(fnToRefactor, false, token)).Returns("refactor post command");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("refactor post command", It.IsAny<string>(), null, default)).ReturnsAsync(jsonResponse);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("refactor post command", It.IsAny<string>(), null, default, It.IsAny<string>())).ReturnsAsync(jsonResponse);
 
             var result = await _cliExecutor.PostRefactoringAsync(fnToRefactor, skipCache: false);
 
@@ -88,7 +88,7 @@ namespace Codescene.VSExtension.Core.Tests
             var response = new RefactorResponseModel { Code = "refactored" };
             var jsonResponse = JsonConvert.SerializeObject(response);
             _mockCommandProvider.Setup(x => x.GetRefactorPostCommand(fnToRefactor, false, providedToken)).Returns("refactor post");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>())).ReturnsAsync(jsonResponse);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>())).ReturnsAsync(jsonResponse);
 
             var result = await _cliExecutor.PostRefactoringAsync(fnToRefactor, skipCache: false, token: providedToken);
 
@@ -115,7 +115,7 @@ namespace Codescene.VSExtension.Core.Tests
             var fnToRefactor = new FnToRefactorModel { Name = "Test" };
             _mockSettingsProvider.Setup(x => x.AuthToken).Returns("test-token");
             _mockCommandProvider.Setup(x => x.GetRefactorPostCommand(It.IsAny<FnToRefactorModel>(), It.IsAny<bool>(), It.IsAny<string>())).Returns("refactor post");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>())).ThrowsAsync(new Exception("Error"));
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>())).ThrowsAsync(new Exception("Error"));
 
             var result = await _cliExecutor.PostRefactoringAsync(fnToRefactor);
 
@@ -132,7 +132,7 @@ namespace Codescene.VSExtension.Core.Tests
             var jsonResponse = JsonConvert.SerializeObject(response);
             _mockSettingsProvider.Setup(x => x.AuthToken).Returns(token);
             _mockCommandProvider.Setup(x => x.GetRefactorPostCommand(fnToRefactor, true, token)).Returns("refactor post --skip-cache");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>())).ReturnsAsync(jsonResponse);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>())).ReturnsAsync(jsonResponse);
 
             var result = await _cliExecutor.PostRefactoringAsync(fnToRefactor, skipCache: true);
 
@@ -149,7 +149,7 @@ namespace Codescene.VSExtension.Core.Tests
             var jsonResponse = JsonConvert.SerializeObject(expectedFunctions);
             _mockCommandProvider.Setup(x => x.GetRefactorWithCodeSmellsPayload(TestFileName, TestFileContent, TestCachePath, codeSmells, preflight)).Returns("payload");
             _mockCommandProvider.Setup(x => x.RefactorCommand).Returns("refactor");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("refactor", "payload", null, default)).ReturnsAsync(jsonResponse);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("refactor", "payload", null, default, It.IsAny<string>())).ReturnsAsync(jsonResponse);
 
             var result = await _cliExecutor.FnsToRefactorFromCodeSmellsAsync(TestFileName, TestFileContent, codeSmells, preflight);
 
@@ -195,7 +195,7 @@ namespace Codescene.VSExtension.Core.Tests
             var jsonResponse = JsonConvert.SerializeObject(new List<FnToRefactorModel>());
             _mockCommandProvider.Setup(x => x.GetRefactorWithCodeSmellsPayload(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<CliCodeSmellModel>>(), It.IsAny<PreFlightResponseModel>())).Returns("payload");
             _mockCommandProvider.Setup(x => x.RefactorCommand).Returns("refactor");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>())).ReturnsAsync(jsonResponse);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>())).ReturnsAsync(jsonResponse);
 
             await _cliExecutor.FnsToRefactorFromCodeSmellsAsync(TestFileName, TestFileContent, codeSmells, null);
 
@@ -211,7 +211,7 @@ namespace Codescene.VSExtension.Core.Tests
             var jsonResponse = JsonConvert.SerializeObject(expectedFunctions);
             _mockCommandProvider.Setup(x => x.GetRefactorWithDeltaResultPayload(TestFileName, TestFileContent, TestCachePath, deltaResult, preflight)).Returns("payload");
             _mockCommandProvider.Setup(x => x.RefactorCommand).Returns("refactor");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("refactor", "payload", null, default)).ReturnsAsync(jsonResponse);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("refactor", "payload", null, default, It.IsAny<string>())).ReturnsAsync(jsonResponse);
 
             var result = await _cliExecutor.FnsToRefactorFromDeltaAsync(TestFileName, TestFileContent, deltaResult, preflight);
 
@@ -248,7 +248,7 @@ namespace Codescene.VSExtension.Core.Tests
             var jsonResponse = JsonConvert.SerializeObject(new List<FnToRefactorModel>());
             _mockCommandProvider.Setup(x => x.GetRefactorWithDeltaResultPayload(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DeltaResponseModel>(), It.IsAny<PreFlightResponseModel>())).Returns("payload");
             _mockCommandProvider.Setup(x => x.RefactorCommand).Returns("refactor");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>())).ReturnsAsync(jsonResponse);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>())).ReturnsAsync(jsonResponse);
 
             await _cliExecutor.FnsToRefactorFromDeltaAsync(TestFileName, TestFileContent, deltaResult, null);
 
@@ -266,8 +266,8 @@ namespace Codescene.VSExtension.Core.Tests
 
             _mockCommandProvider.Setup(x => x.GetRefactorWithDeltaResultPayload(TestFileName, TestFileContent, TestCachePath, deltaResult, null)).Returns("payload");
             _mockCommandProvider.Setup(x => x.RefactorCommand).Returns("refactor");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("refactor", "payload", null, It.IsAny<CancellationToken>()))
-                .Returns<string, string, TimeSpan?, CancellationToken>(async (_, _, _, _) =>
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("refactor", "payload", null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .Returns<string, string, TimeSpan?, CancellationToken, string>(async (_, _, _, _, __) =>
                 {
                     Interlocked.Increment(ref callCount);
                     await completion.Task;
@@ -301,8 +301,8 @@ namespace Codescene.VSExtension.Core.Tests
 
             _mockCommandProvider.Setup(x => x.GetRefactorWithDeltaResultPayload(TestFileName, TestFileContent, TestCachePath, deltaResult, null)).Returns("payload");
             _mockCommandProvider.Setup(x => x.RefactorCommand).Returns("refactor");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("refactor", "payload", null, It.IsAny<CancellationToken>()))
-                .Returns<string, string, TimeSpan?, CancellationToken>((_, _, _, token) =>
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("refactor", "payload", null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .Returns<string, string, TimeSpan?, CancellationToken, string>((_, _, _, token, __) =>
                 {
                     capturedToken = token;
                     entered.TrySetResult(true);
@@ -323,7 +323,7 @@ namespace Codescene.VSExtension.Core.Tests
 
             Assert.HasCount(1, secondResult);
             Assert.AreEqual(CancellationToken.None, capturedToken);
-            _mockProcessExecutor.Verify(x => x.ExecuteAsync("refactor", "payload", null, It.IsAny<CancellationToken>()), Times.Once);
+            _mockProcessExecutor.Verify(x => x.ExecuteAsync("refactor", "payload", null, It.IsAny<CancellationToken>(), It.IsAny<string>()), Times.Once);
         }
 
         [TestMethod]
@@ -331,7 +331,7 @@ namespace Codescene.VSExtension.Core.Tests
         {
             var expectedDeviceId = "device-id-123";
             _mockCommandProvider.Setup(x => x.DeviceIdCommand).Returns("device-id");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("device-id", null, null, default)).ReturnsAsync(expectedDeviceId);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("device-id", null, null, default, It.IsAny<string>())).ReturnsAsync(expectedDeviceId);
 
             var result = await _cliExecutor.GetDeviceIdAsync();
 
@@ -342,7 +342,7 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task GetDeviceId_WhenProcessExecutorThrowsException_ReturnsEmptyString()
         {
             _mockCommandProvider.Setup(x => x.DeviceIdCommand).Returns("device-id");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("device-id", null, null, default)).ThrowsAsync(new Exception("Error"));
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("device-id", null, null, default, It.IsAny<string>())).ThrowsAsync(new Exception("Error"));
 
             var result = await _cliExecutor.GetDeviceIdAsync();
 
@@ -355,7 +355,7 @@ namespace Codescene.VSExtension.Core.Tests
         {
             var deviceIdWithWhitespace = "  device-id-123  \r\n";
             _mockCommandProvider.Setup(x => x.DeviceIdCommand).Returns("device-id");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("device-id", null, null, default)).ReturnsAsync(deviceIdWithWhitespace);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("device-id", null, null, default, It.IsAny<string>())).ReturnsAsync(deviceIdWithWhitespace);
 
             var result = await _cliExecutor.GetDeviceIdAsync();
 
@@ -367,7 +367,7 @@ namespace Codescene.VSExtension.Core.Tests
         {
             var expectedVersion = "1.2.3";
             _mockCommandProvider.Setup(x => x.VersionCommand).Returns("version --sha");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("version --sha", null, null, default)).ReturnsAsync(expectedVersion);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("version --sha", null, null, default, It.IsAny<string>())).ReturnsAsync(expectedVersion);
 
             var result = await _cliExecutor.GetFileVersionAsync();
 
@@ -378,7 +378,7 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task GetFileVersion_WhenProcessExecutorThrowsException_ReturnsEmptyString()
         {
             _mockCommandProvider.Setup(x => x.VersionCommand).Returns("version --sha");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("version --sha", null, null, default)).ThrowsAsync(new Exception("Error"));
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("version --sha", null, null, default, It.IsAny<string>())).ThrowsAsync(new Exception("Error"));
 
             var result = await _cliExecutor.GetFileVersionAsync();
 
@@ -391,7 +391,7 @@ namespace Codescene.VSExtension.Core.Tests
         {
             var versionWithWhitespace = "  1.2.3  \r\n";
             _mockCommandProvider.Setup(x => x.VersionCommand).Returns("version --sha");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("version --sha", null, null, default)).ReturnsAsync(versionWithWhitespace);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("version --sha", null, null, default, It.IsAny<string>())).ReturnsAsync(versionWithWhitespace);
 
             var result = await _cliExecutor.GetFileVersionAsync();
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
@@ -477,6 +477,53 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public void GetReviewCancellationPathIdentity_WhenGetFullPathThrows_ReturnsOriginalPath()
+        {
+            var method = typeof(CliExecutor).GetMethod("GetReviewCancellationPathIdentity", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+            var tooLong = new string('a', 40000);
+            var result = (string)method.Invoke(null, new object[] { tooLong });
+            Assert.AreEqual(tooLong, result);
+        }
+
+        [TestMethod]
+        public void GetCliWorkingDirectoryForFile_WhenGetFullPathThrows_UsesPathForFallback()
+        {
+            _mockCacheStorage.Setup(x => x.GetWorkspaceDirectory()).Returns(string.Empty);
+            var method = typeof(CliExecutor).GetMethod("GetCliWorkingDirectoryForFile", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(method);
+            var pathWithIllegalName = Path.Combine(Path.GetTempPath(), "bad*name.cs");
+            var wd = (string)method.Invoke(_cliExecutor, new object[] { pathWithIllegalName });
+            Assert.AreEqual(Path.GetDirectoryName(pathWithIllegalName), wd);
+        }
+
+        [TestMethod]
+        public void GetCliWorkingDirectoryForFile_BareRepository_SkipsNormalizeWhenWorkingDirectoryEmpty()
+        {
+            var bareRepoPath = Path.Combine(Path.GetTempPath(), "cli-bare-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(bareRepoPath);
+                Repository.Init(bareRepoPath, isBare: true);
+                var fileInBare = Path.Combine(bareRepoPath, "marker.cs");
+                File.WriteAllText(fileInBare, "//");
+                _mockCacheStorage.Setup(x => x.GetWorkspaceDirectory()).Returns(string.Empty);
+                var method = typeof(CliExecutor).GetMethod("GetCliWorkingDirectoryForFile", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.IsNotNull(method);
+                var wd = (string)method.Invoke(_cliExecutor, new object[] { fileInBare });
+                var expectedDir = Path.GetDirectoryName(Path.GetFullPath(fileInBare));
+                Assert.AreEqual(expectedDir, wd);
+            }
+            finally
+            {
+                if (Directory.Exists(bareRepoPath))
+                {
+                    Directory.Delete(bareRepoPath, true);
+                }
+            }
+        }
+
+        [TestMethod]
         public void GetCliWorkingDirectoryForFile_WhenGitResolutionFails_LogsDebugAndUsesFileDirectory()
         {
             var bad = Path.Combine(Path.GetTempPath(), "cli-badgit-" + Guid.NewGuid().ToString("N"));

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) CodeScene. All rights reserved.
 
+using System.Reflection;
 using Codescene.VSExtension.Core.Application.Cli;
 using Codescene.VSExtension.Core.Exceptions;
 using Codescene.VSExtension.Core.Interfaces;
@@ -9,6 +10,8 @@ using Codescene.VSExtension.Core.Interfaces.Telemetry;
 using Codescene.VSExtension.Core.Models.Cli.Delta;
 using Codescene.VSExtension.Core.Models.Cli.Refactor;
 using Codescene.VSExtension.Core.Models.Cli.Review;
+using Codescene.VSExtension.Core.Util;
+using LibGit2Sharp;
 using Moq;
 using Newtonsoft.Json;
 
@@ -384,6 +387,119 @@ namespace Codescene.VSExtension.Core.Tests
             Assert.IsNotNull(firstResult);
             Assert.IsNotNull(secondResult);
             Assert.AreEqual(2, callCount);
+        }
+
+        [TestMethod]
+        public void GetCliWorkingDirectoryForFile_NullOrWhitespace_ReturnsNullWhenNoWorkspace()
+        {
+            _mockCacheStorage.Setup(x => x.GetWorkspaceDirectory()).Returns(string.Empty);
+            var method = typeof(CliExecutor).GetMethod("GetCliWorkingDirectoryForFile", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(method);
+            var rNull = (string)method.Invoke(_cliExecutor, new object[] { null });
+            var rBlank = (string)method.Invoke(_cliExecutor, new object[] { "  \t  " });
+            Assert.IsNull(rNull);
+            Assert.IsNull(rBlank);
+        }
+
+        [TestMethod]
+        public void GetCliWorkingDirectoryForFile_NullOrWhitespace_ReturnsNormalizedWorkspaceWhenConfigured()
+        {
+            var ws = Path.Combine(Path.GetTempPath(), "cli-ws-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(ws);
+                _mockCacheStorage.Setup(x => x.GetWorkspaceDirectory()).Returns(ws);
+                var method = typeof(CliExecutor).GetMethod("GetCliWorkingDirectoryForFile", BindingFlags.NonPublic | BindingFlags.Instance);
+                var r = (string)method.Invoke(_cliExecutor, new object[] { null });
+                Assert.AreEqual(PathNormalization.NormalizeWorkingDirectory(ws), r);
+            }
+            finally
+            {
+                if (Directory.Exists(ws))
+                {
+                    Directory.Delete(ws, true);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void GetCliWorkingDirectoryForFile_FileInsideGitRepo_ReturnsNormalizedRepoRoot()
+        {
+            var repoPath = Path.Combine(Path.GetTempPath(), "cli-git-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(repoPath);
+                Repository.Init(repoPath);
+                var fileInRepo = Path.Combine(repoPath, "file.cs");
+                File.WriteAllText(fileInRepo, "//");
+                _mockCacheStorage.Setup(x => x.GetWorkspaceDirectory()).Returns(string.Empty);
+                var method = typeof(CliExecutor).GetMethod("GetCliWorkingDirectoryForFile", BindingFlags.NonPublic | BindingFlags.Instance);
+                var wd = (string)method.Invoke(_cliExecutor, new object[] { fileInRepo });
+                Assert.AreEqual(PathNormalization.NormalizeWorkingDirectory(Path.GetFullPath(repoPath)), wd);
+            }
+            finally
+            {
+                if (Directory.Exists(repoPath))
+                {
+                    Directory.Delete(repoPath, true);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void GetCliWorkingDirectoryForFile_FileOutsideGitWithExistingWorkspace_ReturnsWorkspace()
+        {
+            var outside = Path.Combine(Path.GetTempPath(), "cli-out-" + Guid.NewGuid().ToString("N"));
+            var ws = Path.Combine(Path.GetTempPath(), "cli-ws2-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(outside);
+                Directory.CreateDirectory(ws);
+                var filePath = Path.Combine(outside, "orphan.cs");
+                File.WriteAllText(filePath, "//");
+                _mockCacheStorage.Setup(x => x.GetWorkspaceDirectory()).Returns(ws);
+                var method = typeof(CliExecutor).GetMethod("GetCliWorkingDirectoryForFile", BindingFlags.NonPublic | BindingFlags.Instance);
+                var wd = (string)method.Invoke(_cliExecutor, new object[] { filePath });
+                Assert.AreEqual(PathNormalization.NormalizeWorkingDirectory(ws), wd);
+            }
+            finally
+            {
+                if (Directory.Exists(outside))
+                {
+                    Directory.Delete(outside, true);
+                }
+
+                if (Directory.Exists(ws))
+                {
+                    Directory.Delete(ws, true);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void GetCliWorkingDirectoryForFile_WhenGitResolutionFails_LogsDebugAndUsesFileDirectory()
+        {
+            var bad = Path.Combine(Path.GetTempPath(), "cli-badgit-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(bad);
+                File.WriteAllText(Path.Combine(bad, ".git"), "invalid");
+                var fp = Path.Combine(bad, "x.cs");
+                File.WriteAllText(fp, "//");
+                _mockCacheStorage.Setup(x => x.GetWorkspaceDirectory()).Returns(string.Empty);
+                var method = typeof(CliExecutor).GetMethod("GetCliWorkingDirectoryForFile", BindingFlags.NonPublic | BindingFlags.Instance);
+                var wd = (string)method.Invoke(_cliExecutor, new object[] { fp });
+                var expectedDir = Path.GetDirectoryName(Path.GetFullPath(fp));
+                Assert.AreEqual(expectedDir, wd);
+                _mockLogger.Verify(x => x.Debug(It.Is<string>(s => s.Contains("Could not resolve git working directory"))), Times.Once);
+            }
+            finally
+            {
+                if (Directory.Exists(bad))
+                {
+                    Directory.Delete(bad, true);
+                }
+            }
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) CodeScene. All rights reserved.
 
-using System.Threading;
 using Codescene.VSExtension.Core.Application.Cli;
 using Codescene.VSExtension.Core.Exceptions;
 using Codescene.VSExtension.Core.Interfaces;
@@ -19,8 +18,8 @@ namespace Codescene.VSExtension.Core.Tests
     public class CliExecutorTests
     {
         private const string TestCachePath = "/test/cache/path";
-        private const string TestFileName = "test.cs";
         private const string TestFileContent = "public class Test { }";
+        private static readonly string TestFilePath = $"{TestCachePath}/test.cs";
 
         private Mock<ILogger> _mockLogger;
         private Mock<ICliServices> _mockCliServices;
@@ -49,6 +48,7 @@ namespace Codescene.VSExtension.Core.Tests
             _mockCliServices.Setup(x => x.CacheStorage).Returns(_mockCacheStorage.Object);
 
             _mockCacheStorage.Setup(x => x.GetSolutionReviewCacheLocation()).Returns(TestCachePath);
+            _mockCacheStorage.Setup(x => x.GetWorkspaceDirectory()).Returns(string.Empty);
 
             _cliExecutor = new CliExecutor(
                 _mockLogger.Object,
@@ -67,30 +67,30 @@ namespace Codescene.VSExtension.Core.Tests
             };
             var jsonResponse = JsonConvert.SerializeObject(expectedReview);
             _mockCommandProvider.Setup(x => x.ReviewFileContentCommand).Returns("review --file-name test.cs");
-            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFileName, TestFileContent, TestCachePath))
+            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFilePath, TestFileContent, TestCachePath))
                 .Returns("payload");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>()))
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync(jsonResponse);
 
-            var result = await _cliExecutor.ReviewContentAsync(TestFileName, TestFileContent);
+            var result = await _cliExecutor.ReviewContentAsync(TestFilePath, TestFileContent);
 
             Assert.IsNotNull(result);
             Assert.AreEqual(expectedReview.Score, result.Score);
             Assert.AreEqual(expectedReview.RawScore, result.RawScore);
-            _mockProcessExecutor.Verify(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>()), Times.Once);
+            _mockProcessExecutor.Verify(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>(), It.IsAny<string>()), Times.Once);
         }
 
         [TestMethod]
         public async Task ReviewContentAsync_WhenProcessExecutorThrowsDevtoolsException_ThrowsException()
         {
             _mockCommandProvider.Setup(x => x.ReviewFileContentCommand).Returns("review --file-name test.cs");
-            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFileName, TestFileContent, TestCachePath))
+            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFilePath, TestFileContent, TestCachePath))
                 .Returns("payload");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>()))
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ThrowsAsync(new DevtoolsException("CLI error", 500, "trace-123"));
 
             var exception = await Assert.ThrowsAsync<DevtoolsException>(() =>
-                _cliExecutor.ReviewContentAsync(TestFileName, TestFileContent));
+                _cliExecutor.ReviewContentAsync(TestFilePath, TestFileContent));
             Assert.AreEqual("CLI error", exception.Message);
             _mockLogger.Verify(x => x.Error(It.Is<string>(s => s.Contains("Review of file")), It.IsAny<DevtoolsException>()), Times.Once);
             _mockLogger.Verify(x => x.Warn(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
@@ -102,13 +102,13 @@ namespace Codescene.VSExtension.Core.Tests
             const string creditsMessage =
                 "Your credits of refactoring functionality ran out. Buy a bigger plan.";
             _mockCommandProvider.Setup(x => x.ReviewFileContentCommand).Returns("review --file-name test.cs");
-            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFileName, TestFileContent, TestCachePath))
+            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFilePath, TestFileContent, TestCachePath))
                 .Returns("payload");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>()))
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ThrowsAsync(new DevtoolsException(creditsMessage, 402, "trace-xyz"));
 
             var exception = await Assert.ThrowsAsync<DevtoolsException>(() =>
-                _cliExecutor.ReviewContentAsync(TestFileName, TestFileContent));
+                _cliExecutor.ReviewContentAsync(TestFilePath, TestFileContent));
             Assert.AreEqual(creditsMessage, exception.Message);
             _mockLogger.Verify(
                 x => x.Warn(It.Is<string>(s => s.Contains("Review of file") && s.Contains(creditsMessage) && s.Contains("402") && s.Contains("trace-xyz")), It.IsAny<bool>()),
@@ -120,11 +120,11 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task ReviewContentAsync_WhenProcessExecutorThrowsGenericException_ReturnsNull()
         {
             _mockCommandProvider.Setup(x => x.ReviewFileContentCommand).Returns("review --file-name test.cs");
-            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFileName, TestFileContent, TestCachePath))
+            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFilePath, TestFileContent, TestCachePath))
                 .Returns("payload");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>()))
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ThrowsAsync(new Exception("Generic error"));
-            var result = await _cliExecutor.ReviewContentAsync(TestFileName, TestFileContent);
+            var result = await _cliExecutor.ReviewContentAsync(TestFilePath, TestFileContent);
 
             Assert.IsNull(result);
             _mockLogger.Verify(x => x.Error(It.Is<string>(s => s.Contains("Review of file")), It.IsAny<Exception>()), Times.Once);
@@ -134,11 +134,11 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task ReviewContentAsync_WithInvalidJson_ReturnsNull()
         {
             _mockCommandProvider.Setup(x => x.ReviewFileContentCommand).Returns("review --file-name test.cs");
-            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFileName, TestFileContent, TestCachePath))
+            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFilePath, TestFileContent, TestCachePath))
                 .Returns("payload");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>()))
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync("invalid json");
-            var result = await _cliExecutor.ReviewContentAsync(TestFileName, TestFileContent);
+            var result = await _cliExecutor.ReviewContentAsync(TestFilePath, TestFileContent);
 
             Assert.IsNull(result);
         }
@@ -157,10 +157,10 @@ namespace Codescene.VSExtension.Core.Tests
             var jsonResponse = JsonConvert.SerializeObject(expectedDelta);
             _mockCommandProvider.Setup(x => x.GetReviewDeltaCommand(oldScore, newScore))
                 .Returns("delta command");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync(jsonResponse);
 
-            var result = await _cliExecutor.ReviewDeltaAsync(new ReviewDeltaRequest { OldScore = oldScore, NewScore = newScore, FilePath = TestFileName, FileContent = TestFileContent });
+            var result = await _cliExecutor.ReviewDeltaAsync(new ReviewDeltaRequest { OldScore = oldScore, NewScore = newScore, FilePath = TestFilePath, FileContent = TestFileContent });
 
             Assert.IsNotNull(result);
             Assert.AreEqual(expectedDelta.NewScore, result.NewScore);
@@ -197,7 +197,7 @@ namespace Codescene.VSExtension.Core.Tests
         {
             _mockCommandProvider.Setup(x => x.GetReviewDeltaCommand(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns("delta command");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ThrowsAsync(new Exception("Error"));
 
             var result = await _cliExecutor.ReviewDeltaAsync(new ReviewDeltaRequest { OldScore = "old", NewScore = "new" });
@@ -217,7 +217,7 @@ namespace Codescene.VSExtension.Core.Tests
             var jsonResponse = JsonConvert.SerializeObject(expectedPreflight);
             _mockCommandProvider.Setup(x => x.GetPreflightSupportInformationCommand(It.IsAny<bool>()))
                 .Returns("refactor preflight --force");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync(jsonResponse);
 
             var result = await _cliExecutor.PreflightAsync(force: true);
@@ -244,7 +244,7 @@ namespace Codescene.VSExtension.Core.Tests
         {
             _mockCommandProvider.Setup(x => x.GetPreflightSupportInformationCommand(It.IsAny<bool>()))
                 .Returns("refactor preflight");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ThrowsAsync(new Exception("Error"));
 
             var result = await _cliExecutor.PreflightAsync();
@@ -260,7 +260,7 @@ namespace Codescene.VSExtension.Core.Tests
             var jsonResponse = JsonConvert.SerializeObject(preflight);
             _mockCommandProvider.Setup(x => x.GetPreflightSupportInformationCommand(false))
                 .Returns("refactor preflight");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync(jsonResponse);
 
             var result = await _cliExecutor.PreflightAsync(force: false);
@@ -298,18 +298,18 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task ReviewContentAsync_WhenCancelled_ReturnsNull()
         {
             _mockCommandProvider.Setup(x => x.ReviewFileContentCommand).Returns("review --file-name test.cs");
-            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFileName, TestFileContent, TestCachePath))
+            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFilePath, TestFileContent, TestCachePath))
                 .Returns("payload");
             var completion = new TaskCompletionSource<string>();
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>()))
-                .Returns<string, string, TimeSpan?, CancellationToken>((_, _, _, ct) =>
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .Returns<string, string, TimeSpan?, CancellationToken, string>((_, _, _, ct, __) =>
                 {
                     ct.Register(() => completion.TrySetCanceled(ct));
                     return completion.Task;
                 });
 
             var cts = new CancellationTokenSource();
-            var task = _cliExecutor.ReviewContentAsync(TestFileName, TestFileContent, false, cts.Token);
+            var task = _cliExecutor.ReviewContentAsync(TestFilePath, TestFileContent, false, cts.Token);
             cts.Cancel();
 
             var result = await task;
@@ -321,12 +321,12 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task ReviewContentAsync_WhenSecondCallCancelsFirst_FirstReturnsNull()
         {
             _mockCommandProvider.Setup(x => x.ReviewFileContentCommand).Returns("review --file-name test.cs");
-            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFileName, TestFileContent, TestCachePath))
+            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(TestFilePath, TestFileContent, TestCachePath))
                 .Returns("payload");
             var firstCompletion = new TaskCompletionSource<string>();
             var callCount = 0;
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>()))
-                .Returns<string, string, TimeSpan?, CancellationToken>((cmd, payload, timeout, ct) =>
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name test.cs", "payload", null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .Returns<string, string, TimeSpan?, CancellationToken, string>((cmd, payload, timeout, ct, _) =>
                 {
                     callCount++;
                     if (callCount == 1)
@@ -337,9 +337,9 @@ namespace Codescene.VSExtension.Core.Tests
                     return Task.FromResult(JsonConvert.SerializeObject(new CliReviewModel { Score = 7.5f, RawScore = "raw" }));
                 });
 
-            var firstTask = _cliExecutor.ReviewContentAsync(TestFileName, TestFileContent, false);
+            var firstTask = _cliExecutor.ReviewContentAsync(TestFilePath, TestFileContent, false);
             await Task.Delay(50);
-            var secondTask = _cliExecutor.ReviewContentAsync(TestFileName, TestFileContent, false);
+            var secondTask = _cliExecutor.ReviewContentAsync(TestFilePath, TestFileContent, false);
             firstCompletion.SetCanceled();
 
             var firstResult = await firstTask;
@@ -352,17 +352,17 @@ namespace Codescene.VSExtension.Core.Tests
         [TestMethod]
         public async Task ReviewContentAsync_ConcurrentDifferentFiles_UsesBoundedConcurrency()
         {
-            var firstFile = "first.cs";
-            var secondFile = "second.cs";
+            var firstFile = $"{TestCachePath}/first.cs";
+            var secondFile = $"{TestCachePath}/second.cs";
             var completion = new TaskCompletionSource<bool>();
             var startedSignal = new TaskCompletionSource<bool>();
             var callCount = 0;
 
             _mockCommandProvider.Setup(x => x.ReviewFileContentCommand).Returns("review --file-name");
             _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(It.IsAny<string>(), It.IsAny<string>(), TestCachePath))
-                .Returns((string filename, string _, string _) => "payload-" + filename);
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name", It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
-                .Returns<string, string, TimeSpan?, CancellationToken>(async (_, payload, _, _) =>
+                .Returns((string filePath, string _, string _) => "payload-" + filePath);
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("review --file-name", It.IsAny<string>(), null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .Returns<string, string, TimeSpan?, CancellationToken, string>(async (_, payload, _, _, __) =>
                 {
                     Interlocked.Increment(ref callCount);
                     startedSignal.TrySetResult(true);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliSettingsProviderTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliSettingsProviderTests.cs
@@ -8,7 +8,7 @@ namespace Codescene.VSExtension.Core.Tests
     [TestClass]
     public class CliSettingsProviderTests
     {
-        private readonly string expectedVersion = "66beda3b9e26e74eacd78f68247b2591196c999d";
+        private readonly string expectedVersion = "e1a8e6c1f7533d9d44f00e1a6becb5c404ca0485";
 
         [TestMethod]
         public void RequiredDevToolVersion_ShouldReturnExpectedValue()

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CodeReviewerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CodeReviewerTests.cs
@@ -132,7 +132,7 @@ namespace Codescene.VSExtension.Core.Tests
             var cliReview = new CliReviewModel { Score = 8.5f, RawScore = "raw123" };
             var expectedResult = new FileReviewModel { FilePath = path, Score = 8.5f };
 
-            _mockExecutor.Setup(x => x.ReviewContentAsync("test.cs", content, It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(cliReview);
+            _mockExecutor.Setup(x => x.ReviewContentAsync(path, content, It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(cliReview);
             _mockMapper.Setup(x => x.Map(path, cliReview)).Returns(expectedResult);
 
             // Act
@@ -142,26 +142,26 @@ namespace Codescene.VSExtension.Core.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(path, result.FilePath);
             Assert.AreEqual(8.5f, result.Score);
-            _mockExecutor.Verify(x => x.ReviewContentAsync("test.cs", content, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+            _mockExecutor.Verify(x => x.ReviewContentAsync(path, content, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
             _mockMapper.Verify(x => x.Map(path, cliReview), Times.Once);
         }
 
         [TestMethod]
-        public async Task ReviewAsync_ExtractsFileNameFromPath()
+        public async Task ReviewAsync_PassesFullPathToExecutor()
         {
             // Arrange
             var path = "C:/some/deep/path/to/MyFile.cs";
             var content = "code";
             var cliReview = new CliReviewModel();
 
-            _mockExecutor.Setup(x => x.ReviewContentAsync("MyFile.cs", content, It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(cliReview);
+            _mockExecutor.Setup(x => x.ReviewContentAsync(path, content, It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(cliReview);
             _mockMapper.Setup(x => x.Map(It.IsAny<string>(), It.IsAny<CliReviewModel>())).Returns(new FileReviewModel());
 
             // Act
             await _codeReviewer.ReviewAsync(path, content);
 
             // Assert
-            _mockExecutor.Verify(x => x.ReviewContentAsync("MyFile.cs", content, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+            _mockExecutor.Verify(x => x.ReviewContentAsync(path, content, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/FileChangeHandlerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/FileChangeHandlerTests.cs
@@ -142,31 +142,6 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
-        public async Task HandleFileChangeAsync_WhenFileIsActiveDocument_SkipsReviewButAddsToTracker()
-        {
-            var testFile = Path.Combine(_testWorkspacePath, "active.cs");
-            var changedFiles = new List<string> { "active.cs" };
-            File.WriteAllText(testFile, "public class Active {}");
-
-            var handlerWithActiveDoc = new FileChangeHandler(
-                _fakeLogger,
-                _fakeCodeReviewer,
-                _fakeSupportedFileChecker,
-                new[] { _testWorkspacePath },
-                _trackerManager,
-                new FakeGitService(),
-                _testWorkspacePath,
-                null,
-                null,
-                () => testFile);
-
-            await handlerWithActiveDoc.HandleFileChangeAsync(testFile, changedFiles);
-
-            Assert.IsTrue(_trackerManager.Contains(testFile));
-            Assert.AreEqual(0, _fakeCodeReviewer.ReviewCallCount);
-        }
-
-        [TestMethod]
         public async Task HandleFileChangeAsync_WhenOpenDocumentContentProviderReturnsContent_UsesProviderContentNotDisk()
         {
             var testFile = Path.Combine(_testWorkspacePath, "open.cs");

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) CodeScene. All rights reserved.
 
-using System.IO;
 using System.Reflection;
-using System.Threading;
 using Codescene.VSExtension.Core.Application.Git;
 using Codescene.VSExtension.Core.Models;
 using LibGit2Sharp;
@@ -150,6 +148,19 @@ namespace Codescene.VSExtension.Core.Tests
             _gitChangeObserverCore.Dispose();
             var method = typeof(GitChangeObserverCore).GetMethod("OnGitChangeListerFilesDetected", BindingFlags.NonPublic | BindingFlags.Instance);
             method.Invoke(_gitChangeObserverCore, new object[] { this, new HashSet<string>() });
+        }
+
+        [TestMethod]
+        public void OnCodeHealthRulesChanged_RemovesAllTrackedFiles()
+        {
+            var existingFile = CreateFile("rules-invalidate.ts", "export const x = 1;");
+            _fakeGitChangeLister.SimulateFilesDetected(new HashSet<string> { existingFile });
+            AssertFileInTracker(existingFile, true);
+
+            var method = typeof(GitChangeObserverCore).GetMethod("OnCodeHealthRulesChanged", BindingFlags.NonPublic | BindingFlags.Instance);
+            method.Invoke(_gitChangeObserverCore, new object[] { this, EventArgs.Empty });
+
+            AssertFileInTracker(existingFile, false);
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/PathNormalizationTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/PathNormalizationTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Runtime.InteropServices;
+using Codescene.VSExtension.Core.Util;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class PathNormalizationTests
+    {
+        [TestMethod]
+        public void NormalizeWorkingDirectory_NullAndEmpty_ReturnOriginal()
+        {
+            Assert.IsNull(PathNormalization.NormalizeWorkingDirectory(null!));
+            Assert.AreEqual(string.Empty, PathNormalization.NormalizeWorkingDirectory(string.Empty));
+        }
+
+        [TestMethod]
+        public void NormalizeWorkingDirectory_RelativePathNoRoot_ReturnsTrimmed()
+        {
+            var path = Path.Combine("sub", "dir") + Path.DirectorySeparatorChar;
+            var result = PathNormalization.NormalizeWorkingDirectory(path);
+            Assert.AreEqual(Path.Combine("sub", "dir"), result);
+        }
+
+        [TestMethod]
+        public void NormalizeWorkingDirectory_WindowsDriveRoot_ReturnsOriginalPath()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Inconclusive();
+                return;
+            }
+
+            var root = Path.GetPathRoot(Path.GetTempPath());
+            Assert.IsFalse(string.IsNullOrEmpty(root));
+            var pathWithExtraSeparators = root + new string(Path.DirectorySeparatorChar, 2);
+            var result = PathNormalization.NormalizeWorkingDirectory(pathWithExtraSeparators);
+            Assert.AreEqual(pathWithExtraSeparators, result);
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryManagerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryManagerTests.cs
@@ -59,7 +59,7 @@ namespace Codescene.VSExtension.Core.Tests
             _mockDeviceIdStore.Setup(x => x.GetDeviceIdAsync()).ReturnsAsync("device-123");
             _mockMetadataProvider.Setup(x => x.GetVersion()).Returns("1.0.0");
             _mockCommandProvider.Setup(x => x.SendTelemetryCommand(It.IsAny<string>())).Returns("telemetry command");
-            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>()))
+            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>()))
                 .ThrowsAsync(new Exception("Telemetry failed"));
 
             // Act - should not throw
@@ -85,7 +85,7 @@ namespace Codescene.VSExtension.Core.Tests
             _mockDeviceIdStore.Setup(x => x.GetDeviceIdAsync()).ReturnsAsync("device-123");
             _mockMetadataProvider.Setup(x => x.GetVersion()).Returns("1.0.0");
             _mockCommandProvider.Setup(x => x.SendTelemetryCommand(It.IsAny<string>())).Returns("telemetry command");
-            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>()))
+            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync("success");
 
             // Act - should not throw
@@ -103,7 +103,7 @@ namespace Codescene.VSExtension.Core.Tests
             _mockDeviceIdStore.Setup(x => x.GetDeviceIdAsync()).ReturnsAsync("my-device-id");
             _mockMetadataProvider.Setup(x => x.GetVersion()).Returns("2.0.0");
             _mockCommandProvider.Setup(x => x.SendTelemetryCommand(It.IsAny<string>())).Returns("cmd");
-            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>()))
+            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync("ok");
 
             // Act
@@ -121,7 +121,7 @@ namespace Codescene.VSExtension.Core.Tests
             _mockDeviceIdStore.Setup(x => x.GetDeviceIdAsync()).ReturnsAsync("device-123");
             _mockMetadataProvider.Setup(x => x.GetVersion()).Returns("3.0.0");
             _mockCommandProvider.Setup(x => x.SendTelemetryCommand(It.IsAny<string>())).Returns("cmd");
-            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>()))
+            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync("ok");
 
             // Act
@@ -140,7 +140,7 @@ namespace Codescene.VSExtension.Core.Tests
             _mockDeviceIdStore.Setup(x => x.GetDeviceIdAsync()).ReturnsAsync("device-123");
             _mockMetadataProvider.Setup(x => x.GetVersion()).Returns("1.0.0");
             _mockCommandProvider.Setup(x => x.SendTelemetryCommand(It.IsAny<string>())).Returns("telemetry command");
-            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>()))
+            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>()))
                 .ThrowsAsync(new Exception("Telemetry failed"));
 
             // Act - should not throw
@@ -166,7 +166,7 @@ namespace Codescene.VSExtension.Core.Tests
             _mockDeviceIdStore.Setup(x => x.GetDeviceIdAsync()).ReturnsAsync("device-123");
             _mockMetadataProvider.Setup(x => x.GetVersion()).Returns("1.0.0");
             _mockCommandProvider.Setup(x => x.SendTelemetryCommand(It.IsAny<string>())).Returns("telemetry command");
-            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>()))
+            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync("success");
 
             // Act - should not throw
@@ -190,7 +190,7 @@ namespace Codescene.VSExtension.Core.Tests
 
             // Assert - executor should not be called for telemetry-related errors
             _mockExecutor.Verify(
-                x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>()),
+                x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>()),
                 Times.Never);
         }
 
@@ -209,7 +209,7 @@ namespace Codescene.VSExtension.Core.Tests
 
             // Assert - executor should not be called for network errors
             _mockExecutor.Verify(
-                x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>()),
+                x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>()),
                 Times.Never);
         }
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cache/Review/ReviewCacheCleanup.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cache/Review/ReviewCacheCleanup.cs
@@ -23,6 +23,7 @@ namespace Codescene.VSExtension.Core.Application.Cache.Review
         {
             new DeltaCacheService().Invalidate(filePath);
             new BaselineReviewCacheService().Invalidate(filePath);
+            new ReviewCacheService().Invalidate(filePath);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
+using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -19,6 +20,7 @@ using Codescene.VSExtension.Core.Models.Cli.Delta;
 using Codescene.VSExtension.Core.Models.Cli.Refactor;
 using Codescene.VSExtension.Core.Models.Cli.Review;
 using Codescene.VSExtension.Core.Util;
+using LibGit2Sharp;
 using Newtonsoft.Json;
 using static Codescene.VSExtension.Core.Consts.Constants;
 
@@ -65,14 +67,15 @@ namespace Codescene.VSExtension.Core.Application.Cli
         /// <summary>
         /// Reviews a file's content by invoking the CLI with the appropriate arguments.
         /// </summary>
-        /// <param name="filename">The name of the file being reviewed (used for context, not passed to CLI).</param>
+        /// <param name="filePath">The path of the file being reviewed.</param>
         /// <param name="content">The content (code) of the file to be reviewed.</param>
         /// <param name="isBaseline">True when reviewing baseline (committed) content for delta; used to avoid cancelling in-flight current-content reviews.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="CliReviewModel"/> containing the review results, or null if the review fails.</returns>
-        public async Task<CliReviewModel> ReviewContentAsync(string filename, string content, bool isBaseline = false, CancellationToken cancellationToken = default)
+        public async Task<CliReviewModel> ReviewContentAsync(string filePath, string content, bool isBaseline = false, CancellationToken cancellationToken = default)
         {
-            var key = GetReviewCancellationKey(filename, isBaseline);
+            var fileName = Path.GetFileName(filePath);
+            var key = GetReviewCancellationKey(fileName, isBaseline);
             var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             var oldCts = _inFlightReviewCancellation.AddOrUpdate(key, cts, (_, existing) =>
@@ -93,27 +96,28 @@ namespace Codescene.VSExtension.Core.Application.Cli
             try
             {
                 var command = _cliServices.CommandProvider.ReviewFileContentCommand;
-                var payload = _cliServices.CommandProvider.GetReviewFileContentPayload(filename, content, _cliServices.CacheStorage.GetSolutionReviewCacheLocation());
+                var payload = _cliServices.CommandProvider.GetReviewFileContentPayload(filePath, content, _cliServices.CacheStorage.GetSolutionReviewCacheLocation());
+                var workingDirectory = GetCliWorkingDirectoryForFile(filePath);
 
                 var (result, elapsedMs) = await ExecuteOnChannelAsync(
                     _cliCommandChannel,
                     cts.Token,
                     () => ExecuteWithTimingAndLoggingAsync<CliReviewModel>(
                         "CLI file review",
-                        () => _cliServices.ProcessExecutor.ExecuteAsync(command, payload, null, cts.Token),
-                        $"Review of file {filename} failed"));
+                        () => _cliServices.ProcessExecutor.ExecuteAsync(command, payload, null, cts.Token, workingDirectory),
+                        $"Review of file {fileName} failed"));
 
                 if (result != null)
                 {
                     _ = Task.Run(async () =>
                     {
                         var loc = PerformanceTelemetryHelper.CalculateLineCount(content);
-                        var language = PerformanceTelemetryHelper.ExtractLanguage(filename);
+                        var language = PerformanceTelemetryHelper.ExtractLanguage(fileName);
                         var telemetryData = new PerformanceTelemetryData
                         {
                             Type = Titles.REVIEW,
                             ElapsedMs = elapsedMs,
-                            FilePath = filename,
+                            FilePath = fileName,
                             Loc = loc,
                             Language = language,
                         };
@@ -151,9 +155,10 @@ namespace Codescene.VSExtension.Core.Application.Cli
             await _deltaChannel.WaitAsync(cancellationToken);
             try
             {
+                var workingDirectory = GetCliWorkingDirectoryForFile(request.FilePath);
                 var (result, elapsedMs) = await ExecuteWithTimingAndLoggingAsync<DeltaResponseModel>(
                     "CLI file delta review",
-                    () => _cliServices.ProcessExecutor.ExecuteAsync(Titles.DELTA, arguments, null, cancellationToken),
+                    () => _cliServices.ProcessExecutor.ExecuteAsync(Titles.DELTA, arguments, null, cancellationToken, workingDirectory),
                     "Delta for file failed.");
 
                 if (result != null && !string.IsNullOrEmpty(request.FilePath))
@@ -466,6 +471,64 @@ namespace Codescene.VSExtension.Core.Application.Cli
                 _logger.Error(errorMessage, e);
                 return (default, elapsedMs);
             }
+        }
+
+        private string GetCliWorkingDirectoryForFile(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                return GetCliWorkingDirectoryWithoutFilePath();
+            }
+
+            string fullPath;
+            try
+            {
+                fullPath = Path.GetFullPath(filePath);
+            }
+            catch
+            {
+                fullPath = filePath;
+            }
+
+            try
+            {
+                var discovered = Repository.Discover(fullPath);
+                if (!string.IsNullOrEmpty(discovered))
+                {
+                    using (var repo = new Repository(discovered))
+                    {
+                        var wd = repo.Info.WorkingDirectory;
+                        if (!string.IsNullOrEmpty(wd))
+                        {
+                            return wd.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug($"Could not resolve git working directory for CLI: {ex.Message}");
+            }
+
+            var workspace = _cliServices.CacheStorage.GetWorkspaceDirectory();
+            if (!string.IsNullOrWhiteSpace(workspace) && Directory.Exists(workspace))
+            {
+                return workspace.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+
+            var dir = Path.GetDirectoryName(fullPath);
+            return string.IsNullOrEmpty(dir) ? null : dir;
+        }
+
+        private string GetCliWorkingDirectoryWithoutFilePath()
+        {
+            var workspace = _cliServices.CacheStorage.GetWorkspaceDirectory();
+            if (!string.IsNullOrWhiteSpace(workspace) && Directory.Exists(workspace))
+            {
+                return workspace.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+
+            return null;
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
@@ -75,7 +75,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
         public async Task<CliReviewModel> ReviewContentAsync(string filePath, string content, bool isBaseline = false, CancellationToken cancellationToken = default)
         {
             var fileName = Path.GetFileName(filePath);
-            var key = GetReviewCancellationKey(fileName, isBaseline);
+            var key = GetReviewCancellationKey(GetReviewCancellationPathIdentity(filePath), isBaseline);
             var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             var oldCts = _inFlightReviewCancellation.AddOrUpdate(key, cts, (_, existing) =>
@@ -290,8 +290,20 @@ namespace Codescene.VSExtension.Core.Application.Cli
                 cancellationToken);
         }
 
-        private static string GetReviewCancellationKey(string filename, bool isBaseline) =>
-          string.IsNullOrEmpty(filename) ? string.Empty : filename + (isBaseline ? ":baseline" : ":current");
+        private static string GetReviewCancellationPathIdentity(string filePath)
+        {
+            try
+            {
+                return string.IsNullOrEmpty(filePath) ? string.Empty : Path.GetFullPath(filePath);
+            }
+            catch
+            {
+                return filePath ?? string.Empty;
+            }
+        }
+
+        private static string GetReviewCancellationKey(string filePathIdentity, bool isBaseline) =>
+          string.IsNullOrEmpty(filePathIdentity) ? string.Empty : filePathIdentity + (isBaseline ? ":baseline" : ":current");
 
         private async Task<string> ExecuteSimpleCommandAsync(string command, string errorMessage, CancellationToken cancellationToken = default)
         {
@@ -500,7 +512,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
                         var wd = repo.Info.WorkingDirectory;
                         if (!string.IsNullOrEmpty(wd))
                         {
-                            return wd.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                            return PathNormalization.NormalizeWorkingDirectory(wd);
                         }
                     }
                 }
@@ -513,7 +525,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
             var workspace = _cliServices.CacheStorage.GetWorkspaceDirectory();
             if (!string.IsNullOrWhiteSpace(workspace) && Directory.Exists(workspace))
             {
-                return workspace.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                return PathNormalization.NormalizeWorkingDirectory(workspace);
             }
 
             var dir = Path.GetDirectoryName(fullPath);
@@ -525,7 +537,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
             var workspace = _cliServices.CacheStorage.GetWorkspaceDirectory();
             if (!string.IsNullOrWhiteSpace(workspace) && Directory.Exists(workspace))
             {
-                return workspace.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                return PathNormalization.NormalizeWorkingDirectory(workspace);
             }
 
             return null;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliSettingsProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliSettingsProvider.cs
@@ -11,9 +11,9 @@ namespace Codescene.VSExtension.Core.Application.Cli
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class CliSettingsProvider : ICliSettingsProvider
     {
-        // single point of truth for CLI version
+        // single point of truth for CLI version'
         // used by the build pipeline to bundle the CLI with the extension
-        public string RequiredDevToolVersion => "66beda3b9e26e74eacd78f68247b2591196c999d"; // 1.0.44
+        public string RequiredDevToolVersion => "e1a8e6c1f7533d9d44f00e1a6becb5c404ca0485"; // 1.0.45
 
         public string CliArtifactName => $"cs-ide-windows-amd64-{RequiredDevToolVersion}.zip";
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliSettingsProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliSettingsProvider.cs
@@ -11,7 +11,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class CliSettingsProvider : ICliSettingsProvider
     {
-        // single point of truth for CLI version'
+        // single point of truth for CLI version
         // used by the build pipeline to bundle the CLI with the extension
         public string RequiredDevToolVersion => "e1a8e6c1f7533d9d44f00e1a6becb5c404ca0485"; // 1.0.45
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CodeReviewer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CodeReviewer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -14,10 +12,7 @@ using Codescene.VSExtension.Core.Interfaces.Cli;
 using Codescene.VSExtension.Core.Interfaces.Git;
 using Codescene.VSExtension.Core.Interfaces.Telemetry;
 using Codescene.VSExtension.Core.Models;
-using Codescene.VSExtension.Core.Models.Cache.Delta;
 using Codescene.VSExtension.Core.Models.Cli.Delta;
-using Codescene.VSExtension.Core.Util;
-using Newtonsoft.Json;
 
 namespace Codescene.VSExtension.Core.Application.Cli
 {
@@ -61,7 +56,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
 
             _logger?.Info($"Reviewing file {path}...", true);
 
-            var review = await _executor.ReviewContentAsync(fileName, content, isBaseline, cancellationToken);
+            var review = await _executor.ReviewContentAsync(path, content, isBaseline, cancellationToken);
             return _mapper.Map(path, review);
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/ProcessExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/ProcessExecutor.cs
@@ -34,7 +34,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<string> ExecuteAsync(string arguments, string content = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        public async Task<string> ExecuteAsync(string arguments, string content = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default, string workingDirectory = null)
         {
             var cliFilePath = _cliSettingsProvider.CliFileFullPath;
 
@@ -62,6 +62,11 @@ namespace Codescene.VSExtension.Core.Application.Cli
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
+
+            if (!string.IsNullOrWhiteSpace(workingDirectory) && Directory.Exists(workingDirectory))
+            {
+                processInfo.WorkingDirectory = workingDirectory;
+            }
 
             using var process = new Process();
             process.StartInfo = processInfo;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/CodeHealthRulesWatcher.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/CodeHealthRulesWatcher.cs
@@ -80,6 +80,7 @@ namespace Codescene.VSExtension.Core.Application.Git
 
         private void OnRulesFileEvent(object sender, FileSystemEventArgs e)
         {
+            _logger.Info("Code health rules change detected.");
             CacheGeneration.Increment();
             try
             {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/CodeHealthRulesWatcher.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/CodeHealthRulesWatcher.cs
@@ -80,7 +80,7 @@ namespace Codescene.VSExtension.Core.Application.Git
 
         private void OnRulesFileEvent(object sender, FileSystemEventArgs e)
         {
-            _logger.Info("Code health rules change detected.");
+            _logger?.Info("Code health rules change detected.");
             CacheGeneration.Increment();
             try
             {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeHandler.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeHandler.cs
@@ -6,12 +6,10 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Codescene.VSExtension.Core.Application.Cache.Review;
 using Codescene.VSExtension.Core.Application.Util;
 using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Cli;
 using Codescene.VSExtension.Core.Interfaces.Git;
-using Codescene.VSExtension.Core.Models;
 using Codescene.VSExtension.Core.Util;
 
 namespace Codescene.VSExtension.Core.Application.Git
@@ -26,7 +24,6 @@ namespace Codescene.VSExtension.Core.Application.Git
         private readonly Action<string> _onFileDeletedCallback;
         private readonly IGitService _gitService;
         private readonly IOpenDocumentContentProvider _openDocumentContentProvider;
-        private readonly Func<string> _getActiveDocumentPath;
         private IReadOnlyCollection<string> _workspacePaths;
 
         public FileChangeHandler(
@@ -38,8 +35,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             IGitService gitService,
             string gitRootPath = null,
             Action<string> onFileDeletedCallback = null,
-            IOpenDocumentContentProvider openDocumentContentProvider = null,
-            Func<string> getActiveDocumentPath = null)
+            IOpenDocumentContentProvider openDocumentContentProvider = null)
         {
             _logger = logger;
             _codeReviewer = codeReviewer;
@@ -50,7 +46,6 @@ namespace Codescene.VSExtension.Core.Application.Git
             _gitRootPath = gitRootPath;
             _onFileDeletedCallback = onFileDeletedCallback;
             _openDocumentContentProvider = openDocumentContentProvider;
-            _getActiveDocumentPath = getActiveDocumentPath;
         }
 
         public event EventHandler<string> FileDeletedFromGit;
@@ -86,12 +81,6 @@ namespace Codescene.VSExtension.Core.Application.Git
             _logger?.Info($">>> FileChangeHandler: Processing file change: {filePath}");
             #endif
             _trackerManager.Add(filePath);
-
-            var activePath = _getActiveDocumentPath?.Invoke();
-            if (!string.IsNullOrEmpty(activePath) && string.Equals(activePath, filePath, StringComparison.OrdinalIgnoreCase))
-            {
-                return;
-            }
 
             await ReviewFileAsync(filePath, operationGeneration, cancellationToken);
         }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
@@ -14,7 +14,6 @@ using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Cli;
 using Codescene.VSExtension.Core.Interfaces.Git;
 using Codescene.VSExtension.Core.Util;
-using LibGit2Sharp;
 
 namespace Codescene.VSExtension.Core.Application.Git
 {
@@ -109,7 +108,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             _gitChangeLister.Initialize(_gitRootPath, _workspacePaths);
             _gitChangeLister.FilesDetected += OnGitChangeListerFilesDetected;
 
-            _fileChangeHandler = new FileChangeHandler(_logger, _codeReviewer, _supportedFileChecker, _workspacePaths, _trackerManager, _gitService, _gitRootPath, OnFileDeleted, openDocumentContentProvider, () => _openFilesObserver?.GetActiveDocumentPath());
+            _fileChangeHandler = new FileChangeHandler(_logger, _codeReviewer, _supportedFileChecker, _workspacePaths, _trackerManager, _gitService, _gitRootPath, OnFileDeleted, openDocumentContentProvider);
             _fileChangeHandler.FileDeletedFromGit += (sender, args) => FileDeletedFromGit?.Invoke(this, args);
 
             if (!string.IsNullOrEmpty(_gitRootPath) && Directory.Exists(_gitRootPath))
@@ -121,7 +120,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
 
             _rulesWatcher = new CodeHealthRulesWatcher(_gitRootPath, _logger);
-            _rulesWatcher.RulesFileChanged += (sender, args) => ViewUpdateRequested?.Invoke(this, EventArgs.Empty);
+            _rulesWatcher.RulesFileChanged += OnCodeHealthRulesChanged;
 
             _gitIgnoreWatcher = new GitIgnoreWatcher(_gitRootPath, _logger);
             _gitIgnoreWatcher.GitIgnoreChanged += OnGitIgnoreChanged;
@@ -332,7 +331,17 @@ namespace Codescene.VSExtension.Core.Application.Git
             ViewUpdateRequested?.Invoke(this, EventArgs.Empty);
         }
 
+        private void OnCodeHealthRulesChanged(object sender, EventArgs e)
+        {
+            InvalidateTrackedFiles(onlyIgnored: false);
+        }
+
         private void OnGitIgnoreChanged(object sender, EventArgs e)
+        {
+            InvalidateTrackedFiles();
+        }
+
+        private void InvalidateTrackedFiles(bool onlyIgnored = true)
         {
             _taskScheduler.Schedule(async () =>
             {
@@ -341,7 +350,7 @@ namespace Codescene.VSExtension.Core.Application.Git
                     var trackedFiles = _trackerManager.GetAllTrackedFiles();
                     foreach (var filePath in trackedFiles)
                     {
-                        if (_gitService.IsFileIgnored(filePath))
+                        if (!onlyIgnored || _gitService.IsFileIgnored(filePath))
                         {
                             _trackerManager.Remove(filePath);
                             ReviewCacheCleanup.InvalidateFile(filePath);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/ICacheStorageService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/ICacheStorageService.cs
@@ -23,6 +23,12 @@ namespace Codescene.VSExtension.Core.Interfaces.Cli
         string GetSolutionReviewCacheLocation();
 
         /// <summary>
+        /// Root directory of the open workspace (solution, project, or folder), used as CLI working directory when the reviewed file is not inside a git repository.
+        /// </summary>
+        /// <returns>Absolute directory path, or empty when no workspace is open.</returns>
+        string GetWorkspaceDirectory();
+
+        /// <summary>
         /// Removes old cache entries. Default 30 days.
         /// </summary>
         /// <param name="nrOfDays">How many days old the cache files should be before deleting.</param>

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/ICliExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/ICliExecutor.cs
@@ -13,7 +13,7 @@ namespace Codescene.VSExtension.Core.Interfaces.Cli
     {
         Task<DeltaResponseModel> ReviewDeltaAsync(ReviewDeltaRequest request, CancellationToken cancellationToken = default);
 
-        Task<CliReviewModel> ReviewContentAsync(string filename, string content, bool isBaseLine = false, CancellationToken cancellationToken = default);
+        Task<CliReviewModel> ReviewContentAsync(string filePath, string content, bool isBaseLine = false, CancellationToken cancellationToken = default);
 
         Task<string> GetFileVersionAsync(CancellationToken cancellationToken = default);
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/IProcessExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/IProcessExecutor.cs
@@ -8,6 +8,6 @@ namespace Codescene.VSExtension.Core.Interfaces.Cli
 {
     public interface IProcessExecutor
     {
-        Task<string> ExecuteAsync(string arguments, string content = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+        Task<string> ExecuteAsync(string arguments, string content = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default, string workingDirectory = null);
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/PathNormalization.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/PathNormalization.cs
@@ -1,0 +1,33 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.IO;
+
+namespace Codescene.VSExtension.Core.Util
+{
+    public static class PathNormalization
+    {
+        public static string NormalizeWorkingDirectory(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            var trimmedPath = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var root = Path.GetPathRoot(path);
+            if (string.IsNullOrEmpty(root))
+            {
+                return trimmedPath;
+            }
+
+            var trimmedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (string.Equals(trimmedPath, trimmedRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                return path;
+            }
+
+            return trimmedPath;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Cache/CacheStorageService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Cache/CacheStorageService.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Cli;
+using Codescene.VSExtension.Core.Util;
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
@@ -105,8 +106,9 @@ namespace Codescene.VSExtension.VS2022.Cache
                 var hash = ComputeHash(workspaceId);
                 _cachePath = Path.Combine(basePath, "WorkspaceCache", hash);
                 _workspaceDirectory = Directory.Exists(workspaceId)
-                    ? Path.GetFullPath(workspaceId.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
-                    : Path.GetFullPath(Path.GetDirectoryName(workspaceId) ?? string.Empty);
+                    ? Path.GetFullPath(PathNormalization.NormalizeWorkingDirectory(workspaceId))
+                    : Path.GetFullPath(
+                        PathNormalization.NormalizeWorkingDirectory(Path.GetDirectoryName(workspaceId) ?? string.Empty));
                 if (string.IsNullOrEmpty(_workspaceDirectory))
                 {
                     _workspaceDirectory = null;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Cache/CacheStorageService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Cache/CacheStorageService.cs
@@ -24,6 +24,7 @@ namespace Codescene.VSExtension.VS2022.Cache
         private IAsyncTaskScheduler _scheduler;
 
         private string _cachePath;
+        private string _workspaceDirectory;
         private bool _initialized;
 
         public async Task InitializeAsync(CancellationToken cancellationToken = default)
@@ -58,6 +59,11 @@ namespace Codescene.VSExtension.VS2022.Cache
             }
 
             return location;
+        }
+
+        public string GetWorkspaceDirectory()
+        {
+            return string.IsNullOrEmpty(_workspaceDirectory) ? string.Empty : _workspaceDirectory;
         }
 
         public void RemoveOldReviewCacheEntries(int nrOfDays = 30)
@@ -98,10 +104,18 @@ namespace Codescene.VSExtension.VS2022.Cache
             {
                 var hash = ComputeHash(workspaceId);
                 _cachePath = Path.Combine(basePath, "WorkspaceCache", hash);
+                _workspaceDirectory = Directory.Exists(workspaceId)
+                    ? Path.GetFullPath(workspaceId.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+                    : Path.GetFullPath(Path.GetDirectoryName(workspaceId) ?? string.Empty);
+                if (string.IsNullOrEmpty(_workspaceDirectory))
+                {
+                    _workspaceDirectory = null;
+                }
             }
             else
             {
-                _cachePath = null;  // No workspace open
+                _cachePath = null;
+                _workspaceDirectory = null;
             }
 
             if (_cachePath != null)


### PR DESCRIPTION
Fixes support for the CLI to listen to .codescene\code-health-rules.json

- Bumped the CLI version to 1.0.45, for a bugfix around resolving rules in the file
- For the CLI to properly resolve the code-health-rules.json file when reviewing, the spawned process Working directory needs to be inside the current repository.
- Removed GitChangeObservers check to ignore active document