### PR TITLE
fix: CS-11165: Pass ACE auth token via CLI stdin instead of argv

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliCommandProviderTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliCommandProviderTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) CodeScene. All rights reserved.
 
+using System;
 using System.Globalization;
 using Codescene.VSExtension.Core.Application.Cli;
 using Codescene.VSExtension.Core.Interfaces;
@@ -146,6 +147,24 @@ namespace Codescene.VSExtension.Core.Tests
         public void RefactorPostCommand_ReturnsRunCommandRefactor()
         {
             Assert.AreEqual("run-command refactor", _commandProvider.RefactorPostCommand);
+        }
+
+        [TestMethod]
+        public void GetRefactorPostPayload_WithNullFnToRefactor_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                _commandProvider.GetRefactorPostPayload(null, skipCache: false, token: "token"));
+        }
+
+        [TestMethod]
+        public void GetRefactorPostPayload_WithNullOrEmptyToken_Throws()
+        {
+            var fnToRefactor = CreateFnToRefactor();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                _commandProvider.GetRefactorPostPayload(fnToRefactor, skipCache: false, token: null));
+            Assert.Throws<ArgumentException>(() =>
+                _commandProvider.GetRefactorPostPayload(fnToRefactor, skipCache: false, token: string.Empty));
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliCommandProviderTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliCommandProviderTests.cs
@@ -7,6 +7,8 @@ using Codescene.VSExtension.Core.Models.Cli.Delta;
 using Codescene.VSExtension.Core.Models.Cli.Refactor;
 using Codescene.VSExtension.Core.Models.Cli.Review;
 using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Codescene.VSExtension.Core.Tests
 {
@@ -141,97 +143,63 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
-        public void GetRefactorPostCommand_WithoutSkipCache_ReturnsBasicCommand()
+        public void RefactorPostCommand_ReturnsRunCommandRefactor()
         {
-            var fnToRefactor = CreateFnToRefactor();
-
-            var command = _commandProvider.GetRefactorPostCommand(fnToRefactor, skipCache: false);
-
-            Assert.StartsWith("refactor post", command);
-            Assert.DoesNotContain("--skip-cache", command);
+            Assert.AreEqual("run-command refactor", _commandProvider.RefactorPostCommand);
         }
 
         [TestMethod]
-        public void GetRefactorPostCommand_WithSkipCache_IncludesSkipCacheFlag()
-        {
-            var fnToRefactor = CreateFnToRefactor();
-
-            var command = _commandProvider.GetRefactorPostCommand(fnToRefactor, skipCache: true);
-
-            Assert.Contains("--skip-cache", command);
-        }
-
-        [TestMethod]
-        public void GetRefactorPostCommand_WithToken_IncludesTokenArgument()
+        public void GetRefactorPostPayload_WithoutSkipCache_IncludesTokenAndFnToRefactor()
         {
             var fnToRefactor = CreateFnToRefactor();
             var token = "test-token-123";
 
-            var command = _commandProvider.GetRefactorPostCommand(fnToRefactor, skipCache: false, token: token);
+            var payload = _commandProvider.GetRefactorPostPayload(fnToRefactor, skipCache: false, token: token);
+            var json = JObject.Parse(payload);
 
-            Assert.Contains("--token", command);
-            Assert.Contains(token, command);
+            Assert.AreEqual(token, json["token"]?.ToString());
+            Assert.IsNull(json["skip-cache"]);
+            Assert.IsNotNull(json["fn-to-refactor"]);
+            Assert.IsNull(json["fn-to-refactor-nippy-b64"]);
         }
 
         [TestMethod]
-        public void GetRefactorPostCommand_WithNullToken_DoesNotIncludeTokenArgument()
+        public void GetRefactorPostPayload_WithSkipCache_IncludesSkipCacheFlag()
         {
             var fnToRefactor = CreateFnToRefactor();
 
-            var command = _commandProvider.GetRefactorPostCommand(fnToRefactor, skipCache: false, token: null);
+            var payload = _commandProvider.GetRefactorPostPayload(fnToRefactor, skipCache: true, token: "token");
+            var json = JObject.Parse(payload);
 
-            Assert.DoesNotContain("--token", command);
+            Assert.IsTrue(json["skip-cache"]?.Value<bool>());
         }
 
         [TestMethod]
-        public void GetRefactorPostCommand_WithEmptyToken_DoesNotIncludeTokenArgument()
-        {
-            var fnToRefactor = CreateFnToRefactor();
-
-            var command = _commandProvider.GetRefactorPostCommand(fnToRefactor, skipCache: false, token: string.Empty);
-
-            Assert.DoesNotContain("--token", command);
-        }
-
-        [TestMethod]
-        public void GetRefactorPostCommand_WithWhitespaceToken_DoesNotIncludeTokenArgument()
-        {
-            var fnToRefactor = CreateFnToRefactor();
-
-            var command = _commandProvider.GetRefactorPostCommand(fnToRefactor, skipCache: false, token: "   ");
-
-            Assert.DoesNotContain("--token", command);
-        }
-
-        [TestMethod]
-        public void GetRefactorPostCommand_WithNippyB64_UsesFnToRefactorNippyB64Flag()
+        public void GetRefactorPostPayload_WithNippyB64_UsesFnToRefactorNippyB64Property()
         {
             var nippyB64 = "base64encodeddata";
             var fnToRefactor = CreateFnToRefactor(nippyB64: nippyB64);
 
-            var command = _commandProvider.GetRefactorPostCommand(fnToRefactor, skipCache: false);
+            var payload = _commandProvider.GetRefactorPostPayload(fnToRefactor, skipCache: false, token: "token");
+            var json = JObject.Parse(payload);
 
-            Assert.Contains("--fn-to-refactor-nippy-b64", command);
-            Assert.Contains(nippyB64, command);
-            Assert.DoesNotContain("--fn-to-refactor ", command);
+            Assert.AreEqual(nippyB64, json["fn-to-refactor-nippy-b64"]?.ToString());
+            Assert.IsNull(json["fn-to-refactor"]);
         }
 
         [TestMethod]
-        public void GetRefactorPostCommand_WithAllOptions_IncludesAllArguments()
+        public void GetRefactorPostPayload_WithAllOptions_IncludesExpectedProperties()
         {
             var nippyB64 = "encodeddata";
             var fnToRefactor = CreateFnToRefactor(nippyB64: nippyB64);
             var token = "my-token";
 
-            var command = _commandProvider.GetRefactorPostCommand(fnToRefactor, skipCache: true, token: token);
+            var payload = _commandProvider.GetRefactorPostPayload(fnToRefactor, skipCache: true, token: token);
+            var json = JObject.Parse(payload);
 
-            Assert.Contains("refactor", command);
-            Assert.Contains("post", command);
-            Assert.Contains("--skip-cache", command);
-            Assert.Contains("--token", command);
-            Assert.Contains(token, command);
-            Assert.Contains("--fn-to-refactor-nippy-b64", command);
-            Assert.Contains(nippyB64, command);
+            Assert.AreEqual(token, json["token"]?.ToString());
+            Assert.IsTrue(json["skip-cache"]?.Value<bool>());
+            Assert.AreEqual(nippyB64, json["fn-to-refactor-nippy-b64"]?.ToString());
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorRefactorDeviceTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorRefactorDeviceTests.cs
@@ -55,8 +55,9 @@ namespace Codescene.VSExtension.Core.Tests
             var jsonResponse = JsonConvert.SerializeObject(expectedResponse);
             var token = "test-token";
             _mockSettingsProvider.Setup(x => x.AuthToken).Returns(token);
-            _mockCommandProvider.Setup(x => x.GetRefactorPostCommand(fnToRefactor, false, token)).Returns("refactor post command");
-            _mockProcessExecutor.Setup(x => x.ExecuteAsync("refactor post command", It.IsAny<string>(), null, default, It.IsAny<string>())).ReturnsAsync(jsonResponse);
+            _mockCommandProvider.Setup(x => x.RefactorPostCommand).Returns("run-command refactor");
+            _mockCommandProvider.Setup(x => x.GetRefactorPostPayload(fnToRefactor, false, token)).Returns("{\"token\":\"test-token\"}");
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync("run-command refactor", It.IsAny<string>(), null, default, It.IsAny<string>())).ReturnsAsync(jsonResponse);
 
             var result = await _cliExecutor.PostRefactoringAsync(fnToRefactor, skipCache: false);
 
@@ -87,13 +88,15 @@ namespace Codescene.VSExtension.Core.Tests
             var providedToken = "provided-token";
             var response = new RefactorResponseModel { Code = "refactored" };
             var jsonResponse = JsonConvert.SerializeObject(response);
-            _mockCommandProvider.Setup(x => x.GetRefactorPostCommand(fnToRefactor, false, providedToken)).Returns("refactor post");
+            _mockCommandProvider.Setup(x => x.RefactorPostCommand).Returns("run-command refactor");
+            _mockCommandProvider.Setup(x => x.GetRefactorPostPayload(fnToRefactor, false, providedToken)).Returns("{\"token\":\"provided-token\"}");
             _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>())).ReturnsAsync(jsonResponse);
 
             var result = await _cliExecutor.PostRefactoringAsync(fnToRefactor, skipCache: false, token: providedToken);
 
             Assert.IsNotNull(result);
-            _mockCommandProvider.Verify(x => x.GetRefactorPostCommand(fnToRefactor, false, providedToken), Times.Once);
+            _mockCommandProvider.Verify(x => x.GetRefactorPostPayload(fnToRefactor, false, providedToken), Times.Once);
+            _mockProcessExecutor.Verify(x => x.ExecuteAsync("run-command refactor", It.IsAny<string>(), null, It.IsAny<CancellationToken>(), It.IsAny<string>()), Times.Once);
         }
 
         [TestMethod]
@@ -101,7 +104,7 @@ namespace Codescene.VSExtension.Core.Tests
         {
             var fnToRefactor = new FnToRefactorModel { Name = "Test" };
             _mockSettingsProvider.Setup(x => x.AuthToken).Returns("test-token");
-            _mockCommandProvider.Setup(x => x.GetRefactorPostCommand(It.IsAny<FnToRefactorModel>(), It.IsAny<bool>(), It.IsAny<string>())).Returns(string.Empty);
+            _mockCommandProvider.Setup(x => x.RefactorPostCommand).Returns(string.Empty);
 
             var result = await _cliExecutor.PostRefactoringAsync(fnToRefactor);
 
@@ -114,7 +117,8 @@ namespace Codescene.VSExtension.Core.Tests
         {
             var fnToRefactor = new FnToRefactorModel { Name = "Test" };
             _mockSettingsProvider.Setup(x => x.AuthToken).Returns("test-token");
-            _mockCommandProvider.Setup(x => x.GetRefactorPostCommand(It.IsAny<FnToRefactorModel>(), It.IsAny<bool>(), It.IsAny<string>())).Returns("refactor post");
+            _mockCommandProvider.Setup(x => x.RefactorPostCommand).Returns("run-command refactor");
+            _mockCommandProvider.Setup(x => x.GetRefactorPostPayload(It.IsAny<FnToRefactorModel>(), It.IsAny<bool>(), It.IsAny<string>())).Returns("{\"token\":\"test-token\"}");
             _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>())).ThrowsAsync(new Exception("Error"));
 
             var result = await _cliExecutor.PostRefactoringAsync(fnToRefactor);
@@ -131,13 +135,14 @@ namespace Codescene.VSExtension.Core.Tests
             var response = new RefactorResponseModel { Code = "refactored" };
             var jsonResponse = JsonConvert.SerializeObject(response);
             _mockSettingsProvider.Setup(x => x.AuthToken).Returns(token);
-            _mockCommandProvider.Setup(x => x.GetRefactorPostCommand(fnToRefactor, true, token)).Returns("refactor post --skip-cache");
+            _mockCommandProvider.Setup(x => x.RefactorPostCommand).Returns("run-command refactor");
+            _mockCommandProvider.Setup(x => x.GetRefactorPostPayload(fnToRefactor, true, token)).Returns("{\"token\":\"test-token\",\"skip-cache\":true}");
             _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<System.Threading.CancellationToken>(), It.IsAny<string>())).ReturnsAsync(jsonResponse);
 
             var result = await _cliExecutor.PostRefactoringAsync(fnToRefactor, skipCache: true);
 
             Assert.IsNotNull(result);
-            _mockCommandProvider.Verify(x => x.GetRefactorPostCommand(fnToRefactor, true, token), Times.Once);
+            _mockCommandProvider.Verify(x => x.GetRefactorPostPayload(fnToRefactor, true, token), Times.Once);
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliCommandProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliCommandProvider.cs
@@ -17,6 +17,12 @@ namespace Codescene.VSExtension.Core.Application.Cli
     {
         private static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Include };
 
+        private static readonly JsonSerializerSettings RefactorPostSerializerSettings = new JsonSerializerSettings
+        {
+            DefaultValueHandling = DefaultValueHandling.Include,
+            NullValueHandling = NullValueHandling.Ignore,
+        };
+
         private readonly ICliObjectScoreCreator _creator;
 
         [ImportingConstructor]
@@ -30,6 +36,8 @@ namespace Codescene.VSExtension.Core.Application.Cli
         public string DeviceIdCommand => "telemetry --device-id";
 
         public string RefactorCommand => "run-command fns-to-refactor";
+
+        public string RefactorPostCommand => "run-command refactor";
 
         public string ReviewFileContentCommand => "run-command review";
 
@@ -53,28 +61,28 @@ namespace Codescene.VSExtension.Core.Application.Cli
             return SerializeRefactorRequest(request, fileName, fileContent, cachePath, preflight);
         }
 
-        public string GetRefactorPostCommand(FnToRefactorModel fnToRefactor, bool skipCache, string token = null)
+        public string GetRefactorPostPayload(FnToRefactorModel fnToRefactor, bool skipCache, string token)
         {
-            var args = new List<string> { "refactor", "post" };
+            var request = new RefactorPostRequestModel
+            {
+                Token = token,
+            };
+
             if (skipCache)
             {
-                args.Add("--skip-cache");
-            }
-
-            if (!string.IsNullOrWhiteSpace(token))
-            {
-                args.Add("--token");
-                args.Add(token);
+                request.SkipCache = true;
             }
 
             if (!string.IsNullOrEmpty(fnToRefactor.NippyB64))
             {
-                args.Add("--fn-to-refactor-nippy-b64");
-                args.Add(fnToRefactor.NippyB64);
+                request.FnToRefactorNippyB64 = fnToRefactor.NippyB64;
+            }
+            else
+            {
+                request.FnToRefactor = fnToRefactor;
             }
 
-            var command = GetArgumentStr(args.ToArray());
-            return command;
+            return JsonConvert.SerializeObject(request, RefactorPostSerializerSettings);
         }
 
         public string GetReviewFileContentPayload(string filePath, string fileContent, string cachePath)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliCommandProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliCommandProvider.cs
@@ -1,5 +1,6 @@
 // Copyright (c) CodeScene. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Text;
@@ -63,6 +64,21 @@ namespace Codescene.VSExtension.Core.Application.Cli
 
         public string GetRefactorPostPayload(FnToRefactorModel fnToRefactor, bool skipCache, string token)
         {
+            if (fnToRefactor == null)
+            {
+                throw new ArgumentNullException(nameof(fnToRefactor));
+            }
+
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (token.Length == 0)
+            {
+                throw new ArgumentException("Token must not be empty.", nameof(token));
+            }
+
             var request = new RefactorPostRequestModel
             {
                 Token = token,

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
@@ -219,8 +219,9 @@ namespace Codescene.VSExtension.Core.Application.Cli
                 throw missingTokenEx;
             }
 
-            var arguments = _cliServices.CommandProvider.GetRefactorPostCommand(fnToRefactor: fnToRefactor, skipCache: skipCache, token: effectiveToken);
-            if (string.IsNullOrEmpty(arguments))
+            var arguments = _cliServices.CommandProvider.RefactorPostCommand;
+            var payload = _cliServices.CommandProvider.GetRefactorPostPayload(fnToRefactor, skipCache, effectiveToken);
+            if (string.IsNullOrEmpty(arguments) || string.IsNullOrEmpty(payload))
             {
                 _logger.Warn("Skipping refactoring. Arguments were not defined.");
                 return null;
@@ -231,7 +232,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
                 cancellationToken,
                 () => ExecuteWithTimingAndLoggingAsync<RefactorResponseModel>(
                     "ACE refactoring",
-                    () => _cliServices.ProcessExecutor.ExecuteAsync(arguments, null, null, cancellationToken),
+                    () => _cliServices.ProcessExecutor.ExecuteAsync(arguments, payload, null, cancellationToken),
                     "Refactoring failed."));
 
             if (result != null && fnToRefactor != null)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/ICliCommandProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/ICliCommandProvider.cs
@@ -17,6 +17,8 @@ namespace Codescene.VSExtension.Core.Interfaces.Cli
 
         string ReviewFileContentCommand { get; }
 
+        string RefactorPostCommand { get; }
+
         string SendTelemetryCommand(string jsonEvent);
 
         string GetReviewFileContentPayload(string filePath, string fileContent, string cachePath);
@@ -29,6 +31,6 @@ namespace Codescene.VSExtension.Core.Interfaces.Cli
 
         string GetPreflightSupportInformationCommand(bool force);
 
-        string GetRefactorPostCommand(FnToRefactorModel fnToRefactor, bool skipCache, string token = null);
+        string GetRefactorPostPayload(FnToRefactorModel fnToRefactor, bool skipCache, string token);
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Models/Cli/Refactor/RefactorPostRequestModel.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Models/Cli/Refactor/RefactorPostRequestModel.cs
@@ -1,0 +1,21 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using Newtonsoft.Json;
+
+namespace Codescene.VSExtension.Core.Models.Cli.Refactor
+{
+    public class RefactorPostRequestModel
+    {
+        [JsonProperty("token")]
+        public string Token { get; set; }
+
+        [JsonProperty("skip-cache")]
+        public bool? SkipCache { get; set; }
+
+        [JsonProperty("fn-to-refactor-nippy-b64")]
+        public string FnToRefactorNippyB64 { get; set; }
+
+        [JsonProperty("fn-to-refactor")]
+        public FnToRefactorModel FnToRefactor { get; set; }
+    }
+}


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpja0 (CS-11165)

## Problem
ACE refactor passed the auth token as `--token` on the CLI process command line, exposing it to local process inspection.

## Fix
Invoke `run-command refactor` with a JSON stdin payload (token, fn-to-refactor, skip-cache) instead of `refactor post --token ...`.

## Test plan
- [ ] Trigger ACE refactor and confirm the CLI process command line has no token
- [ ] `make iter` passed

Made with [Cursor](https://cursor.com)