### PR TITLE
CS-11177: Gate Logger console output behind ShowDebugLogs

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/ErrorHandling/Logger.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/ErrorHandling/Logger.cs
@@ -64,32 +64,17 @@ public class Logger : ILogger
         }
     }
 
-    public void Info(string message, bool statusBar = false)
-    {
-        _scheduler.Schedule(ct => WriteLogAsync(message, INFORMATION));
-        Console.WriteLine(message);
-        if (statusBar)
-        {
-            _scheduler.Schedule(ct => SendToStatusBarAsync(message));
-        }
-    }
+    public void Info(string message, bool statusBar = false) =>
+        LogMessage(message, INFORMATION, statusBar);
 
-    public void Warn(string message, bool statusBar = false)
-    {
-        _scheduler.Schedule(ct => WriteLogAsync(message, WARNING));
-        Console.WriteLine(message);
-        if (statusBar)
-        {
-            _scheduler.Schedule(ct => SendToStatusBarAsync(message));
-        }
-    }
+    public void Warn(string message, bool statusBar = false) =>
+        LogMessage(message, WARNING, statusBar);
 
     public void Debug(string message)
     {
-        Console.WriteLine(message);
-
         if (General.Instance.ShowDebugLogs)
         {
+            Console.WriteLine(message);
             _scheduler.Schedule(ct => WriteLogAsync(message, DEBUG));
         }
     }
@@ -97,6 +82,20 @@ public class Logger : ILogger
     private static async Task SendToStatusBarAsync(string message)
     {
         await VS.StatusBar.ShowMessageAsync($"{Titles.CODESCENE}: {message}");
+    }
+
+    private void LogMessage(string message, string level, bool statusBar)
+    {
+        _scheduler.Schedule(ct => WriteLogAsync(message, level));
+        if (General.Instance.ShowDebugLogs)
+        {
+            Console.WriteLine(message);
+        }
+
+        if (statusBar)
+        {
+            _scheduler.Schedule(ct => SendToStatusBarAsync(message));
+        }
     }
 
     private async Task WriteLogAsync(string message, string level)


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpm3g (CS-11177)

## Problem
Console.WriteLine in Logger.Info/Warn/Debug always wrote to stdout even when debug logging was disabled, which can leak messages into CI transcripts and dev-console captures.

## Fix
Route Info/Warn console output through ShowDebugLogs (same gate as Debug file logging). Consolidate Info/Warn shared logic into LogMessage.

## Test plan
- [ ] With ShowDebugLogs off, Info/Warn/Debug do not emit to stdout
- [ ] With ShowDebugLogs on, console and file/debug logging behave as before
- [x] make iter passed

Made with [Cursor](https://cursor.com)