### PR TITLE
CS-11175: Store previous auth token in zeroed byte buffer

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/SecretBufferTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/SecretBufferTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using Codescene.VSExtension.Core.Application.Security;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Codescene.VSExtension.Core.Tests;
+
+[TestClass]
+public class SecretBufferTests
+{
+    [TestMethod]
+    public void Equals_EmptyAndNull_AreEqual()
+    {
+        Assert.IsTrue(SecretBuffer.Equals(null, string.Empty));
+        Assert.IsTrue(SecretBuffer.Equals(null, null!));
+    }
+
+    [TestMethod]
+    public void Equals_SameValue_ReturnsTrue()
+    {
+        var stored = SecretBuffer.FromString("token-a");
+        Assert.IsTrue(SecretBuffer.Equals(stored, "token-a"));
+        SecretBuffer.Clear(ref stored);
+    }
+
+    [TestMethod]
+    public void Equals_DifferentValue_ReturnsFalse()
+    {
+        var stored = SecretBuffer.FromString("token-a");
+        Assert.IsFalse(SecretBuffer.Equals(stored, "token-b"));
+        SecretBuffer.Clear(ref stored);
+    }
+
+    [TestMethod]
+    public void Replace_ClearsPreviousBuffer()
+    {
+        byte[] stored = SecretBuffer.FromString("old");
+        var previousReference = stored;
+        SecretBuffer.Replace(ref stored, "new");
+        Assert.AreNotSame(previousReference, stored);
+        Assert.IsTrue(SecretBuffer.Equals(stored, "new"));
+        SecretBuffer.Clear(ref stored);
+        foreach (var b in previousReference)
+        {
+            Assert.AreEqual(0, b);
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/SecretBufferTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/SecretBufferTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) CodeScene. All rights reserved.
 
+using System;
 using Codescene.VSExtension.Core.Application.Security;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -29,6 +30,34 @@ public class SecretBufferTests
         var stored = SecretBuffer.FromString("token-a");
         Assert.IsFalse(SecretBuffer.Equals(stored, "token-b"));
         SecretBuffer.Clear(ref stored);
+    }
+
+    [TestMethod]
+    public void Equals_NonEmptyLeft_EmptyRight_ReturnsFalse()
+    {
+        var stored = SecretBuffer.FromString("token");
+        Assert.IsFalse(SecretBuffer.Equals(stored, string.Empty));
+        SecretBuffer.Clear(ref stored);
+    }
+
+    [TestMethod]
+    public void Equals_DifferentLengths_ReturnsFalse()
+    {
+        var stored = SecretBuffer.FromString("ab");
+        Assert.IsFalse(SecretBuffer.Equals(stored, "abc"));
+        SecretBuffer.Clear(ref stored);
+    }
+
+    [TestMethod]
+    public void Clear_NullOrEmpty_SetsNull()
+    {
+        byte[] buffer = null;
+        SecretBuffer.Clear(ref buffer);
+        Assert.IsNull(buffer);
+
+        buffer = Array.Empty<byte>();
+        SecretBuffer.Clear(ref buffer);
+        Assert.IsNull(buffer);
     }
 
     [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Security/SecretBuffer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Security/SecretBuffer.cs
@@ -53,25 +53,15 @@ internal static class SecretBuffer
 
     private static bool ConstantTimeEquals(byte[] a, byte[] b)
     {
-        if (a == null || a.Length == 0)
+        var aLength = a?.Length ?? 0;
+        var bLength = b?.Length ?? 0;
+        var diff = aLength ^ bLength;
+        var maxLength = Math.Max(aLength, bLength);
+        for (var i = 0; i < maxLength; i++)
         {
-            return b == null || b.Length == 0;
-        }
-
-        if (b == null || b.Length == 0)
-        {
-            return false;
-        }
-
-        if (a.Length != b.Length)
-        {
-            return false;
-        }
-
-        var diff = 0;
-        for (var i = 0; i < a.Length; i++)
-        {
-            diff |= a[i] ^ b[i];
+            var aByte = i < aLength ? a[i] : (byte)0;
+            var bByte = i < bLength ? b[i] : (byte)0;
+            diff |= aByte ^ bByte;
         }
 
         return diff == 0;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Security/SecretBuffer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Security/SecretBuffer.cs
@@ -1,0 +1,79 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Text;
+
+namespace Codescene.VSExtension.Core.Application.Security;
+
+internal static class SecretBuffer
+{
+    public static byte[] FromString(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return Array.Empty<byte>();
+        }
+
+        return Encoding.UTF8.GetBytes(value);
+    }
+
+    public static void Clear(ref byte[] buffer)
+    {
+        if (buffer == null || buffer.Length == 0)
+        {
+            buffer = null;
+            return;
+        }
+
+        Array.Clear(buffer, 0, buffer.Length);
+        buffer = null;
+    }
+
+    public static void Replace(ref byte[] current, string newValue)
+    {
+        Clear(ref current);
+        current = FromString(newValue);
+    }
+
+    public static bool Equals(byte[] left, string right)
+    {
+        var rightBytes = FromString(right);
+        try
+        {
+            return ConstantTimeEquals(left, rightBytes);
+        }
+        finally
+        {
+            if (rightBytes.Length > 0)
+            {
+                Array.Clear(rightBytes, 0, rightBytes.Length);
+            }
+        }
+    }
+
+    private static bool ConstantTimeEquals(byte[] a, byte[] b)
+    {
+        if (a == null || a.Length == 0)
+        {
+            return b == null || b.Length == 0;
+        }
+
+        if (b == null || b.Length == 0)
+        {
+            return false;
+        }
+
+        if (a.Length != b.Length)
+        {
+            return false;
+        }
+
+        var diff = 0;
+        for (var i = 0; i < a.Length; i++)
+        {
+            diff |= a[i] ^ b[i];
+        }
+
+        return diff == 0;
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Options/General.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Options/General.cs
@@ -22,16 +22,14 @@ internal class OptionsProvider
 
 public class General : BaseOptionModel<General>
 {
-    // Track previous values to detect changes
-    private string _previousAuthToken;
+    private byte[] _previousAuthToken;
     private bool _previousShowDebugLogs;
 
     public General()
     {
         Load();
 
-        // Store initial values
-        _previousAuthToken = AuthToken;
+        _previousAuthToken = SecretBuffer.FromString(AuthToken);
         _previousShowDebugLogs = ShowDebugLogs;
 
         Saved += OnSettingsSaved;
@@ -92,9 +90,9 @@ public class General : BaseOptionModel<General>
         SettingsSaved?.Invoke(this, EventArgs.Empty);
 
         // Check for specific setting changes and fire targeted events
-        if (_previousAuthToken != AuthToken)
+        if (!SecretBuffer.Equals(_previousAuthToken, AuthToken))
         {
-            _previousAuthToken = AuthToken;
+            SecretBuffer.Replace(ref _previousAuthToken, AuthToken);
             AuthTokenChanged?.Invoke(this, EventArgs.Empty);
         }
 


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpm51 (CS-11175)

## Problem
OnSettingsSaved compared the previous auth token with plain string equality and kept the prior value as a long-lived string on the General singleton.

## Fix
Track the previous token as a UTF-8 byte buffer via SecretBuffer, compare with constant-time equality, and zero buffers on replace. AuthToken remains a string for the VS options UI.

## Test plan
- [ ] Save options with unchanged auth token — no spurious AuthTokenChanged
- [ ] Change auth token and save — AuthTokenChanged fires once
- [x] `make iter` passed

Made with [Cursor](https://cursor.com)