### PR TITLE
fix: CS-11166: Redact auth tokens in CLI log output

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TextUtilsTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TextUtilsTests.cs
@@ -217,5 +217,65 @@ namespace Codescene.VSExtension.Core.Tests
             Assert.DoesNotContain("file-content", result);
             Assert.DoesNotContain("huge content", result);
         }
+
+        [TestMethod]
+        public void BuildCommandForLogging_RedactsTokenInJsonPayload()
+        {
+            var args = "run-command refactor";
+            var json = "{\"token\":\"super-secret\",\"skip-cache\":true}";
+            var result = TextUtils.BuildCommandForLogging(args, json);
+
+            Assert.Contains("'token' \"***\"", result);
+            Assert.DoesNotContain("super-secret", result);
+            Assert.Contains("'skip-cache'", result);
+        }
+
+        [TestMethod]
+        public void RedactSensitiveCliArguments_NullOrEmpty_ReturnsInput()
+        {
+            Assert.IsNull(TextUtils.RedactSensitiveCliArguments(null));
+            Assert.AreEqual(string.Empty, TextUtils.RedactSensitiveCliArguments(string.Empty));
+        }
+
+        [TestMethod]
+        public void RedactSensitiveCliArguments_TokenWithSpaceSeparatedValue_Redacts()
+        {
+            var args = "refactor post --skip-cache --token my-secret-token --fn-to-refactor-nippy-b64 abc";
+            var result = TextUtils.RedactSensitiveCliArguments(args);
+
+            Assert.AreEqual("refactor post --skip-cache --token *** --fn-to-refactor-nippy-b64 abc", result);
+            Assert.DoesNotContain("my-secret-token", result);
+        }
+
+        [TestMethod]
+        public void RedactSensitiveCliArguments_TokenWithEqualsForm_Redacts()
+        {
+            var args = "refactor post --token=my-secret-token";
+            var result = TextUtils.RedactSensitiveCliArguments(args);
+
+            Assert.AreEqual("refactor post --token ***", result);
+            Assert.DoesNotContain("my-secret-token", result);
+        }
+
+        [TestMethod]
+        public void RedactSensitiveCliArguments_QuotedTokenValue_Redacts()
+        {
+            var args = "refactor post --token \"secret with spaces\"";
+            var result = TextUtils.RedactSensitiveCliArguments(args);
+
+            Assert.AreEqual("refactor post --token ***", result);
+            Assert.DoesNotContain("secret with spaces", result);
+        }
+
+        [TestMethod]
+        public void BuildCommandForLogging_TokenInArgs_RedactsBeforeTrim()
+        {
+            var padding = new string('x', 200);
+            var args = $"refactor post --token {padding}super-secret";
+            var result = TextUtils.BuildCommandForLogging(args, null, maxValueLength: 120);
+
+            Assert.DoesNotContain("super-secret", result);
+            Assert.Contains("--token ***", result);
+        }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TextUtils.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TextUtils.cs
@@ -11,6 +11,10 @@ namespace Codescene.VSExtension.Core.Util
 {
     public static class TextUtils
     {
+        private static readonly Regex SecretCliFlagRegex = new Regex(
+            @"--token(?:\s*=\s*|\s+)(?:""[^""]*""|'[^']*'|\S+)",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         public static string ToSnakeCase(string input)
         {
             var normalized = input.Replace("-", "_");
@@ -51,20 +55,32 @@ namespace Codescene.VSExtension.Core.Util
             return value.Substring(0, maxLength) + "...";
         }
 
+        public static string RedactSensitiveCliArguments(string arguments)
+        {
+            if (string.IsNullOrEmpty(arguments))
+            {
+                return arguments;
+            }
+
+            return SecretCliFlagRegex.Replace(arguments, "--token ***");
+        }
+
         public static string BuildCommandForLogging(string arguments, string jsonContent, int maxValueLength = 120)
         {
+            var safeArguments = RedactSensitiveCliArguments(arguments);
+
             if (string.IsNullOrEmpty(jsonContent))
             {
-                return TrimForLogging(arguments, maxValueLength);
+                return TrimForLogging(safeArguments, maxValueLength);
             }
 
             var entries = ExtractLoggableJsonEntries(jsonContent, maxValueLength);
             if (string.IsNullOrEmpty(entries))
             {
-                return TrimForLogging(arguments, maxValueLength);
+                return TrimForLogging(safeArguments, maxValueLength);
             }
 
-            return $"{arguments} {entries}";
+            return $"{safeArguments} {entries}";
         }
 
         public static string ExtractLoggableJsonEntries(string jsonContent, int maxValueLength = 120)
@@ -93,6 +109,33 @@ namespace Codescene.VSExtension.Core.Util
             return FormatJsonProperties(jsonObject, maxValueLength);
         }
 
+        private static bool ShouldSkipLoggableJsonProperty(string propertyName) =>
+            propertyName == "file-content";
+
+        private static string FormatLoggableJsonProperty(JProperty property, int maxValueLength)
+        {
+            if (property.Name == "token")
+            {
+                return "'token' \"***\"";
+            }
+
+            var value = property.Value.Type == JTokenType.String
+                ? property.Value.ToString()
+                : property.Value.ToString(Formatting.None);
+
+            return $"'{property.Name}' \"{TrimForLogging(value, maxValueLength)}\"";
+        }
+
+        private static void AppendLoggableEntry(StringBuilder result, string entry)
+        {
+            if (result.Length > 0)
+            {
+                result.Append(" ");
+            }
+
+            result.Append(entry);
+        }
+
         private static string FormatJsonProperties(JObject jsonObject, int maxValueLength)
         {
             try
@@ -100,23 +143,12 @@ namespace Codescene.VSExtension.Core.Util
                 var result = new StringBuilder();
                 foreach (var property in jsonObject.Properties())
                 {
-                    if (property.Name == "file-content")
+                    if (ShouldSkipLoggableJsonProperty(property.Name))
                     {
                         continue;
                     }
 
-                    var value = property.Value.Type == JTokenType.String
-                        ? property.Value.ToString()
-                        : property.Value.ToString(Formatting.None);
-
-                    var trimmedValue = TrimForLogging(value, maxValueLength);
-
-                    if (result.Length > 0)
-                    {
-                        result.Append(" ");
-                    }
-
-                    result.Append($"'{property.Name}' \"{trimmedValue}\"");
+                    AppendLoggableEntry(result, FormatLoggableJsonProperty(property, maxValueLength));
                 }
 
                 return result.ToString();


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpjyz (CS-11166)

## Problem
`ProcessExecutor` logged full CLI arguments and JSON payload fields; `--token` values and token properties could appear in the extension log file and VS Output pane.

## Fix
Centralize redaction in `TextUtils.BuildCommandForLogging`: strip `--token` argument values and mask `token` in logged JSON entries.

## Test plan
- [ ] Run ACE refactor with token configured; confirm log/Output pane show `***` not the real token
- [ ] `make iter` passed

## Note
Merge after CS-11165 if both land separately; together they cover argv and log surfaces.