### PR TITLE
CS-11172: Use Codescene folder for WebView2 user data

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/WebComponentUserControl.xaml.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/WebComponentUserControl.xaml.cs
@@ -293,7 +293,7 @@ public partial class WebComponentUserControl : UserControl
 
     private async Task<CoreWebView2Environment> CreatePerWindowEnvAsync(string view)
     {
-        var cachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "MyExtensionName", $"WebView2Cache_{view}");
+        var cachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Codescene", $"WebView2Cache_{view}");
         return await CoreWebView2Environment.CreateAsync(userDataFolder: cachePath);
     }
 


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpkr2 (CS-11172)

## Problem
WebView2 user-data lived under %LocalAppData%\MyExtensionName, leftover scaffolding that could collide with other extensions and stored cookies/localStorage outside a CodeScene-namespaced folder.

## Fix
Use %LocalAppData%\Codescene\WebView2Cache_{view} to align with logger and workspace cache paths.

## Test plan
- [ ] Open a web component tool window; confirm WebView2 profile created under %LocalAppData%\Codescene\WebView2Cache_*
- [x] make iter passed