### PR TITLE
CS-11180: Restrict log directory to owner-only ACLs

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/ErrorHandling/Logger.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/ErrorHandling/Logger.cs
@@ -49,7 +49,7 @@ public class Logger : ILogger
     {
         _outputPaneManager = outputPaneManager ?? throw new ArgumentNullException(nameof(outputPaneManager));
         _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
-        Directory.CreateDirectory(Path.GetDirectoryName(LogFilePath));
+        SecureLogDirectory.EnsureExists(Path.GetDirectoryName(LogFilePath));
     }
 
     public void Error(string message, Exception ex)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/ErrorHandling/SecureLogDirectory.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/ErrorHandling/SecureLogDirectory.cs
@@ -1,0 +1,66 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.IO;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace Codescene.VSExtension.VS2022.Application.ErrorHandling;
+
+internal static class SecureLogDirectory
+{
+    internal static void EnsureExists(string directoryPath)
+    {
+        if (string.IsNullOrEmpty(directoryPath))
+        {
+            return;
+        }
+
+        if (Directory.Exists(directoryPath))
+        {
+            TryApplyOwnerOnlyAccess(directoryPath);
+            return;
+        }
+
+        var ownerSid = WindowsIdentity.GetCurrent().User;
+        if (ownerSid == null)
+        {
+            Directory.CreateDirectory(directoryPath);
+            return;
+        }
+
+        var security = CreateOwnerOnlyDirectorySecurity(ownerSid);
+        Directory.CreateDirectory(directoryPath, security);
+    }
+
+    private static DirectorySecurity CreateOwnerOnlyDirectorySecurity(SecurityIdentifier ownerSid)
+    {
+        var security = new DirectorySecurity();
+        security.SetAccessRuleProtection(true, false);
+        security.AddAccessRule(new FileSystemAccessRule(
+            ownerSid,
+            FileSystemRights.FullControl,
+            InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+            PropagationFlags.None,
+            AccessControlType.Allow));
+        return security;
+    }
+
+    private static void TryApplyOwnerOnlyAccess(string directoryPath)
+    {
+        try
+        {
+            var ownerSid = WindowsIdentity.GetCurrent().User;
+            if (ownerSid == null)
+            {
+                return;
+            }
+
+            var directoryInfo = new DirectoryInfo(directoryPath);
+            directoryInfo.SetAccessControl(CreateOwnerOnlyDirectorySecurity(ownerSid));
+        }
+        catch (Exception)
+        {
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022.csproj
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022.csproj
@@ -64,6 +64,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Application\ErrorHandling\Logger.cs" />
+    <Compile Include="Application\ErrorHandling\SecureLogDirectory.cs" />
     <Compile Include="Application\ErrorHandling\OutputPaneManager.cs" />
     <Compile Include="Application\ErrorListWindowHandler\ErrorListWindowHandler.cs" />
     <Compile Include="Application\ErrorListWindowHandler\HierarchyHelper.cs" />


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpm9w (CS-11180)

## Problem
Log directory under %LocalAppData% was created with default ACLs; tokens may appear in log files.

## Fix
Create and tighten the Codescene log folder with owner-only DirectorySecurity (no inherited access for other principals).

## Test plan
- [ ] Confirm %LocalAppData%\\Codescene exists after extension load and only current user has access
- [x] make iter passed

Made with [Cursor](https://cursor.com)