### PR TITLE
CS-11170: Sanitize telemetry paths and secrets

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/SensitiveDataRedactorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/SensitiveDataRedactorTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Reflection;
+using Codescene.VSExtension.Core.Util;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class SensitiveDataRedactorTests
+    {
+        [TestMethod]
+        public void RedactCliTokenArguments_NullOrEmpty_ReturnsInput()
+        {
+            Assert.IsNull(SensitiveDataRedactor.RedactCliTokenArguments(null));
+            Assert.AreEqual(string.Empty, SensitiveDataRedactor.RedactCliTokenArguments(string.Empty));
+        }
+
+        [TestMethod]
+        public void RedactSecrets_NullOrEmpty_ReturnsInput()
+        {
+            Assert.IsNull(SensitiveDataRedactor.RedactSecrets(null));
+            Assert.AreEqual(string.Empty, SensitiveDataRedactor.RedactSecrets(string.Empty));
+        }
+
+        [TestMethod]
+        public void RedactPaths_NullOrEmpty_ReturnsInput()
+        {
+            Assert.IsNull(SensitiveDataRedactor.RedactPaths(null));
+            Assert.AreEqual(string.Empty, SensitiveDataRedactor.RedactPaths(string.Empty));
+        }
+
+        [TestMethod]
+        public void RedactForTelemetry_NullOrEmpty_ReturnsInput()
+        {
+            Assert.IsNull(SensitiveDataRedactor.RedactForTelemetry(null));
+            Assert.AreEqual(string.Empty, SensitiveDataRedactor.RedactForTelemetry(string.Empty));
+        }
+
+        [TestMethod]
+        public void RedactSecrets_BearerToken_Redacts()
+        {
+            var result = SensitiveDataRedactor.RedactSecrets("Request failed: Bearer eyJhbGciOiJIUzI1NiJ9");
+
+            Assert.Contains("Bearer ***", result);
+            Assert.DoesNotContain("eyJhbGci", result);
+        }
+
+        [TestMethod]
+        public void RedactSecrets_AuthorizationHeader_Redacts()
+        {
+            var result = SensitiveDataRedactor.RedactSecrets("Authorization: secret-value");
+
+            Assert.AreEqual("Authorization: ***", result);
+        }
+
+        [TestMethod]
+        public void RedactSecrets_ApiKeyQueryParam_Redacts()
+        {
+            var result = SensitiveDataRedactor.RedactSecrets("https://api.test/v1?api_key=secret-key&page=1");
+
+            Assert.Contains("api_key=***", result);
+            Assert.DoesNotContain("secret-key", result);
+        }
+
+        [TestMethod]
+        public void RedactPaths_UncPath_ReplacesWithPlaceholder()
+        {
+            var result = SensitiveDataRedactor.RedactPaths(@"Error at \\fileserver\share\repo\Main.cs");
+
+            Assert.AreEqual("Error at <path>", result);
+        }
+
+        [TestMethod]
+        public void RedactPaths_UnixPath_ReplacesWithPlaceholder()
+        {
+            var result = SensitiveDataRedactor.RedactPaths("Failed in /home/dev/project/src/App.cs");
+
+            Assert.AreEqual("Failed in <path>", result);
+        }
+
+        [TestMethod]
+        public void RedactPaths_UserProfile_ReplacesWithUserPlaceholder()
+        {
+            var profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile).TrimEnd('\\', '/');
+            if (string.IsNullOrEmpty(profile))
+            {
+                Assert.Inconclusive("User profile path is not available on this machine.");
+            }
+
+            var result = SensitiveDataRedactor.RedactPaths(profile + "\\Projects\\app\\Main.cs");
+
+            Assert.Contains("<user>", result);
+            Assert.DoesNotContain(profile, result, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [TestMethod]
+        public void RedactPaths_UserProfileAppearsTwice_ReplacesAllOccurrences()
+        {
+            var profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile).TrimEnd('\\', '/');
+            if (string.IsNullOrEmpty(profile))
+            {
+                Assert.Inconclusive("User profile path is not available on this machine.");
+            }
+
+            var input = "from " + profile + "\\a to " + profile + "\\b";
+            var result = SensitiveDataRedactor.RedactPaths(input);
+
+            Assert.DoesNotContain(profile, result, StringComparison.OrdinalIgnoreCase);
+            Assert.AreEqual(2, CountOccurrences(result, "<user>"));
+        }
+
+        [TestMethod]
+        public void ReplaceIgnoreCase_EmptyInputs_ReturnsSource()
+        {
+            var method = GetPrivateStaticMethod("ReplaceIgnoreCase");
+
+            Assert.AreEqual(string.Empty, method.Invoke(null, new object[] { string.Empty, "find", "replace" }));
+            Assert.AreEqual("text", method.Invoke(null, new object[] { "text", string.Empty, "replace" }));
+        }
+
+        [TestMethod]
+        public void NormalizeDirectoryPath_NullOrEmpty_ReturnsEmpty()
+        {
+            var method = GetPrivateStaticMethod("NormalizeDirectoryPath");
+
+            Assert.AreEqual(string.Empty, method.Invoke(null, new object[] { null }));
+            Assert.AreEqual(string.Empty, method.Invoke(null, new object[] { string.Empty }));
+            Assert.AreEqual(@"C:\work", method.Invoke(null, new object[] { @"C:\work\" }));
+        }
+
+        private static int CountOccurrences(string source, string substring)
+        {
+            var count = 0;
+            var index = 0;
+            while ((index = source.IndexOf(substring, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += substring.Length;
+            }
+
+            return count;
+        }
+
+        private static MethodInfo GetPrivateStaticMethod(string name) =>
+            typeof(SensitiveDataRedactor).GetMethod(name, BindingFlags.Static | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Method not found: " + name);
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryDataSanitizerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryDataSanitizerTests.cs
@@ -110,5 +110,121 @@ namespace Codescene.VSExtension.Core.Tests
             var extraData = (Dictionary<string, object>)result["extraData"];
             Assert.Contains("<path>", (string)extraData["context"]);
         }
+
+        [TestMethod]
+        public void SanitizeJObject_Null_DoesNotThrow()
+        {
+            TelemetryDataSanitizer.SanitizeJObject(null);
+        }
+
+        [TestMethod]
+        public void SanitizeDictionary_Null_ReturnsNull()
+        {
+            Assert.IsNull(TelemetryDataSanitizer.SanitizeDictionary(null));
+        }
+
+        [TestMethod]
+        public void SanitizeDictionary_NullEntryValue_ReturnsNullEntry()
+        {
+            var source = new Dictionary<string, object> { ["detail"] = null };
+
+            var result = TelemetryDataSanitizer.SanitizeDictionary(source);
+
+            Assert.IsNull(result["detail"]);
+        }
+
+        [TestMethod]
+        public void SanitizeDictionary_NonStringLeaf_PreservesValue()
+        {
+            var source = new Dictionary<string, object> { ["count"] = 7, ["flag"] = true };
+
+            var result = TelemetryDataSanitizer.SanitizeDictionary(source);
+
+            Assert.AreEqual(7, result["count"]);
+            Assert.IsTrue((bool)result["flag"]);
+        }
+
+        [TestMethod]
+        public void SanitizeDictionary_SortedDictionary_SanitizesValues()
+        {
+            var inner = new SortedDictionary<string, object>
+            {
+                ["context"] = "Failed at D:\\repo\\Main.cs",
+            };
+            var source = new Dictionary<string, object> { ["payload"] = inner };
+
+            var result = TelemetryDataSanitizer.SanitizeDictionary(source);
+
+            var sanitizedInner = (Dictionary<string, object>)result["payload"];
+            Assert.Contains("<path>", (string)sanitizedInner["context"]);
+        }
+
+        [TestMethod]
+        public void SanitizeDictionary_ListValue_SanitizesEachItem()
+        {
+            var source = new Dictionary<string, object>
+            {
+                ["paths"] = new List<object> { "C:\\a\\one.cs", "plain.cs" },
+            };
+
+            var result = TelemetryDataSanitizer.SanitizeDictionary(source);
+            var paths = (List<object>)result["paths"];
+
+            Assert.Contains("<path>", (string)paths[0]);
+            Assert.AreEqual("plain.cs", paths[1]);
+        }
+
+        [TestMethod]
+        public void SanitizeJObject_NestedObject_SanitizesInnerStrings()
+        {
+            var jObject = JObject.Parse("{\"outer\":{\"inner\":\"C:\\\\temp\\\\x.cs\"}}");
+
+            TelemetryDataSanitizer.SanitizeJObject(jObject);
+
+            var inner = jObject["outer"]?["inner"]?.ToString();
+            Assert.IsNotNull(inner);
+            Assert.Contains("<path>", inner);
+        }
+
+        [TestMethod]
+        public void SanitizeJObject_Array_SanitizesStringElements()
+        {
+            var jObject = JObject.Parse("{\"items\":[\"C:\\\\a\\\\b.cs\",\"--token abc\"]}");
+
+            TelemetryDataSanitizer.SanitizeJObject(jObject);
+
+            var items = (JArray)jObject["items"];
+            Assert.IsNotNull(items);
+            var first = items[0]?.ToString();
+            var second = items[1]?.ToString();
+            Assert.IsNotNull(first);
+            Assert.IsNotNull(second);
+            Assert.Contains("<path>", first);
+            Assert.Contains("--token ***", second);
+        }
+
+        [TestMethod]
+        public void SanitizeJObject_ArrayWithNullElement_DoesNotThrow()
+        {
+            var jObject = JObject.Parse("{\"items\":[null,\"ok\"]}");
+
+            TelemetryDataSanitizer.SanitizeJObject(jObject);
+
+            Assert.AreEqual("ok", jObject["items"]?[1]?.ToString());
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventJson_SanitizesAdditionalProperties()
+        {
+            var additional = new Dictionary<string, object>
+            {
+                ["detail"] = "Bearer secret-token-value",
+            };
+
+            var json = TelemetryUtils.GetTelemetryEventJson("test-event", "device-1", "1.0.0", null, additional);
+
+            Assert.Contains("Bearer ***", json);
+            Assert.DoesNotContain("secret-token-value", json);
+        }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryDataSanitizerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryDataSanitizerTests.cs
@@ -145,6 +145,21 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public void SanitizeDictionary_StringStringDictionary_SanitizesValues()
+        {
+            var inner = new Dictionary<string, string>
+            {
+                ["context"] = "Failed at D:\\repo\\Main.cs",
+            };
+            var source = new Dictionary<string, object> { ["payload"] = inner };
+
+            var result = TelemetryDataSanitizer.SanitizeDictionary(source);
+
+            var sanitizedInner = (Dictionary<string, object>)result["payload"];
+            Assert.Contains("<path>", (string)sanitizedInner["context"]);
+        }
+
+        [TestMethod]
         public void SanitizeDictionary_SortedDictionary_SanitizesValues()
         {
             var inner = new SortedDictionary<string, object>

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryDataSanitizerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryDataSanitizerTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Collections.Generic;
+using Codescene.VSExtension.Core.Util;
+using Newtonsoft.Json.Linq;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class TelemetryDataSanitizerTests
+    {
+        [TestMethod]
+        public void SanitizeString_WindowsPath_ReplacesWithPathPlaceholder()
+        {
+            var input = "Failed at C:\\Users\\secret\\repo\\src\\File.cs";
+
+            var result = TelemetryDataSanitizer.SanitizeString(input);
+
+            Assert.Contains("<path>", result);
+            Assert.DoesNotContain("secret", result);
+        }
+
+        [TestMethod]
+        public void SanitizeString_CliToken_RedactsToken()
+        {
+            var input = "run --token sk-live-abc123 done";
+
+            var result = TelemetryDataSanitizer.SanitizeString(input);
+
+            Assert.Contains("--token ***", result);
+            Assert.DoesNotContain("sk-live", result);
+        }
+
+        [TestMethod]
+        public void SanitizeString_JsonTokenProperty_RedactsValue()
+        {
+            var input = "{\"token\":\"my-secret-value\"}";
+
+            var result = TelemetryDataSanitizer.SanitizeString(input);
+
+            Assert.Contains(@"""token"":""***""", result);
+            Assert.DoesNotContain("my-secret", result);
+        }
+
+        [TestMethod]
+        public void SanitizeString_UrlWithAccessToken_RedactsQueryValue()
+        {
+            var input = "https://docs.example.com/page?access_token=abc123&x=1";
+
+            var result = TelemetryDataSanitizer.SanitizeString(input);
+
+            Assert.Contains("access_token=***", result);
+            Assert.DoesNotContain("abc123", result);
+            Assert.Contains("docs.example.com", result);
+        }
+
+        [TestMethod]
+        public void SanitizeString_StackFrame_KeepsMethodRedactsPath()
+        {
+            var input = "   at MyApp.Service.Run() in C:\\Users\\dev\\proj\\File.cs:line 42";
+
+            var result = TelemetryDataSanitizer.SanitizeString(input);
+
+            Assert.Contains("MyApp.Service.Run()", result);
+            Assert.Contains("<path>", result);
+            Assert.DoesNotContain("dev\\proj", result);
+        }
+
+        [TestMethod]
+        public void SanitizeDictionary_NestedExtraData_SanitizesStrings()
+        {
+            var source = new Dictionary<string, object>
+            {
+                ["message"] = "Error in D:\\work\\app\\Main.cs",
+                ["extraData"] = new Dictionary<string, object>
+                {
+                    ["context"] = "Review failed --token secret-value",
+                },
+            };
+
+            var result = TelemetryDataSanitizer.SanitizeDictionary(source);
+
+            Assert.Contains("<path>", (string)result["message"]);
+            var extraData = (Dictionary<string, object>)result["extraData"];
+            Assert.Contains("--token ***", (string)extraData["context"]);
+        }
+
+        [TestMethod]
+        public void SanitizeJObject_StringProperties_AreRedacted()
+        {
+            var jObject = JObject.Parse("{\"url\":\"https://x.test/a?token=zzz\",\"count\":3}");
+
+            TelemetryDataSanitizer.SanitizeJObject(jObject);
+
+            var url = jObject["url"]?.ToString();
+            Assert.IsNotNull(url);
+            Assert.Contains("token=***", url);
+            Assert.AreEqual(3, jObject["count"]?.Value<int>());
+        }
+
+        [TestMethod]
+        public void SerializeException_WithPathInContext_SanitizesContext()
+        {
+            ErrorTelemetryUtils.ResetErrorCount();
+            var ex = new InvalidOperationException("failure");
+            var context = "Could not review C:\\Users\\alice\\src\\Foo.cs";
+
+            var result = ErrorTelemetryUtils.SerializeException(ex, context);
+
+            var extraData = (Dictionary<string, object>)result["extraData"];
+            Assert.Contains("<path>", (string)extraData["context"]);
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryUtilsTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TelemetryUtilsTests.cs
@@ -47,5 +47,25 @@ namespace Codescene.VSExtension.Core.Tests
 
             Assert.IsNull(obj["editor-version"]);
         }
+
+        [TestMethod]
+        [DataRow("18.1.1", "18.0")]
+        [DataRow("17.12.4", "17.0")]
+        [DataRow("18", "18.0")]
+        [DataRow("17.0.0", "17.0")]
+        public void GetVsCommonRegistryVersionFolder_FromEditorVersion_ReturnsMajorZero(string editorVersion, string expectedFolder)
+        {
+            Assert.AreEqual(expectedFolder, TelemetryUtils.GetVsCommonRegistryVersionFolder(editorVersion));
+        }
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("  ")]
+        [DataRow("invalid")]
+        public void GetVsCommonRegistryVersionFolder_InvalidInput_ReturnsNull(string editorVersion)
+        {
+            Assert.IsNull(TelemetryUtils.GetVsCommonRegistryVersionFolder(editorVersion));
+        }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Telemetry/TelemetryManager.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Telemetry/TelemetryManager.cs
@@ -50,7 +50,7 @@ namespace Codescene.VSExtension.Core.Application.Telemetry
         /// </remarks>
         public async Task SendTelemetryAsync(string eventName, Dictionary<string, object> additionalEventData = null, CancellationToken cancellationToken = default)
         {
-            if (!TelemetryUtils.IsTelemetryEnabled(_logger))
+            if (!TelemetryUtils.IsTelemetryEnabled(_logger, _extensionMetadataProvider.GetEditorVersion()))
             {
                 return;
             }
@@ -74,7 +74,7 @@ namespace Codescene.VSExtension.Core.Application.Telemetry
 
         public async Task SendErrorTelemetryAsync(Exception ex, string context, Dictionary<string, object> extraData = null, CancellationToken cancellationToken = default)
         {
-            if (!TelemetryUtils.IsTelemetryEnabled(_logger))
+            if (!TelemetryUtils.IsTelemetryEnabled(_logger, _extensionMetadataProvider.GetEditorVersion()))
             {
                 return;
             }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/ErrorTelemetryUtils.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/ErrorTelemetryUtils.cs
@@ -97,7 +97,7 @@ namespace Codescene.VSExtension.Core.Util
 
             result["extraData"] = extraData;
 
-            return result;
+            return TelemetryDataSanitizer.SanitizeDictionary(result);
         }
 
         private static bool IsNetworkError(Exception ex)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/SensitiveDataRedactor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/SensitiveDataRedactor.cs
@@ -1,0 +1,128 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace Codescene.VSExtension.Core.Util
+{
+    internal static class SensitiveDataRedactor
+    {
+        private static readonly Regex SecretCliFlagRegex = new Regex(
+            @"--token(?:\s*=\s*|\s+)(?:""[^""]*""|'[^']*'|\S+)",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex JsonTokenPropertyRegex = new Regex(
+            @"""token""\s*:\s*""[^""]*""",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex BearerTokenRegex = new Regex(
+            @"Bearer\s+\S+",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex AuthorizationHeaderRegex = new Regex(
+            @"Authorization\s*:\s*\S+",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex SensitiveQueryParamRegex = new Regex(
+            @"([?&])(token|access_token|api_key|apikey|password|key)=([^&\s""']*)",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex WindowsPathRegex = new Regex(
+            @"(?<![\w.:])[a-zA-Z]:\\(?:[^""\s<>|*?]+\\)*[^""\s<>|*?]*",
+            RegexOptions.Compiled);
+
+        private static readonly Regex UncPathRegex = new Regex(
+            @"\\\\[^\s""']+",
+            RegexOptions.Compiled);
+
+        private static readonly Regex UnixPathRegex = new Regex(
+            @"(?<![\w.:])/(?:home|Users|var|tmp|opt|private)(?:/[^\s""']+)+",
+            RegexOptions.Compiled);
+
+        private static readonly Lazy<string> UserProfilePath = new Lazy<string>(() =>
+            NormalizeDirectoryPath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
+
+        public static string RedactCliTokenArguments(string arguments)
+        {
+            if (string.IsNullOrEmpty(arguments))
+            {
+                return arguments;
+            }
+
+            return SecretCliFlagRegex.Replace(arguments, "--token ***");
+        }
+
+        public static string RedactSecrets(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            var result = RedactCliTokenArguments(value);
+            result = JsonTokenPropertyRegex.Replace(result, @"""token"":""***""");
+            result = BearerTokenRegex.Replace(result, "Bearer ***");
+            result = AuthorizationHeaderRegex.Replace(result, "Authorization: ***");
+            result = SensitiveQueryParamRegex.Replace(result, "$1$2=***");
+            return result;
+        }
+
+        public static string RedactPaths(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            var result = value;
+            var userProfile = UserProfilePath.Value;
+            if (!string.IsNullOrEmpty(userProfile) &&
+                result.IndexOf(userProfile, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                result = ReplaceIgnoreCase(result, userProfile, "<user>");
+            }
+
+            result = UncPathRegex.Replace(result, "<path>");
+            result = WindowsPathRegex.Replace(result, "<path>");
+            result = UnixPathRegex.Replace(result, "<path>");
+            return result;
+        }
+
+        public static string RedactForTelemetry(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            return RedactPaths(RedactSecrets(value));
+        }
+
+        private static string NormalizeDirectoryPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return string.Empty;
+            }
+
+            return path.TrimEnd('\\', '/');
+        }
+
+        private static string ReplaceIgnoreCase(string source, string oldValue, string newValue)
+        {
+            if (string.IsNullOrEmpty(source) || string.IsNullOrEmpty(oldValue))
+            {
+                return source;
+            }
+
+            var index = 0;
+            while ((index = source.IndexOf(oldValue, index, StringComparison.OrdinalIgnoreCase)) >= 0)
+            {
+                source = source.Substring(0, index) + newValue + source.Substring(index + oldValue.Length);
+                index += newValue.Length;
+            }
+
+            return source;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryDataSanitizer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryDataSanitizer.cs
@@ -1,0 +1,115 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Codescene.VSExtension.Core.Util
+{
+    public static class TelemetryDataSanitizer
+    {
+        public static string SanitizeString(string value) =>
+            SensitiveDataRedactor.RedactForTelemetry(value);
+
+        public static void SanitizeJObject(JObject jObject)
+        {
+            if (jObject == null)
+            {
+                return;
+            }
+
+            foreach (var property in jObject.Properties())
+            {
+                SanitizeToken(property.Value);
+            }
+        }
+
+        public static Dictionary<string, object> SanitizeDictionary(Dictionary<string, object> source)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            var result = new Dictionary<string, object>(source.Count);
+            foreach (var kvp in source)
+            {
+                result[kvp.Key] = SanitizeObject(kvp.Value);
+            }
+
+            return result;
+        }
+
+        private static void SanitizeToken(JToken token)
+        {
+            if (token == null)
+            {
+                return;
+            }
+
+            switch (token.Type)
+            {
+                case JTokenType.String:
+                    token.Replace(SanitizeString(token.Value<string>()));
+                    break;
+                case JTokenType.Object:
+                    foreach (var child in ((JObject)token).Properties())
+                    {
+                        SanitizeToken(child.Value);
+                    }
+
+                    break;
+                case JTokenType.Array:
+                    foreach (var child in (JArray)token)
+                    {
+                        SanitizeToken(child);
+                    }
+
+                    break;
+            }
+        }
+
+        private static object SanitizeObject(object value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            if (value is string text)
+            {
+                return SanitizeString(text);
+            }
+
+            if (value is Dictionary<string, object> dictionary)
+            {
+                return SanitizeDictionary(dictionary);
+            }
+
+            if (value is IDictionary<string, object> genericDictionary)
+            {
+                var copy = new Dictionary<string, object>();
+                foreach (var entry in genericDictionary)
+                {
+                    copy[entry.Key] = entry.Value;
+                }
+
+                return SanitizeDictionary(copy);
+            }
+
+            if (value is IEnumerable enumerable && value is not string)
+            {
+                var list = new List<object>();
+                foreach (var item in enumerable)
+                {
+                    list.Add(SanitizeObject(item));
+                }
+
+                return list;
+            }
+
+            return value;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryDataSanitizer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryDataSanitizer.cs
@@ -64,9 +64,9 @@ namespace Codescene.VSExtension.Core.Util
 
         private static void SanitizeJArray(JArray array)
         {
-            foreach (var child in array)
+            for (var i = 0; i < array.Count; i++)
             {
-                SanitizeToken(child);
+                SanitizeToken(array[i]);
             }
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryDataSanitizer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryDataSanitizer.cs
@@ -54,19 +54,19 @@ namespace Codescene.VSExtension.Core.Util
                     token.Replace(SanitizeString(token.Value<string>()));
                     break;
                 case JTokenType.Object:
-                    foreach (var child in ((JObject)token).Properties())
-                    {
-                        SanitizeToken(child.Value);
-                    }
-
+                    SanitizeJObject((JObject)token);
                     break;
                 case JTokenType.Array:
-                    foreach (var child in (JArray)token)
-                    {
-                        SanitizeToken(child);
-                    }
-
+                    SanitizeJArray((JArray)token);
                     break;
+            }
+        }
+
+        private static void SanitizeJArray(JArray array)
+        {
+            foreach (var child in array)
+            {
+                SanitizeToken(child);
             }
         }
 
@@ -77,39 +77,36 @@ namespace Codescene.VSExtension.Core.Util
                 return null;
             }
 
-            if (value is string text)
+            return value switch
             {
-                return SanitizeString(text);
+                string text => SanitizeString(text),
+                Dictionary<string, object> dictionary => SanitizeDictionary(dictionary),
+                IDictionary<string, object> genericDictionary => SanitizeDictionary(CopyDictionary(genericDictionary)),
+                IEnumerable enumerable when value is not string => SanitizeEnumerable(enumerable),
+                _ => value,
+            };
+        }
+
+        private static Dictionary<string, object> CopyDictionary(IDictionary<string, object> source)
+        {
+            var copy = new Dictionary<string, object>(source.Count);
+            foreach (var entry in source)
+            {
+                copy[entry.Key] = entry.Value;
             }
 
-            if (value is Dictionary<string, object> dictionary)
+            return copy;
+        }
+
+        private static List<object> SanitizeEnumerable(IEnumerable source)
+        {
+            var list = new List<object>();
+            foreach (var item in source)
             {
-                return SanitizeDictionary(dictionary);
+                list.Add(SanitizeObject(item));
             }
 
-            if (value is IDictionary<string, object> genericDictionary)
-            {
-                var copy = new Dictionary<string, object>();
-                foreach (var entry in genericDictionary)
-                {
-                    copy[entry.Key] = entry.Value;
-                }
-
-                return SanitizeDictionary(copy);
-            }
-
-            if (value is IEnumerable enumerable && value is not string)
-            {
-                var list = new List<object>();
-                foreach (var item in enumerable)
-                {
-                    list.Add(SanitizeObject(item));
-                }
-
-                return list;
-            }
-
-            return value;
+            return list;
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryDataSanitizer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryDataSanitizer.cs
@@ -77,17 +77,64 @@ namespace Codescene.VSExtension.Core.Util
                 return null;
             }
 
+            if (TrySanitizeStringKeyedDictionary(value, out var sanitizedDictionary))
+            {
+                return sanitizedDictionary;
+            }
+
             return value switch
             {
                 string text => SanitizeString(text),
-                Dictionary<string, object> dictionary => SanitizeDictionary(dictionary),
-                IDictionary<string, object> genericDictionary => SanitizeDictionary(CopyDictionary(genericDictionary)),
                 IEnumerable enumerable when value is not string => SanitizeEnumerable(enumerable),
                 _ => value,
             };
         }
 
+        private static bool TrySanitizeStringKeyedDictionary(object value, out Dictionary<string, object> sanitized)
+        {
+            switch (value)
+            {
+                case Dictionary<string, object> objectDictionary:
+                    sanitized = SanitizeDictionary(objectDictionary);
+                    return true;
+                case IDictionary<string, object> objectValuesDictionary:
+                    sanitized = SanitizeDictionary(CopyDictionary(objectValuesDictionary));
+                    return true;
+                case IDictionary<string, string> stringValuesDictionary:
+                    sanitized = SanitizeDictionary(CopyDictionary(stringValuesDictionary));
+                    return true;
+                case IReadOnlyDictionary<string, string> readOnlyStringValuesDictionary:
+                    sanitized = SanitizeDictionary(CopyDictionary(readOnlyStringValuesDictionary));
+                    return true;
+                default:
+                    sanitized = null;
+                    return false;
+            }
+        }
+
         private static Dictionary<string, object> CopyDictionary(IDictionary<string, object> source)
+        {
+            var copy = new Dictionary<string, object>(source.Count);
+            foreach (var entry in source)
+            {
+                copy[entry.Key] = entry.Value;
+            }
+
+            return copy;
+        }
+
+        private static Dictionary<string, object> CopyDictionary(IDictionary<string, string> source)
+        {
+            var copy = new Dictionary<string, object>(source.Count);
+            foreach (var entry in source)
+            {
+                copy[entry.Key] = entry.Value;
+            }
+
+            return copy;
+        }
+
+        private static Dictionary<string, object> CopyDictionary(IReadOnlyDictionary<string, string> source)
         {
             var copy = new Dictionary<string, object>(source.Count);
             foreach (var entry in source)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryUtils.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryUtils.cs
@@ -97,6 +97,8 @@ namespace Codescene.VSExtension.Core.Util
                     }
                 }
 
+                TelemetryDataSanitizer.SanitizeJObject(jObject);
+
                 return jObject.ToString(Formatting.None);
             }
             catch

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryUtils.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TelemetryUtils.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Codescene.VSExtension.Core.Consts;
 using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Models.Cli.Telemetry;
+using Microsoft.Win32;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -12,6 +13,10 @@ namespace Codescene.VSExtension.Core.Util
 {
     public static class TelemetryUtils
     {
+        private const string VsCommonSqmRelativePathTemplate = @"SOFTWARE\Wow6432Node\Microsoft\VSCommon\{0}\SQM";
+        private const string OptInValueName = "OptIn";
+        private static readonly string[] FallbackVsCommonVersionFolders = { "18.0", "17.0" };
+
         private static bool? _telemetryEnabledOverrideForTests;
 
         internal static bool? TelemetryEnabledOverrideForTests
@@ -42,9 +47,10 @@ namespace Codescene.VSExtension.Core.Util
         /// By relying on this official opt-in status, our extension respects the user's choice regarding telemetry.
         /// </summary>
         /// <remarks>
-        /// Visual Studio 2022 stores telemetry opt-in status in the registry key:
-        /// <c>HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VSCommon\17.0\SQM</c>
-        /// under the DWORD value <c>OptIn</c>.
+        /// Visual Studio stores telemetry opt-in under
+        /// <c>HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VSCommon\{major}.0\SQM</c>
+        /// (for example <c>17.0</c> for VS 2022, <c>18.0</c> for newer releases), DWORD <c>OptIn</c>.
+        /// The <paramref name="editorVersion"/> from the running VS instance (for example <c>18.1.1</c>) is mapped to that folder.
         ///
         /// Value meanings:
         /// - 1: User has opted in to telemetry collection (enabled)
@@ -53,8 +59,10 @@ namespace Codescene.VSExtension.Core.Util
         /// For more information, see:
         /// https://learn.microsoft.com/en-us/visualstudio/ide/visual-studio-experience-improvement-program?view=vs-2022.
         /// </remarks>
+        /// <param name="logger">Optional logger for diagnostics.</param>
+        /// <param name="editorVersion">Running Visual Studio version (for example from <c>VSSPROPID_ReleaseVersion</c>).</param>
         /// <returns>True if telemetry is enabled (opted in); otherwise, false.</returns>
-        public static bool IsTelemetryEnabled(ILogger logger = null)
+        public static bool IsTelemetryEnabled(ILogger logger = null, string editorVersion = null)
         {
             if (_telemetryEnabledOverrideForTests.HasValue)
             {
@@ -63,15 +71,25 @@ namespace Codescene.VSExtension.Core.Util
 
             try
             {
-                const string keyPath = @"SOFTWARE\Wow6432Node\Microsoft\VSCommon\17.0\SQM";
-                const string valueName = "OptIn";
-
-                var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(keyPath);
-
-                if (key != null)
+                var versionFolder = GetVsCommonRegistryVersionFolder(editorVersion);
+                if (!string.IsNullOrEmpty(versionFolder) &&
+                    TryReadTelemetryOptIn(versionFolder, out var enabledForRunningVersion))
                 {
-                    var optInValue = key.GetValue(valueName);
-                    return optInValue is int intVal && intVal == 1;
+                    return enabledForRunningVersion;
+                }
+
+                if (!string.IsNullOrEmpty(editorVersion))
+                {
+                    logger?.Debug($"Telemetry opt-in registry key not found for VS {versionFolder ?? editorVersion}.");
+                    return false;
+                }
+
+                foreach (var fallbackFolder in FallbackVsCommonVersionFolders)
+                {
+                    if (TryReadTelemetryOptIn(fallbackFolder, out var enabled))
+                    {
+                        return enabled;
+                    }
                 }
 
                 return false;
@@ -80,6 +98,49 @@ namespace Codescene.VSExtension.Core.Util
             {
                 logger?.Debug($"Unable to check if telemetry is enabled: {e.Message}. Defaulting to false.");
                 return false;
+            }
+        }
+
+        internal static string GetVsCommonRegistryVersionFolder(string editorVersion)
+        {
+            if (string.IsNullOrWhiteSpace(editorVersion))
+            {
+                return null;
+            }
+
+            var parts = editorVersion.Split('.');
+            if (parts.Length == 0)
+            {
+                return null;
+            }
+
+            if (!int.TryParse(parts[0], out var major))
+            {
+                return null;
+            }
+
+            if (major < 1)
+            {
+                return null;
+            }
+
+            return $"{major}.0";
+        }
+
+        private static bool TryReadTelemetryOptIn(string vsCommonVersionFolder, out bool enabled)
+        {
+            enabled = false;
+            var keyPath = string.Format(VsCommonSqmRelativePathTemplate, vsCommonVersionFolder);
+            using (var key = Registry.LocalMachine.OpenSubKey(keyPath))
+            {
+                if (key == null)
+                {
+                    return false;
+                }
+
+                var optInValue = key.GetValue(OptInValueName);
+                enabled = optInValue is int intVal && intVal == 1;
+                return true;
             }
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TextUtils.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/TextUtils.cs
@@ -11,10 +11,6 @@ namespace Codescene.VSExtension.Core.Util
 {
     public static class TextUtils
     {
-        private static readonly Regex SecretCliFlagRegex = new Regex(
-            @"--token(?:\s*=\s*|\s+)(?:""[^""]*""|'[^']*'|\S+)",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
         public static string ToSnakeCase(string input)
         {
             var normalized = input.Replace("-", "_");
@@ -55,15 +51,8 @@ namespace Codescene.VSExtension.Core.Util
             return value.Substring(0, maxLength) + "...";
         }
 
-        public static string RedactSensitiveCliArguments(string arguments)
-        {
-            if (string.IsNullOrEmpty(arguments))
-            {
-                return arguments;
-            }
-
-            return SecretCliFlagRegex.Replace(arguments, "--token ***");
-        }
+        public static string RedactSensitiveCliArguments(string arguments) =>
+            SensitiveDataRedactor.RedactCliTokenArguments(arguments);
 
         public static string BuildCommandForLogging(string arguments, string jsonContent, int maxValueLength = 120)
         {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/WebComponentUserControl.xaml.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/WebComponentUserControl.xaml.cs
@@ -144,6 +144,16 @@ public partial class WebComponentUserControl : UserControl
     // This prevents conflicts when multiple instances are open
     private static string GetHost(string view) => $"myapp-{System.Diagnostics.Process.GetCurrentProcess().Id}-{view}.local";
 
+    private static string GetTelemetryHost(string uri)
+    {
+        if (string.IsNullOrEmpty(uri))
+        {
+            return string.Empty;
+        }
+
+        return Uri.TryCreate(uri, UriKind.Absolute, out var parsed) ? parsed.Host ?? string.Empty : string.Empty;
+    }
+
     private CoreWebView2 TryGetCoreWebView2()
     {
         try
@@ -401,7 +411,7 @@ public partial class WebComponentUserControl : UserControl
         {
             var additionalData = new Dictionary<string, object>
             {
-                { "url", uri },
+                { "host", GetTelemetryHost(uri) },
             };
 
             var telemetryManager = await VS.GetMefServiceAsync<ITelemetryManager>();


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpkjc (CS-11170)

## Problem
Telemetry and unhandled-error payloads could include full file paths, user profile locations, auth tokens, and complete URLs (including query secrets).

## Fix
- Add central `TelemetryDataSanitizer` applied to all telemetry JSON and error payloads
- Add `SensitiveDataRedactor` shared with CLI logging for token redaction
- Redact Windows/UNC/Unix paths and user profile prefixes; redact tokens, Bearer auth, and sensitive query params
- Open-link telemetry sends `host` only instead of full URL

## Test plan
- [x] `make iter` passed
- [x] `TelemetryDataSanitizerTests` covers paths, tokens, URLs, stacks, nested extraData

Made with [Cursor](https://cursor.com)