### PR TITLE
CS-11174: Serialize theme CSS for WebView scripts

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/WebComponentUserControl.xaml.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/WebComponentUserControl.xaml.cs
@@ -237,7 +237,7 @@ public partial class WebComponentUserControl : UserControl
             return;
         }
 
-        var css = GenerateCssVariablesFromTheme().Replace("`", "\\`");
+        var css = JsonConvert.SerializeObject(GenerateCssVariablesFromTheme());
 
         var script = $@"
         (function() {{
@@ -247,7 +247,7 @@ public partial class WebComponentUserControl : UserControl
             }}
             const style = document.createElement('style');
             style.id = '{STYLEELEMENTID}';
-            style.textContent = `{css}`;
+            style.textContent = {css};
             document.head.appendChild(style);
         }})();
         ";
@@ -263,7 +263,7 @@ public partial class WebComponentUserControl : UserControl
         const string template = $@"
         function setContext() {{
             window.ideContext = %ideContext%;
-            const css = `%cssVars%`;
+            const css = %cssVars%;
             function injectStyle() {{
                 const style = document.createElement('style');
                 style.id = '{STYLEELEMENTID}';
@@ -292,11 +292,11 @@ public partial class WebComponentUserControl : UserControl
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
         }
 
-        var cssVars = GenerateCssVariablesFromTheme();
+        var cssVars = JsonConvert.SerializeObject(GenerateCssVariablesFromTheme());
 
         var script = template
            .Replace("%ideContext%", ideContext)
-           .Replace("%cssVars%", cssVars.Replace("`", "\\`"));
+           .Replace("%cssVars%", cssVars);
 
         return script;
     }


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpm0q (CS-11174)

## Problem
Theme CSS was embedded in JavaScript template literals with only backtick escaping. Any ${...} in the CSS would be interpreted as JS interpolation.

## Fix
Serialize theme CSS with JsonConvert.SerializeObject and assign it as a normal JS string in both ApplyThemeToWebViewAsync and GenerateInitialScriptAsync.

## Test plan
- [ ] Open a WebView tool window and confirm theme variables apply on load and after theme change
- [x] make iter passed
