### PR TITLE
CS-11171: Restrict webview file paths to workspace roots

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/WorkspaceFilePathValidatorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/WorkspaceFilePathValidatorTests.cs
@@ -34,6 +34,30 @@ public class WorkspaceFilePathValidatorTests
     }
 
     [TestMethod]
+    public void HasUnsafePathSyntax_Null_ReturnsTrue()
+    {
+        Assert.IsTrue(WorkspaceFilePathValidator.HasUnsafePathSyntax(null));
+    }
+
+    [TestMethod]
+    public void HasUnsafePathSyntax_Whitespace_ReturnsTrue()
+    {
+        Assert.IsTrue(WorkspaceFilePathValidator.HasUnsafePathSyntax("   "));
+    }
+
+    [TestMethod]
+    public void HasUnsafePathSyntax_InvalidPathChar_ReturnsTrue()
+    {
+        Assert.IsTrue(WorkspaceFilePathValidator.HasUnsafePathSyntax("bad\0path.cs"));
+    }
+
+    [TestMethod]
+    public void HasUnsafePathSyntax_Wildcard_ReturnsTrue()
+    {
+        Assert.IsTrue(WorkspaceFilePathValidator.HasUnsafePathSyntax(@"C:\repo\*.cs"));
+    }
+
+    [TestMethod]
     public void HasUnsafePathSyntax_ParentTraversal_ReturnsTrue()
     {
         Assert.IsTrue(WorkspaceFilePathValidator.HasUnsafePathSyntax(@"C:\repo\..\secret.cs"));
@@ -96,5 +120,49 @@ public class WorkspaceFilePathValidatorTests
         Assert.IsTrue(WorkspaceFilePathValidator.IsAllowedWorkspaceFilePath(
             "src" + Path.DirectorySeparatorChar + "file.cs",
             new[] { _workspaceDir }));
+    }
+
+    [TestMethod]
+    public void IsAllowedWorkspaceFilePath_EmptyRootSkipped_RelativePathStillAllowed()
+    {
+        var subDir = Path.Combine(_workspaceDir, "src");
+        Directory.CreateDirectory(subDir);
+        var filePath = Path.Combine(subDir, "file.cs");
+        File.WriteAllText(filePath, "x");
+        Assert.IsTrue(WorkspaceFilePathValidator.IsAllowedWorkspaceFilePath(
+            "src" + Path.DirectorySeparatorChar + "file.cs",
+            new[] { string.Empty, _workspaceDir }));
+    }
+
+    [TestMethod]
+    public void IsAllowedWorkspaceFilePath_UnsafeRelativePath_ReturnsFalse()
+    {
+        Assert.IsFalse(WorkspaceFilePathValidator.IsAllowedWorkspaceFilePath(
+            "bad\0file.cs",
+            new[] { _workspaceDir }));
+    }
+
+    [TestMethod]
+    public void IsAllowedWorkspaceFilePath_InvalidRootPath_ReturnsFalse()
+    {
+        var invalidRoot = _workspaceDir + Path.DirectorySeparatorChar + "a|b";
+        Assert.IsFalse(WorkspaceFilePathValidator.IsAllowedWorkspaceFilePath(
+            "file.cs",
+            new[] { invalidRoot }));
+    }
+
+    [TestMethod]
+    public void IsAllowedWorkspaceFilePath_OnlyEmptyRoots_ReturnsFalse()
+    {
+        Assert.IsFalse(WorkspaceFilePathValidator.IsAllowedWorkspaceFilePath(
+            "file.cs",
+            new[] { string.Empty }));
+    }
+
+    [TestMethod]
+    public void IsAllowedWorkspaceFilePath_EmptyRoots_ReturnsFalse()
+    {
+        var filePath = Path.Combine(_workspaceDir, "file.cs");
+        Assert.IsFalse(WorkspaceFilePathValidator.IsAllowedWorkspaceFilePath(filePath, Array.Empty<string>()));
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/WorkspaceFilePathValidatorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/WorkspaceFilePathValidatorTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.IO;
+using Codescene.VSExtension.Core.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Codescene.VSExtension.Core.Tests;
+
+[TestClass]
+public class WorkspaceFilePathValidatorTests
+{
+    private string _workspaceDir;
+    private string _outsideDir;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ws-path-validator-{Guid.NewGuid()}");
+        _workspaceDir = Path.Combine(tempDir, "workspace");
+        _outsideDir = Path.Combine(tempDir, "outside");
+        Directory.CreateDirectory(_workspaceDir);
+        Directory.CreateDirectory(_outsideDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        var root = Directory.GetParent(_workspaceDir)?.FullName;
+        if (!string.IsNullOrEmpty(root) && Directory.Exists(root))
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [TestMethod]
+    public void HasUnsafePathSyntax_ParentTraversal_ReturnsTrue()
+    {
+        Assert.IsTrue(WorkspaceFilePathValidator.HasUnsafePathSyntax(@"C:\repo\..\secret.cs"));
+    }
+
+    [TestMethod]
+    public void HasUnsafePathSyntax_UncPath_ReturnsTrue()
+    {
+        Assert.IsTrue(WorkspaceFilePathValidator.HasUnsafePathSyntax(@"\\server\share\file.cs"));
+    }
+
+    [TestMethod]
+    public void HasUnsafePathSyntax_ShellMetacharacter_ReturnsTrue()
+    {
+        Assert.IsTrue(WorkspaceFilePathValidator.HasUnsafePathSyntax(@"C:\repo\file|other.cs"));
+    }
+
+    [TestMethod]
+    public void HasUnsafePathSyntax_AlternateDataStream_ReturnsTrue()
+    {
+        Assert.IsTrue(WorkspaceFilePathValidator.HasUnsafePathSyntax(@"C:\repo\file.cs:stream"));
+    }
+
+    [TestMethod]
+    public void HasUnsafePathSyntax_ValidFileName_ReturnsFalse()
+    {
+        Assert.IsFalse(WorkspaceFilePathValidator.HasUnsafePathSyntax(@"C:\repo\file..cs"));
+    }
+
+    [TestMethod]
+    public void IsAllowedWorkspaceFilePath_NullRoots_ReturnsFalse()
+    {
+        var filePath = Path.Combine(_workspaceDir, "file.cs");
+        Assert.IsFalse(WorkspaceFilePathValidator.IsAllowedWorkspaceFilePath(filePath, null));
+    }
+
+    [TestMethod]
+    public void IsAllowedWorkspaceFilePath_PathUnderWorkspace_ReturnsTrue()
+    {
+        var filePath = Path.Combine(_workspaceDir, "file.cs");
+        File.WriteAllText(filePath, "x");
+        Assert.IsTrue(WorkspaceFilePathValidator.IsAllowedWorkspaceFilePath(filePath, new[] { _workspaceDir }));
+    }
+
+    [TestMethod]
+    public void IsAllowedWorkspaceFilePath_PathOutsideWorkspace_ReturnsFalse()
+    {
+        var filePath = Path.Combine(_outsideDir, "file.cs");
+        File.WriteAllText(filePath, "x");
+        Assert.IsFalse(WorkspaceFilePathValidator.IsAllowedWorkspaceFilePath(filePath, new[] { _workspaceDir }));
+    }
+
+    [TestMethod]
+    public void IsAllowedWorkspaceFilePath_RelativePathUnderWorkspace_ReturnsTrue()
+    {
+        var subDir = Path.Combine(_workspaceDir, "src");
+        Directory.CreateDirectory(subDir);
+        var filePath = Path.Combine(subDir, "file.cs");
+        File.WriteAllText(filePath, "x");
+        Assert.IsTrue(WorkspaceFilePathValidator.IsAllowedWorkspaceFilePath(
+            "src" + Path.DirectorySeparatorChar + "file.cs",
+            new[] { _workspaceDir }));
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/WorkspaceFilePathValidator.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/WorkspaceFilePathValidator.cs
@@ -51,7 +51,7 @@ public static class WorkspaceFilePathValidator
 
     public static bool IsAllowedWorkspaceFilePath(string filePath, IReadOnlyCollection<string> workspaceRoots)
     {
-        if (HasUnsafePathSyntax(filePath) || workspaceRoots == null || workspaceRoots.Count == 0)
+        if (!HasWorkspaceRootsForValidation(filePath, workspaceRoots))
         {
             return false;
         }
@@ -61,6 +61,21 @@ public static class WorkspaceFilePathValidator
             return GitPathHelper.IsPathUnderAnyRoot(filePath, workspaceRoots);
         }
 
+        return IsRelativePathUnderAnyRoot(filePath, workspaceRoots);
+    }
+
+    private static bool HasWorkspaceRootsForValidation(string filePath, IReadOnlyCollection<string> workspaceRoots)
+    {
+        if (HasUnsafePathSyntax(filePath))
+        {
+            return false;
+        }
+
+        return workspaceRoots != null && workspaceRoots.Count > 0;
+    }
+
+    private static bool IsRelativePathUnderAnyRoot(string filePath, IReadOnlyCollection<string> workspaceRoots)
+    {
         foreach (var root in workspaceRoots)
         {
             if (string.IsNullOrEmpty(root))
@@ -68,16 +83,19 @@ public static class WorkspaceFilePathValidator
                 continue;
             }
 
+            string absolutePath;
             try
             {
-                var absolutePath = Path.GetFullPath(Path.Combine(root, filePath));
-                if (GitPathHelper.IsPathUnderAnyRoot(absolutePath, workspaceRoots))
-                {
-                    return true;
-                }
+                absolutePath = Path.GetFullPath(Path.Combine(root, filePath));
             }
             catch
             {
+                continue;
+            }
+
+            if (GitPathHelper.IsPathUnderAnyRoot(absolutePath, workspaceRoots))
+            {
+                return true;
             }
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/WorkspaceFilePathValidator.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/WorkspaceFilePathValidator.cs
@@ -1,0 +1,86 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Codescene.VSExtension.Core.Util;
+
+public static class WorkspaceFilePathValidator
+{
+    public static bool HasUnsafePathSyntax(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return true;
+        }
+
+        if (path.StartsWith(@"\\", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (path.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+        {
+            return true;
+        }
+
+        if (path.IndexOfAny(new[] { '|', '>', '<', '*', '?' }) >= 0)
+        {
+            return true;
+        }
+
+        var segments = path.Split(
+            new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+            StringSplitOptions.None);
+        if (segments.Any(segment => segment == ".."))
+        {
+            return true;
+        }
+
+        var root = Path.GetPathRoot(path);
+        var pathWithoutRoot = string.IsNullOrEmpty(root) ? path : path.Substring(root.Length);
+        if (pathWithoutRoot.IndexOf(':') >= 0)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool IsAllowedWorkspaceFilePath(string filePath, IReadOnlyCollection<string> workspaceRoots)
+    {
+        if (HasUnsafePathSyntax(filePath) || workspaceRoots == null || workspaceRoots.Count == 0)
+        {
+            return false;
+        }
+
+        if (Path.IsPathRooted(filePath))
+        {
+            return GitPathHelper.IsPathUnderAnyRoot(filePath, workspaceRoots);
+        }
+
+        foreach (var root in workspaceRoots)
+        {
+            if (string.IsNullOrEmpty(root))
+            {
+                continue;
+            }
+
+            try
+            {
+                var absolutePath = Path.GetFullPath(Path.Combine(root, filePath));
+                if (GitPathHelper.IsPathUnderAnyRoot(absolutePath, workspaceRoots))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        return false;
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022.csproj
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Util\DocumentNavigator.cs" />
     <Compile Include="Util\ExtensionMetadataProvider.cs" />
     <Compile Include="Util\IndentationUtil.cs" />
+    <Compile Include="Util\WorkspacePathResolver.cs" />
     <Compile Include="Util\StyleHelper.cs" />
     <Compile Include="VS2022Package.cs" />
     <Compile Include="source.extension.cs">

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/Handlers/RefactoringChangesApplier.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/Handlers/RefactoringChangesApplier.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Models;
 using Codescene.VSExtension.VS2022.ToolWindows.WebComponent.Models;
 using Codescene.VSExtension.VS2022.Util;
@@ -20,6 +21,13 @@ public class RefactoringChangesApplier
     public async Task ApplyAsync(ApplyPayload payload)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+        if (!await WorkspacePathResolver.IsAllowedWorkspaceFilePathAsync(payload?.FilePath))
+        {
+            var logger = await VS.GetMefServiceAsync<ILogger>();
+            logger?.Warn("Refactoring apply rejected: path is outside the workspace or uses unsafe syntax.");
+            return;
+        }
 
         var newCode = payload.Code;
         var fnStartLine = payload.Fn.Range.StartLine;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Util/DocumentNavigator.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Util/DocumentNavigator.cs
@@ -17,6 +17,12 @@ public static class DocumentNavigator
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
+            if (!await WorkspacePathResolver.IsAllowedWorkspaceFilePathAsync(filePath))
+            {
+                logger.Warn("Unable to open file: path is outside the workspace or uses unsafe syntax.");
+                return;
+            }
+
             var dte = await ServiceProvider.GetGlobalServiceAsync(typeof(DTE)) as DTE2;
             var window = dte?.ItemOperations.OpenFile(filePath);
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Util/WorkspacePathResolver.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Util/WorkspacePathResolver.cs
@@ -1,0 +1,52 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Util;
+using Codescene.VSExtension.VS2022.Application.Git;
+using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Codescene.VSExtension.VS2022.Util;
+
+public static class WorkspacePathResolver
+{
+    public static async Task<IReadOnlyCollection<string>> GetWorkspaceRootsAsync()
+    {
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+        var solution = await VS.Solutions.GetCurrentSolutionAsync();
+        var solutionPath = solution?.FullPath;
+        if (string.IsNullOrEmpty(solutionPath))
+        {
+            return null;
+        }
+
+        var vsSolution = ServiceProvider.GlobalProvider.GetService(typeof(SVsSolution)) as IVsSolution;
+        if (vsSolution == null)
+        {
+            return null;
+        }
+
+        var directories = SolutionProjectDiscovery.GetProjectDirectories(vsSolution, solutionPath);
+        if (directories == null || directories.Count == 0)
+        {
+            return null;
+        }
+
+        return directories.ToList();
+    }
+
+    public static async Task<bool> IsAllowedWorkspaceFilePathAsync(string filePath)
+    {
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return false;
+        }
+
+        var workspaceRoots = await GetWorkspaceRootsAsync();
+        return WorkspaceFilePathValidator.IsAllowedWorkspaceFilePath(filePath, workspaceRoots);
+    }
+}


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpknv (CS-11171)

## Problem
WebView apply/goto handlers opened and rewrote files using unvalidated paths from the webview payload, allowing arbitrary local file access if the bundle were compromised.

## Fix
- Added `WorkspaceFilePathValidator` to reject unsafe path syntax (`..`, UNC, shell metacharacters, alternate data streams) and require paths under solution/project roots.
- `RefactoringChangesApplier` and `DocumentNavigator` now validate paths via `WorkspacePathResolver` before opening or editing files.

## Test plan
- [ ] Apply refactoring in ACE tool window on a solution file (should succeed)
- [ ] Attempt apply/goto with path outside solution (should be blocked; check log)
- [x] `make iter` passed

Made with [Cursor](https://cursor.com)