### PR TITLE
CS-11169: Anchor external navigation to HTTPS host allowlist

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ExternalNavigationAllowlistTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ExternalNavigationAllowlistTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using Codescene.VSExtension.Core.Util;
+
+namespace Codescene.VSExtension.Core.Tests;
+
+[TestClass]
+public class ExternalNavigationAllowlistTests
+{
+    [TestMethod]
+    [DataRow("https://codescene.io/docs")]
+    [DataRow("https://www.codescene.com")]
+    [DataRow("https://en.wikipedia.org/wiki/Test")]
+    [DataRow("https://blog.ploeh.dk/2018/08/27/on-constructor-over-injection/")]
+    [DataRow("https://helpcenter.codescene.com/hc/en-us")]
+    public void IsAllowedExternalUri_AllowedHosts_ReturnsTrue(string uri)
+        => Assert.IsTrue(ExternalNavigationAllowlist.IsAllowedExternalUri(uri));
+
+    [TestMethod]
+    [DataRow("https://codescene.io.evil.example/phish")]
+    [DataRow("https://codescene.com@attacker.tld/")]
+    [DataRow("http://codescene.io")]
+    [DataRow("file:///etc/passwd")]
+    [DataRow("https://evilcodescene.io")]
+    [DataRow("https://notcodescene.io")]
+    [DataRow("")]
+    [DataRow("not-a-uri")]
+    public void IsAllowedExternalUri_DisallowedUris_ReturnsFalse(string uri)
+        => Assert.IsFalse(ExternalNavigationAllowlist.IsAllowedExternalUri(uri));
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/ExternalNavigationAllowlist.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/ExternalNavigationAllowlist.cs
@@ -1,0 +1,58 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Linq;
+
+namespace Codescene.VSExtension.Core.Util;
+
+public static class ExternalNavigationAllowlist
+{
+    private static readonly string[] AllowedHosts =
+    {
+        "refactoring.com",
+        "en.wikipedia.org",
+        "codescene.io",
+        "codescene.com",
+        "blog.ploeh.dk",
+        "supporthub.codescene.com",
+        "forms.clickup.com",
+        "helpcenter.codescene.com",
+    };
+
+    public static bool IsAllowedExternalUri(string uriString)
+    {
+        if (string.IsNullOrWhiteSpace(uriString))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (uri.UserInfo.Length > 0)
+        {
+            return false;
+        }
+
+        var host = uri.IdnHost;
+        if (string.IsNullOrEmpty(host))
+        {
+            return false;
+        }
+
+        return AllowedHosts.Any(allowed => IsHostMatch(host, allowed));
+    }
+
+    private static bool IsHostMatch(string host, string allowedHost)
+    {
+        return string.Equals(host, allowedHost, StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith("." + allowedHost, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/WebComponentUserControl.xaml.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/WebComponentUserControl.xaml.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows.Controls;
@@ -13,6 +12,7 @@ using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Telemetry;
 using Codescene.VSExtension.Core.Models.WebComponent.Data;
 using Codescene.VSExtension.Core.Models.WebComponent.Payload;
+using Codescene.VSExtension.Core.Util;
 using Codescene.VSExtension.VS2022.ToolWindows.WebComponent.Handlers;
 using Codescene.VSExtension.VS2022.Util;
 using Community.VisualStudio.Toolkit;
@@ -31,18 +31,6 @@ public partial class WebComponentUserControl : UserControl
 {
     private const string FOLDERLOCATION = @"ToolWindows\WebComponent";
     private const string STYLEELEMENTID = "cs-theme-vars";
-    private static readonly string[] AllowedDomains =
-    {
-        "https://refactoring.com",
-        "https://en.wikipedia.org",
-        "https://codescene.io",
-        "https://codescene.com",
-        "https://blog.ploeh.dk/2018/08/27/on-constructor-over-injection/",
-        "https://supporthub.codescene.com",
-        "https://forms.clickup.com",
-        "https://helpcenter.codescene.com",
-    };
-
     private readonly ILogger _logger;
 
     private string _host;
@@ -368,8 +356,7 @@ public partial class WebComponentUserControl : UserControl
             return;
         }
 
-        var isExternalNavigationAllowed = AllowedDomains.Any(domain => uri.StartsWith(domain, StringComparison.OrdinalIgnoreCase));
-        if (isExternalNavigationAllowed)
+        if (ExternalNavigationAllowlist.IsAllowedExternalUri(uri))
         {
             try
             {


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpk7q (CS-11169)

## Problem
WebView external links used unanchored StartsWith on URL prefixes, allowing phishing URLs (e.g. codescene.io.evil.example) and userinfo bypasses (codescene.com@attacker.tld). Non-https schemes could slip through.

## Fix
Parse navigation URIs with Uri.TryCreate, require https, reject userinfo, and match host against an anchored hostname allow-list (exact or subdomain suffix).

## Test plan
- [ ] Open web component link to allowed codescene.io URL in external browser
- [x] make iter passed

Made with [Cursor](https://cursor.com)