### PR TITLE
feat: add editor-version to telemetry payload

### DIFF
--- a/.cursor/rules/base-rule.mdc
+++ b/.cursor/rules/base-rule.mdc
@@ -2,10 +2,10 @@
 alwaysApply: true
 ---
 
-Keep your answers short, precise and informative. Avoid uneccesary explanations and diagrams.
+Keep your answers short, precise and informative. Avoid unnecessary explanations and diagrams.
 
 Avoid writing unnecessary explanatory inline comments when writing code. 
-Only add comments for complex confitions that would warrant it. 
+Only add comments for complex conditions that would warrant it. 
 Avoid adding regions to the code.
 
 Never reference the prompt conversation in comments, like "To match VS Code implementation".

--- a/.cursor/rules/base-rule.mdc
+++ b/.cursor/rules/base-rule.mdc
@@ -1,0 +1,13 @@
+---
+alwaysApply: true
+---
+
+Keep your answers short, precise and informative. Avoid uneccesary explanations and diagrams.
+
+Avoid writing unnecessary explanatory inline comments when writing code. 
+Only add comments for complex confitions that would warrant it. 
+Avoid adding regions to the code.
+
+Never reference the prompt conversation in comments, like "To match VS Code implementation".
+
+After completing changes to existing code, or created new files, run the tools in the CodeScene MCP to validate the quality of generated code

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestExtensionMetadataProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestExtensionMetadataProvider.cs
@@ -19,5 +19,7 @@ namespace Codescene.VSExtension.Core.IntegrationTests.TestImplementations
         public string GetPublisher() => Mock.Object.GetPublisher();
 
         public string GetVersion() => Mock.Object.GetVersion();
+
+        public string GetEditorVersion() => Mock.Object.GetEditorVersion();
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliModelSerializationTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliModelSerializationTests.cs
@@ -330,6 +330,17 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public void TelemetryEvent_WithEditorVersion_SetsEditorVersionAndReturnsSelf()
+        {
+            var telemetryEvent = new TelemetryEvent();
+
+            var result = telemetryEvent.WithEditorVersion("18.1.1");
+
+            Assert.AreSame(telemetryEvent, result);
+            Assert.AreEqual("18.1.1", telemetryEvent.EditorVersion);
+        }
+
+        [TestMethod]
         public void TelemetryEvent_WithInternal_SetsInternalAndReturnsSelf()
         {
             var telemetryEvent = new TelemetryEvent();
@@ -347,12 +358,14 @@ namespace Codescene.VSExtension.Core.Tests
                 .WithEventName("code-review")
                 .WithUserId("user-456")
                 .WithEditorType("vs2022")
+                .WithEditorVersion("18.1.1")
                 .WithExtensionVersion("2.0.0")
                 .WithInternal(false);
 
             Assert.AreEqual("code-review", telemetryEvent.EventName);
             Assert.AreEqual("user-456", telemetryEvent.UserId);
             Assert.AreEqual("vs2022", telemetryEvent.EditorType);
+            Assert.AreEqual("18.1.1", telemetryEvent.EditorVersion);
             Assert.AreEqual("2.0.0", telemetryEvent.ExtensionVersion);
             Assert.IsFalse(telemetryEvent.Internal);
         }
@@ -365,13 +378,14 @@ namespace Codescene.VSExtension.Core.Tests
                 EventName = "test",
                 UserId = "user",
                 EditorType = "editor",
+                EditorVersion = "18.1.1",
                 ExtensionVersion = "1.0",
                 Internal = true,
             };
 
             var json = JsonConvert.SerializeObject(telemetryEvent);
 
-            AssertJsonContainsProperties(json, "event-name", "user-id", "editor-type", "extension-version", "internal");
+            AssertJsonContainsProperties(json, "event-name", "user-id", "editor-type", "editor-version", "extension-version", "internal");
         }
 
         [TestMethod]
@@ -384,6 +398,7 @@ namespace Codescene.VSExtension.Core.Tests
             Assert.Contains("\"event-name\"", json);
             Assert.DoesNotContain("\"user-id\"", json);
             Assert.DoesNotContain("\"editor-type\"", json);
+            Assert.DoesNotContain("\"editor-version\"", json);
             Assert.DoesNotContain("\"extension-version\"", json);
             Assert.DoesNotContain("\"internal\"", json);
         }
@@ -395,6 +410,7 @@ namespace Codescene.VSExtension.Core.Tests
                 ""event-name"": ""refactor"",
                 ""user-id"": ""abc123"",
                 ""editor-type"": ""vs2022"",
+                ""editor-version"": ""18.1.1"",
                 ""extension-version"": ""3.0.0"",
                 ""internal"": true
             }";
@@ -404,6 +420,7 @@ namespace Codescene.VSExtension.Core.Tests
             Assert.AreEqual("refactor", result.EventName);
             Assert.AreEqual("abc123", result.UserId);
             Assert.AreEqual("vs2022", result.EditorType);
+            Assert.AreEqual("18.1.1", result.EditorVersion);
             Assert.AreEqual("3.0.0", result.ExtensionVersion);
             Assert.IsTrue(result.Internal);
         }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryManagerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryManagerTests.cs
@@ -28,6 +28,7 @@ namespace Codescene.VSExtension.Core.Tests
             _mockDeviceIdStore = new Mock<IDeviceIdStore>();
             _mockCommandProvider = new Mock<ICliCommandProvider>();
             _mockMetadataProvider = new Mock<IExtensionMetadataProvider>();
+            _mockMetadataProvider.Setup(x => x.GetEditorVersion()).Returns("18.1.1");
 
             _telemetryManager = new TelemetryManager(
                 _mockLogger.Object,
@@ -111,6 +112,26 @@ namespace Codescene.VSExtension.Core.Tests
 
             // Assert - device ID store should be called (if telemetry is enabled)
             // Note: This verification depends on TelemetryUtils.IsTelemetryEnabled() returning true
+        }
+
+        [TestMethod]
+        public async Task SendTelemetryAsync_IncludesEditorVersionInPayload()
+        {
+            var eventName = "test-event";
+            string capturedCommand = null;
+            _mockDeviceIdStore.Setup(x => x.GetDeviceIdAsync()).ReturnsAsync("device-123");
+            _mockMetadataProvider.Setup(x => x.GetVersion()).Returns("1.0.0");
+            _mockMetadataProvider.Setup(x => x.GetEditorVersion()).Returns("18.1.1");
+            _mockCommandProvider.Setup(x => x.SendTelemetryCommand(It.IsAny<string>()))
+                .Callback<string>(json => capturedCommand = json)
+                .Returns("cmd");
+            _mockExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>()))
+                .ReturnsAsync("ok");
+
+            await _telemetryManager.SendTelemetryAsync(eventName);
+
+            Assert.IsNotNull(capturedCommand);
+            Assert.Contains("\"editor-version\":\"18.1.1\"", capturedCommand);
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryManagerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryManagerTests.cs
@@ -38,17 +38,13 @@ namespace Codescene.VSExtension.Core.Tests
                 _mockMetadataProvider.Object);
 
             ErrorTelemetryUtils.ResetErrorCount();
-#if DEBUG
             TelemetryUtils.TelemetryEnabledOverrideForTests = true;
-#endif
         }
 
         [TestCleanup]
         public void TearDown()
         {
-#if DEBUG
             TelemetryUtils.TelemetryEnabledOverrideForTests = null;
-#endif
         }
 
 #if DEBUG
@@ -119,6 +115,7 @@ namespace Codescene.VSExtension.Core.Tests
         {
             var eventName = "test-event";
             string capturedCommand = null;
+            TelemetryUtils.TelemetryEnabledOverrideForTests = true;
             _mockDeviceIdStore.Setup(x => x.GetDeviceIdAsync()).ReturnsAsync("device-123");
             _mockMetadataProvider.Setup(x => x.GetVersion()).Returns("1.0.0");
             _mockMetadataProvider.Setup(x => x.GetEditorVersion()).Returns("18.1.1");

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryUtilsTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryUtilsTests.cs
@@ -11,12 +11,13 @@ namespace Codescene.VSExtension.Core.Tests
         [TestMethod]
         public void GetTelemetryEventJson_ReturnsValidJsonWithExpectedFields()
         {
-            var json = TelemetryUtils.GetTelemetryEventJson("test-event", "device-123", "1.0.0");
+            var json = TelemetryUtils.GetTelemetryEventJson("test-event", "device-123", "1.0.0", "18.1.1");
             var obj = JObject.Parse(json);
 
             Assert.AreEqual("vs/test-event", obj["event-name"]?.ToString());
             Assert.AreEqual("device-123", obj["user-id"]?.ToString());
             Assert.AreEqual("vs", obj["editor-type"]?.ToString());
+            Assert.AreEqual("18.1.1", obj["editor-version"]?.ToString());
             Assert.AreEqual("1.0.0", obj["extension-version"]?.ToString());
         }
 
@@ -29,12 +30,22 @@ namespace Codescene.VSExtension.Core.Tests
                 { "count", 42 },
             };
 
-            var json = TelemetryUtils.GetTelemetryEventJson("test-event", "device-123", "1.0.0", additionalData);
+            var json = TelemetryUtils.GetTelemetryEventJson("test-event", "device-123", "1.0.0", "18.1.1", additionalData);
             var obj = JObject.Parse(json);
 
             Assert.AreEqual("custom-value", obj["custom-key"]?.ToString());
             Assert.AreEqual(42, obj["count"]?.Value<int>());
             Assert.AreEqual("vs/test-event", obj["event-name"]?.ToString());
+            Assert.AreEqual("18.1.1", obj["editor-version"]?.ToString());
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventJson_OmitsEditorVersion_WhenNull()
+        {
+            var json = TelemetryUtils.GetTelemetryEventJson("test-event", "device-123", "1.0.0");
+            var obj = JObject.Parse(json);
+
+            Assert.IsNull(obj["editor-version"]);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Telemetry/TelemetryManager.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Telemetry/TelemetryManager.cs
@@ -61,6 +61,7 @@ namespace Codescene.VSExtension.Core.Application.Telemetry
                     eventName,
                     await _deviceIdStore.GetDeviceIdAsync(cancellationToken),
                     _extensionMetadataProvider.GetVersion(),
+                    _extensionMetadataProvider.GetEditorVersion(),
                     additionalEventData);
                 var arguments = _cliCommandProvider.SendTelemetryCommand(eventJson);
                 await _executor.ExecuteAsync(arguments, null, Constants.Timeout.TELEMETRYTIMEOUT, cancellationToken);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Extension/IExtensionMetadataProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Extension/IExtensionMetadataProvider.cs
@@ -11,5 +11,7 @@ namespace Codescene.VSExtension.Core.Interfaces.Extension
         string GetDescription();
 
         string GetPublisher();
+
+        string GetEditorVersion();
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Models/Cli/Telemetry/TelemetryEvent.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Models/Cli/Telemetry/TelemetryEvent.cs
@@ -15,6 +15,9 @@ namespace Codescene.VSExtension.Core.Models.Cli.Telemetry
         [JsonProperty("editor-type", NullValueHandling = NullValueHandling.Ignore)]
         public string EditorType { get; set; }
 
+        [JsonProperty("editor-version", NullValueHandling = NullValueHandling.Ignore)]
+        public string EditorVersion { get; set; }
+
         [JsonProperty("extension-version", NullValueHandling = NullValueHandling.Ignore)]
         public string ExtensionVersion { get; set; }
 
@@ -36,6 +39,12 @@ namespace Codescene.VSExtension.Core.Models.Cli.Telemetry
         public TelemetryEvent WithEditorType(string editorType)
         {
             this.EditorType = editorType;
+            return this;
+        }
+
+        public TelemetryEvent WithEditorVersion(string editorVersion)
+        {
+            this.EditorVersion = editorVersion;
             return this;
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryUtils.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryUtils.cs
@@ -12,7 +12,6 @@ namespace Codescene.VSExtension.Core.Util
 {
     public static class TelemetryUtils
     {
-#if DEBUG
         private static bool? _telemetryEnabledOverrideForTests;
 
         internal static bool? TelemetryEnabledOverrideForTests
@@ -20,7 +19,6 @@ namespace Codescene.VSExtension.Core.Util
             get => _telemetryEnabledOverrideForTests;
             set => _telemetryEnabledOverrideForTests = value;
         }
-#endif
 
         public static string GetTelemetryEventJson(string eventName, string deviceId, string version, string editorVersion = null, Dictionary<string, object> additionalEventData = null)
         {
@@ -58,12 +56,10 @@ namespace Codescene.VSExtension.Core.Util
         /// <returns>True if telemetry is enabled (opted in); otherwise, false.</returns>
         public static bool IsTelemetryEnabled(ILogger logger = null)
         {
-#if DEBUG
             if (_telemetryEnabledOverrideForTests.HasValue)
             {
                 return _telemetryEnabledOverrideForTests.Value;
             }
-#endif
 
             try
             {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryUtils.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryUtils.cs
@@ -22,12 +22,13 @@ namespace Codescene.VSExtension.Core.Util
         }
 #endif
 
-        public static string GetTelemetryEventJson(string eventName, string deviceId, string version, Dictionary<string, object> additionalEventData = null)
+        public static string GetTelemetryEventJson(string eventName, string deviceId, string version, string editorVersion = null, Dictionary<string, object> additionalEventData = null)
         {
             var telemetryEvent = new TelemetryEvent
             {
                 UserId = deviceId,
                 EditorType = Constants.Telemetry.SOURCEIDE,
+                EditorVersion = editorVersion,
                 EventName = $"{Constants.Telemetry.SOURCEIDE}/{eventName}",
                 ExtensionVersion = version,
             };

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Util/ExtensionMetadataProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Util/ExtensionMetadataProvider.cs
@@ -2,6 +2,9 @@
 
 using System.ComponentModel.Composition;
 using Codescene.VSExtension.Core.Interfaces.Extension;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Codescene.VSExtension.VS2022.Util;
 
@@ -9,6 +12,8 @@ namespace Codescene.VSExtension.VS2022.Util;
 [PartCreationPolicy(CreationPolicy.Shared)]
 public class VsExtensionMetadataProvider : IExtensionMetadataProvider
 {
+    private string _cachedEditorVersion;
+
     public string GetVersion() => Vsix.Version;
 
     public string GetDisplayName() => Vsix.Name;
@@ -16,4 +21,42 @@ public class VsExtensionMetadataProvider : IExtensionMetadataProvider
     public string GetDescription() => Vsix.Description;
 
     public string GetPublisher() => Vsix.Author;
+
+    public string GetEditorVersion()
+    {
+        if (_cachedEditorVersion != null)
+        {
+            return _cachedEditorVersion;
+        }
+
+        _cachedEditorVersion = ThreadHelper.JoinableTaskFactory.Run(async () =>
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            if (Package.GetGlobalService(typeof(SVsShell)) is not IVsShell vsShell)
+            {
+                return string.Empty;
+            }
+
+            if (vsShell.GetProperty((int)__VSSPROPID5.VSSPROPID_ReleaseVersion, out var raw) != VSConstants.S_OK)
+            {
+                return string.Empty;
+            }
+
+            return TrimToThreeParts(raw as string ?? string.Empty);
+        });
+
+        return _cachedEditorVersion;
+    }
+
+    private static string TrimToThreeParts(string version)
+    {
+        if (string.IsNullOrEmpty(version))
+        {
+            return string.Empty;
+        }
+
+        var parts = version.Split('.');
+        return parts.Length >= 3 ? $"{parts[0]}.{parts[1]}.{parts[2]}" : version;
+    }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Util/ExtensionMetadataProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Util/ExtensionMetadataProvider.cs
@@ -29,7 +29,7 @@ public class VsExtensionMetadataProvider : IExtensionMetadataProvider
             return _cachedEditorVersion;
         }
 
-        _cachedEditorVersion = ThreadHelper.JoinableTaskFactory.Run(async () =>
+        var editorVersion = ThreadHelper.JoinableTaskFactory.Run(async () =>
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
@@ -46,7 +46,12 @@ public class VsExtensionMetadataProvider : IExtensionMetadataProvider
             return TrimToThreeParts(raw as string ?? string.Empty);
         });
 
-        return _cachedEditorVersion;
+        if (!string.IsNullOrEmpty(editorVersion))
+        {
+            _cachedEditorVersion = editorVersion;
+        }
+
+        return editorVersion;
     }
 
     private static string TrimToThreeParts(string version)


### PR DESCRIPTION
## Summary

- Adds an `editor-version` property to the base telemetry payload (next to `editor-type`) that reports the host Visual Studio version (e.g. `18.1.1`).
- Resolved at runtime via `IVsShell.VSSPROPID_ReleaseVersion`, trimmed to `Major.Minor.Patch`, cached on first read.

This is how it looks in Amplitude:

<img width="660" height="239" alt="image" src="https://github.com/user-attachments/assets/f4f62046-35a2-41b6-91b2-bf4af04eca94" />

## Test plan

- [ ] `make iter` (60 tests pass)
- [ ] CodeScene `pre_commit_code_health_safeguard` quality gates passed
- [ ] Manual smoke check: load extension in VS 2022 / 2026 and confirm `editor-version` appears in emitted telemetry
