### PR TITLE
CS-11349: Marshal SavedFilesTracker start to UI thread

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/SavedFilesTracker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/SavedFilesTracker.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using Codescene.VSExtension.Core.Application.Git;
 using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Git;
+using Microsoft.VisualStudio.Shell;
 
 namespace Codescene.VSExtension.VS2022.Application.Git
 {
@@ -81,7 +82,11 @@ namespace Codescene.VSExtension.VS2022.Application.Git
                 }
 
                 _core = new SavedFilesTrackerCore(_eventSource, _openFilesObserver, _logger);
-                _core.Start();
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    _core.Start();
+                });
             }
         }
     }


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9yz5fk (CS-11349)

## Problem
GitChangeLister calls SavedFilesTracker from a background thread. Lazy init invoked VsDocumentSaveEventSource.Start() off the UI thread, causing COMException: Start must be called on the UI thread.

## Fix
EnsureInitialized() marshals _core.Start() to the main thread via JoinableTaskFactory, matching VsOpenFilesSource.

## Test plan
- [ ] Open solution with git repo; confirm no GitChangeLister COMException in logs/telemetry
- [x] make iter passed

Made with [Cursor](https://cursor.com)