### PR TITLE
CS-11179: Require HTTPS before Process.Start external links

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/TermsAndPolicies/TermsAndPoliciesService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/TermsAndPolicies/TermsAndPoliciesService.cs
@@ -103,11 +103,21 @@ public class TermsAndPoliciesService : IVsInfoBarUIEvents
                 infoBarUIElement.Close();
                 break;
             case CodeSceneConstants.Titles.VIEWTERMS:
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                const string termsUrl = "https://codescene.com/policies";
+                if (Uri.TryCreate(termsUrl, UriKind.Absolute, out var termsUri)
+                    && string.Equals(termsUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
                 {
-                    FileName = "https://codescene.com/policies",
-                    UseShellExecute = true,
-                });
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = termsUrl,
+                        UseShellExecute = true,
+                    });
+                }
+                else
+                {
+                    _logger.Info("Blocked opening Terms & Policies link: URL is not HTTPS.");
+                }
+
                 break;
         }
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/WebComponentUserControl.xaml.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/WebComponentUserControl.xaml.cs
@@ -368,6 +368,14 @@ public partial class WebComponentUserControl : UserControl
 
         if (ExternalNavigationAllowlist.IsAllowedExternalUri(uri))
         {
+            if (!Uri.TryCreate(uri, UriKind.Absolute, out var externalUri)
+                || !string.Equals(externalUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                args.Cancel = true;
+                _logger.Info($"Blocked navigation to non-HTTPS link '{uri}'.");
+                return;
+            }
+
             try
             {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpm80 (CS-11179)

## Problem
Process.Start with UseShellExecute=true in WebComponentUserControl and TermsAndPoliciesService can invoke the default URI-scheme handler on attacker-supplied URLs. Defense-in-depth requires an explicit HTTPS scheme check before launching external links.

## Fix
- WebComponentUserControl.HandleNavigationStarting: verify uri.Scheme is https before Process.Start, even after allowlist check.
- TermsAndPoliciesService.OnActionItemClicked: parse terms URL and require https before Process.Start.

## Test plan
- [ ] External webview links on allowlisted https hosts still open in browser
- [ ] Non-https URIs blocked even if allowlist logic changes
- [x] make iter passed

Made with [Cursor](https://cursor.com)