### PR TITLE
CS-11176: Detect extension exceptions by assembly not stack text

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ExtensionExceptionFilterTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ExtensionExceptionFilterTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using System;
+using System.Reflection;
 using Codescene.VSExtension.Core.Util;
 
 namespace Codescene.VSExtension.Core.Tests;
@@ -37,6 +38,15 @@ public class ExtensionExceptionFilterTests
         Assert.IsTrue(ExtensionExceptionFilter.IsFromExtension(ex));
     }
 
+    [TestMethod]
+    public void IsFromExtension_StackTraceWithExtensionFrameWhenTargetSiteUnset_ReturnsTrue()
+    {
+        var ex = CaptureExtensionException();
+        ClearExceptionTargetSite(ex);
+
+        Assert.IsTrue(ExtensionExceptionFilter.IsFromExtension(ex));
+    }
+
     private static Exception CaptureExtensionException()
     {
         try
@@ -51,4 +61,13 @@ public class ExtensionExceptionFilterTests
     }
 
     private static void ThrowFromExtensionCode() => throw new InvalidOperationException("test");
+
+    private static void ClearExceptionTargetSite(Exception ex)
+    {
+        var targetSiteField = typeof(Exception).GetField(
+            "_exceptionMethod",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(targetSiteField);
+        targetSiteField.SetValue(ex, null);
+    }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ExtensionExceptionFilterTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ExtensionExceptionFilterTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using Codescene.VSExtension.Core.Util;
+
+namespace Codescene.VSExtension.Core.Tests;
+
+[TestClass]
+public class ExtensionExceptionFilterTests
+{
+    [TestMethod]
+    public void IsFromExtension_MessageContainingNamespaceWithoutExtensionFrames_ReturnsFalse()
+    {
+        var ex = new Exception("Codescene.VSExtension fake");
+
+        Assert.IsFalse(ExtensionExceptionFilter.IsFromExtension(ex));
+    }
+
+    [TestMethod]
+    public void IsFromExtension_ThrownFromExtensionCode_ReturnsTrue()
+    {
+        try
+        {
+            ThrowFromExtensionCode();
+        }
+        catch (Exception ex)
+        {
+            Assert.IsTrue(ExtensionExceptionFilter.IsFromExtension(ex));
+        }
+    }
+
+    [TestMethod]
+    public void IsFromExtension_WrappedInnerExceptionFromExtension_ReturnsTrue()
+    {
+        var ex = new Exception("wrapper", CaptureExtensionException());
+
+        Assert.IsTrue(ExtensionExceptionFilter.IsFromExtension(ex));
+    }
+
+    private static Exception CaptureExtensionException()
+    {
+        try
+        {
+            ThrowFromExtensionCode();
+            throw new InvalidOperationException("Expected extension exception");
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+    }
+
+    private static void ThrowFromExtensionCode() => throw new InvalidOperationException("test");
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/ExtensionExceptionFilter.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/ExtensionExceptionFilter.cs
@@ -1,0 +1,61 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Diagnostics;
+
+namespace Codescene.VSExtension.Core.Util
+{
+    public static class ExtensionExceptionFilter
+    {
+        private const string ExtensionAssemblyPrefix = "Codescene.VSExtension";
+
+        public static bool IsFromExtension(Exception exception)
+        {
+            for (var current = exception; current != null; current = current.InnerException)
+            {
+                if (ExceptionOriginatesFromExtension(current))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ExceptionOriginatesFromExtension(Exception exception)
+        {
+            if (IsFromExtensionAssembly(exception.TargetSite?.DeclaringType))
+            {
+                return true;
+            }
+
+            return StackTraceContainsExtensionFrame(exception);
+        }
+
+        private static bool StackTraceContainsExtensionFrame(Exception exception)
+        {
+            var stackTrace = new StackTrace(exception, false);
+            for (var i = 0; i < stackTrace.FrameCount; i++)
+            {
+                if (IsFromExtensionAssembly(stackTrace.GetFrame(i)?.GetMethod()?.DeclaringType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsFromExtensionAssembly(Type type)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            var assemblyName = type.Assembly.GetName().Name;
+            return assemblyName != null
+                && assemblyName.StartsWith(ExtensionAssemblyPrefix, StringComparison.Ordinal);
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/VS2022Package.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/VS2022Package.cs
@@ -9,6 +9,7 @@ using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Ace;
 using Codescene.VSExtension.Core.Interfaces.Cli;
 using Codescene.VSExtension.Core.Interfaces.Telemetry;
+using Codescene.VSExtension.Core.Util;
 using Codescene.VSExtension.VS2022.Application.ErrorHandling;
 using Codescene.VSExtension.VS2022.Handlers;
 using Codescene.VSExtension.VS2022.Options;
@@ -225,8 +226,7 @@ public sealed class VS2022Package : ToolkitPackage
     {
         if (e.ExceptionObject is Exception exception)
         {
-            var isFromThisExtension = exception.StackTrace?.Contains("Codescene.VSExtension") == true;
-            if (!isFromThisExtension)
+            if (exception == null || !ExtensionExceptionFilter.IsFromExtension(exception))
             {
                 return;
             }
@@ -237,9 +237,7 @@ public sealed class VS2022Package : ToolkitPackage
 
     private void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
     {
-        var isFromThisExtension = e.Exception?.StackTrace?.Contains("Codescene.VSExtension") == true;
-
-        if (isFromThisExtension)
+        if (ExtensionExceptionFilter.IsFromExtension(e.Exception))
         {
             _logger?.Error("Unobserved task exception", e.Exception);
             e.SetObserved();
@@ -248,9 +246,7 @@ public sealed class VS2022Package : ToolkitPackage
 
     private void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
     {
-        var isFromThisExtension = e.Exception.StackTrace?.Contains("Codescene.VSExtension") == true;
-
-        if (isFromThisExtension)
+        if (e.Exception != null && ExtensionExceptionFilter.IsFromExtension(e.Exception))
         {
             _logger?.Error("Unhandled UI exception", e.Exception);
             e.Handled = true;


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpm1w (CS-11176)

## Problem
Global unhandled-exception handlers decided whether an exception belonged to the extension by checking if the stack trace string contained `Codescene.VSExtension`. That substring match is fragile and can miss real extension faults or misclassify unrelated exceptions.

## Fix
- Added `ExtensionExceptionFilter` that walks the exception chain and inspects stack frames by declaring assembly name prefix instead of raw stack text.
- Wired the three VS package exception handlers to use the filter.
- Added unit tests covering misleading messages, extension throws, and wrapped inner exceptions.

## Test plan
- [ ] `make iter` passed
- [ ] Trigger an unhandled exception in extension code and confirm it appears in the CodeScene output pane

Made with [Cursor](https://cursor.com)