### PR TITLE
CS-11178: Remove webview SHOWLOGOUTPUT handler

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Consts/WebComponentConstants.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Consts/WebComponentConstants.cs
@@ -41,7 +41,6 @@ namespace Codescene.VSExtension.Core.Consts
             public const string CLOSE = "close";
             public const string GOTOFUNCTIONLOCATION = "goto-function-location";
             public const string COPYCODE = "copyCode";
-            public const string SHOWLOGOUTPUT = "showLogoutput";
             public const string SHOWDIFF = "showDiff";
             public const string REQUESTANDPRESENTREFACTORING = "request-and-present-refactoring";
             public const string UPDATERENDERER = "update-renderer";

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/Handlers/WebComponentMessageHandler.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/ToolWindows/WebComponent/Handlers/WebComponentMessageHandler.cs
@@ -11,7 +11,6 @@ using Codescene.VSExtension.Core.Interfaces.Telemetry;
 using Codescene.VSExtension.Core.Models;
 using Codescene.VSExtension.Core.Models.WebComponent.Model;
 using Codescene.VSExtension.Core.Util;
-using Codescene.VSExtension.VS2022.Application.ErrorHandling;
 using Codescene.VSExtension.VS2022.Application.Services;
 using Codescene.VSExtension.VS2022.Options;
 using Codescene.VSExtension.VS2022.ToolWindows.WebComponent.Models;
@@ -126,9 +125,6 @@ internal class WebComponentMessageHandler
 
                 case MessageTypes.REQUESTANDPRESENTREFACTORING:
                     await HandleRequestAndPresentRefactoringAsync(msgObject, logger);
-                    break;
-                case MessageTypes.SHOWLOGOUTPUT:
-                    await HandleOpenLogOutputAsync();
                     break;
                 default:
                     logger.Debug($"Unknown message type: {msgObject.MessageType}");
@@ -353,12 +349,6 @@ internal class WebComponentMessageHandler
             payload.FilePath,
             payload.FnToRefactor,
             AceConstants.AceEntryPoint.ACEACKNOWLEDGEMENT);
-    }
-
-    private async Task HandleOpenLogOutputAsync()
-    {
-        var outputPaneManager = await VS.GetMefServiceAsync<OutputPaneManager>();
-        await outputPaneManager.ShowAsync();
     }
 
     private void SendTelemetry(string eventName, Dictionary<string, object> additionalData = null)


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpm6p (CS-11178)

## Problem
A compromised webview could send a SHOWLOGOUTPUT message and force the CodeScene output pane open, surfacing log contents that may include sensitive data.

## Fix
Remove the SHOWLOGOUTPUT webview message type and handler so the output pane can only be shown by the extension host (menus, commands, logger), not from webview postMessage.

## Test plan
- [ ] Confirm webview flows (ACE, docs, acknowledge) still work; no UI depends on opening logs from the web bundle
- [ ] `make iter` passed