### PR TITLE
CS-11167: DPAPI-encrypt auth token in VS settings

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/AuthTokenProtectorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/AuthTokenProtectorTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using Codescene.VSExtension.Core.Application.Security;
+
+namespace Codescene.VSExtension.Core.Tests;
+
+[TestClass]
+public class AuthTokenProtectorTests
+{
+    [TestMethod]
+    public void Protect_Unprotect_RoundTrips()
+    {
+        const string token = "test-token-value";
+
+        var protectedToken = AuthTokenProtector.Protect(token);
+        var restored = AuthTokenProtector.Unprotect(protectedToken);
+
+        Assert.AreNotEqual(token, protectedToken);
+        Assert.AreEqual(token, restored);
+    }
+
+    [TestMethod]
+    public void Protect_Empty_ReturnsEmpty()
+    {
+        Assert.AreEqual(string.Empty, AuthTokenProtector.Protect(string.Empty));
+        Assert.AreEqual(string.Empty, AuthTokenProtector.Protect(null!));
+    }
+
+    [TestMethod]
+    public void Unprotect_Empty_ReturnsEmpty()
+    {
+        Assert.AreEqual(string.Empty, AuthTokenProtector.Unprotect(string.Empty));
+        Assert.AreEqual(string.Empty, AuthTokenProtector.Unprotect(null!));
+    }
+
+    [TestMethod]
+    public void Unprotect_LegacyPlaintext_ReturnsUnchanged()
+    {
+        const string legacyToken = "legacy-plaintext-token";
+
+        Assert.AreEqual(legacyToken, AuthTokenProtector.Unprotect(legacyToken));
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Security/AuthTokenProtector.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Security/AuthTokenProtector.cs
@@ -1,0 +1,47 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Codescene.VSExtension.Core.Application.Security;
+
+internal static class AuthTokenProtector
+{
+    private static readonly byte[] Entropy = Encoding.UTF8.GetBytes("Codescene.VSExtension.VS2022.AuthToken.v1");
+
+    public static string Protect(string plaintext)
+    {
+        if (string.IsNullOrEmpty(plaintext))
+        {
+            return string.Empty;
+        }
+
+        var data = Encoding.UTF8.GetBytes(plaintext);
+        var protectedBytes = ProtectedData.Protect(data, Entropy, DataProtectionScope.CurrentUser);
+        return Convert.ToBase64String(protectedBytes);
+    }
+
+    public static string Unprotect(string stored)
+    {
+        if (string.IsNullOrEmpty(stored))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var protectedBytes = Convert.FromBase64String(stored);
+            var data = ProtectedData.Unprotect(protectedBytes, Entropy, DataProtectionScope.CurrentUser);
+            return Encoding.UTF8.GetString(data);
+        }
+        catch (FormatException)
+        {
+            return stored;
+        }
+        catch (CryptographicException)
+        {
+            return stored;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Codescene.VSExtension.Core.csproj
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Codescene.VSExtension.Core.csproj
@@ -31,6 +31,7 @@
 		<Reference Include="System.ComponentModel.Composition" />
 		<Reference Include="System.IO.Compression.FileSystem" />
 		<Reference Include="System.Net.Http" />
+		<Reference Include="System.Security" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Properties/AssemblyInfo.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("0.4.5.0")]
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Codescene.VSExtension.Core.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Codescene.VSExtension.VS2022")]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Options/General.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Options/General.cs
@@ -3,6 +3,8 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Application.Security;
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
 
@@ -57,9 +59,29 @@ public class General : BaseOptionModel<General>
 
     [Category("Authentication")]
     [DisplayName("Auth Token")]
-    [Description("Authentication token for CodeScene ACE. Note: Token is stored securely in Windows Credential Manager.")]
+    [Description("Authentication token for CodeScene ACE. The token is encrypted with Windows DPAPI for the current user before being stored in Visual Studio settings.")]
     [PasswordPropertyText(true)]
     public string AuthToken { get; set; } = string.Empty;
+
+    public override async Task LoadAsync()
+    {
+        await base.LoadAsync();
+        AuthToken = AuthTokenProtector.Unprotect(AuthToken);
+    }
+
+    public override async Task SaveAsync()
+    {
+        var plaintext = AuthToken;
+        AuthToken = AuthTokenProtector.Protect(plaintext);
+        try
+        {
+            await base.SaveAsync();
+        }
+        finally
+        {
+            AuthToken = plaintext;
+        }
+    }
 
     private void OnSettingsSaved(General obj)
     {


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpk49 (CS-11167)

## Problem
The auth token options description claimed storage in Windows Credential Manager, but the token was persisted in plaintext-equivalent Visual Studio user settings. Any process running as the same user could read it.

## Fix
- Encrypt the auth token with Windows DPAPI (`DataProtectionScope.CurrentUser`) before persisting to VS settings; decrypt on load.
- Migrate existing plaintext tokens transparently on read (re-encrypted on next save).
- Update the options description to reflect actual storage behavior.

## Test plan
- [ ] Open Tools > Options > CodeScene, set auth token, restart VS, confirm token still works for ACE
- [ ] Verify existing plaintext token migrates without re-entry
- [x] `make iter` passed


Made with [Cursor](https://cursor.com)