### PR TITLE
CS-11173: Verify bundled CLI SHA-256 before execution

### DIFF
--- a/.github/cli.ps1
+++ b/.github/cli.ps1
@@ -22,3 +22,8 @@ $url = "https://downloads.codescene.io/enterprise/cli/cs-ide-windows-amd64-$Requ
 Write-Host "Downloading from $url"
 Invoke-WebRequest -Uri $url -OutFile cs-ide.zip
 Expand-Archive -Path cs-ide.zip -DestinationPath ./cs-ide -Force
+
+$cliExePath = "./cs-ide/cs-ide.exe"
+$cliSha256 = (Get-FileHash $cliExePath -Algorithm SHA256).Hash.ToLowerInvariant()
+Write-Host "Bundled CLI SHA-256: $cliSha256"
+Write-Host "Update RequiredCliBinarySha256 in CliSettingsProvider.cs when RequiredDevToolVersion changes."

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliBinaryIntegrityVerifierTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliBinaryIntegrityVerifierTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Security.Cryptography;
+using Codescene.VSExtension.Core.Application.Cli;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class CliBinaryIntegrityVerifierTests
+    {
+        private string _tempFilePath;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _tempFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".exe");
+            File.WriteAllText(_tempFilePath, "integrity test content");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (File.Exists(_tempFilePath))
+            {
+                File.Delete(_tempFilePath);
+            }
+        }
+
+        [TestMethod]
+        public void Verify_WhenHashMatches_DoesNotThrow()
+        {
+            CliBinaryIntegrityVerifier.Verify(_tempFilePath, ComputeSha256Hex(_tempFilePath));
+        }
+
+        [TestMethod]
+        public void Verify_WhenHashMismatch_ThrowsInvalidOperationException()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                CliBinaryIntegrityVerifier.Verify(_tempFilePath, new string('a', 64)));
+
+            Assert.Contains("integrity verification", exception.Message);
+        }
+
+        private static string ComputeSha256Hex(string filePath)
+        {
+            using var stream = File.OpenRead(filePath);
+            using var sha = SHA256.Create();
+            var hashBytes = sha.ComputeHash(stream);
+            return BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLowerInvariant();
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliSettingsProviderTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliSettingsProviderTests.cs
@@ -9,6 +9,7 @@ namespace Codescene.VSExtension.Core.Tests
     public class CliSettingsProviderTests
     {
         private readonly string expectedVersion = "0f50d883b976c66ab81681f4c3b5952f7c16ba87";
+        private readonly string expectedCliBinarySha256 = "64ba5083444d55090281a5639cd473ee870e404a485e9dde72ede7e144bb78bf";
 
         [TestMethod]
         public void RequiredDevToolVersion_ShouldReturnExpectedValue()
@@ -21,6 +22,14 @@ namespace Codescene.VSExtension.Core.Tests
 
             // ASSERT: Verify that the returned value is as expected
             Assert.AreEqual(expectedVersion, actualVersion, "RequiredDevToolVersion should return the expected SHA string.");
+        }
+
+        [TestMethod]
+        public void RequiredCliBinarySha256_ShouldReturnExpectedValue()
+        {
+            var provider = new CliSettingsProvider();
+
+            Assert.AreEqual(expectedCliBinarySha256, provider.RequiredCliBinarySha256);
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ProcessExecutorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ProcessExecutorTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) CodeScene. All rights reserved.
 
+using System.Security.Cryptography;
 using Codescene.VSExtension.Core.Application.Cli;
 using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Cli;
@@ -33,6 +34,19 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public void Execute_FileHashMismatch_ThrowsInvalidOperationException()
+        {
+            File.WriteAllText(_tempFilePath, "tampered cli");
+            SetupCliPath(_tempFilePath, "0000000000000000000000000000000000000000000000000000000000000000");
+            _processExecutor = new ProcessExecutor(_mockCliSettingsProvider.Object, _mockLogger.Object);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                _processExecutor.ExecuteAsync("version --sha").GetAwaiter().GetResult());
+
+            Assert.Contains("integrity verification", exception.Message);
+        }
+
+        [TestMethod]
         public void Execute_FileDoesNotExist_ThrowsFileNotFoundException()
         {
             // Arrange
@@ -53,7 +67,7 @@ namespace Codescene.VSExtension.Core.Tests
         {
             // Arrange
             File.WriteAllText(_tempFilePath, "dummy executable content");
-            _mockCliSettingsProvider.Setup(x => x.CliFileFullPath).Returns(_tempFilePath);
+            SetupCliPath(_tempFilePath);
             _processExecutor = new ProcessExecutor(_mockCliSettingsProvider.Object, _mockLogger.Object);
 
             // Act & Assert
@@ -88,7 +102,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return;
             }
 
-            _mockCliSettingsProvider.Setup(x => x.CliFileFullPath).Returns(pingPath);
+            SetupCliPath(pingPath);
             _processExecutor = new ProcessExecutor(_mockCliSettingsProvider.Object, _mockLogger.Object);
 
             var exception = await Assert.ThrowsAsync<TimeoutException>(() =>
@@ -108,7 +122,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return;
             }
 
-            _mockCliSettingsProvider.Setup(x => x.CliFileFullPath).Returns(pingPath);
+            SetupCliPath(pingPath);
             _processExecutor = new ProcessExecutor(_mockCliSettingsProvider.Object, _mockLogger.Object);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
@@ -127,12 +141,27 @@ namespace Codescene.VSExtension.Core.Tests
                 return;
             }
 
-            _mockCliSettingsProvider.Setup(x => x.CliFileFullPath).Returns(pingPath);
+            SetupCliPath(pingPath);
             _processExecutor = new ProcessExecutor(_mockCliSettingsProvider.Object, _mockLogger.Object);
 
             var result = await _processExecutor.ExecuteAsync("telemetry some-command", null, TimeSpan.FromMilliseconds(1));
 
             Assert.AreEqual(string.Empty, result);
+        }
+
+        private static string ComputeSha256Hex(string filePath)
+        {
+            using var stream = File.OpenRead(filePath);
+            using var sha = SHA256.Create();
+            var hashBytes = sha.ComputeHash(stream);
+            return BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLowerInvariant();
+        }
+
+        private void SetupCliPath(string cliFilePath, string requiredSha256Hex = null)
+        {
+            _mockCliSettingsProvider.Setup(x => x.CliFileFullPath).Returns(cliFilePath);
+            var sha256Hex = requiredSha256Hex ?? ComputeSha256Hex(cliFilePath);
+            _mockCliSettingsProvider.Setup(x => x.RequiredCliBinarySha256).Returns(sha256Hex);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliBinaryIntegrityVerifier.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliBinaryIntegrityVerifier.cs
@@ -1,0 +1,35 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Codescene.VSExtension.Core.Application.Cli
+{
+    internal static class CliBinaryIntegrityVerifier
+    {
+        public static void Verify(string filePath, string expectedSha256Hex)
+        {
+            if (string.IsNullOrWhiteSpace(expectedSha256Hex))
+            {
+                throw new ArgumentException("Expected SHA-256 hash is required.", nameof(expectedSha256Hex));
+            }
+
+            var actualSha256Hex = ComputeSha256Hex(filePath);
+            if (!string.Equals(actualSha256Hex, expectedSha256Hex, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    "CodeScene CLI executable failed integrity verification. " +
+                    "Please reinstall the extension or contact support if this issue persists.");
+            }
+        }
+
+        private static string ComputeSha256Hex(string filePath)
+        {
+            using var stream = File.OpenRead(filePath);
+            using var sha = SHA256.Create();
+            var hashBytes = sha.ComputeHash(stream);
+            return BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLowerInvariant();
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliSettingsProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliSettingsProvider.cs
@@ -15,6 +15,8 @@ namespace Codescene.VSExtension.Core.Application.Cli
         // used by the build pipeline to bundle the CLI with the extension
         public string RequiredDevToolVersion => "0f50d883b976c66ab81681f4c3b5952f7c16ba87"; // 1.0.47
 
+        public string RequiredCliBinarySha256 => "64ba5083444d55090281a5639cd473ee870e404a485e9dde72ede7e144bb78bf";
+
         public string CliArtifactName => $"cs-ide-windows-amd64-{RequiredDevToolVersion}.zip";
 
         public string CliArtifactUrl => $"{ArtifactBaseUrl}{CliArtifactName}";

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/ProcessExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/ProcessExecutor.cs
@@ -24,8 +24,11 @@ namespace Codescene.VSExtension.Core.Application.Cli
     [PartCreationPolicy(CreationPolicy.Shared)]
     internal class ProcessExecutor : IProcessExecutor
     {
+        private readonly object _integrityLock = new object();
         private readonly ICliSettingsProvider _cliSettingsProvider;
         private readonly ILogger _logger;
+        private bool _integrityVerified;
+        private string _verifiedCliPath;
 
         [ImportingConstructor]
         public ProcessExecutor(ICliSettingsProvider cliSettingsProvider, ILogger logger)
@@ -46,6 +49,8 @@ namespace Codescene.VSExtension.Core.Application.Cli
                     "Please reinstall the extension or contact support if this issue persists.",
                     cliFilePath);
             }
+
+            EnsureCliIntegrity(cliFilePath);
 
             var actualTimeout = timeout ?? Constants.Timeout.DEFAULTCLITIMEOUT;
             using var timeoutCts = new CancellationTokenSource();
@@ -165,6 +170,21 @@ namespace Codescene.VSExtension.Core.Application.Cli
             }
 
             throw new TimeoutException($"Process execution exceeded the timeout of {actualTimeout.TotalMilliseconds}ms.");
+        }
+
+        private void EnsureCliIntegrity(string cliFilePath)
+        {
+            lock (_integrityLock)
+            {
+                if (_integrityVerified && string.Equals(_verifiedCliPath, cliFilePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                CliBinaryIntegrityVerifier.Verify(cliFilePath, _cliSettingsProvider.RequiredCliBinarySha256);
+                _integrityVerified = true;
+                _verifiedCliPath = cliFilePath;
+            }
         }
 
         private void AttachOutputHandlers(AttachOutputHandlersArgs handlerArguments)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/ICliSettingsProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/ICliSettingsProvider.cs
@@ -6,6 +6,8 @@ namespace Codescene.VSExtension.Core.Interfaces.Cli
     {
         string RequiredDevToolVersion { get; }
 
+        string RequiredCliBinarySha256 { get; }
+
         string ArtifactBaseUrl { get; }
 
         string CliArtifactName { get; }


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpkvr (CS-11173)

## Problem
ProcessExecutor only checked that cs-ide.exe exists before launch. A tampered binary in the extension install folder could run without detection.

## Fix
- Embed expected SHA-256 of the bundled CLI in CliSettingsProvider
- Verify file hash once per path before the first ProcessExecutor launch
- Print SHA-256 from cli.ps1 when downloading CLI to ease version bumps

## Test plan
- [ ] Reinstall extension and confirm CLI commands still work
- [x] make iter passed

Made with [Cursor](https://cursor.com)