### PR TITLE
CS-11351: Harden margin update on window focus

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Handlers/OnActiveWindowChangeHandler.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Handlers/OnActiveWindowChangeHandler.cs
@@ -44,42 +44,55 @@ public class OnActiveWindowChangeHandler
     {
         ThreadHelper.ThrowIfNotOnUIThread();
 
-        if (focused?.Kind == DocumentKind)
+        if (focused?.Kind != DocumentKind)
         {
-            var doc = focused.Document;
-            if (doc == null)
-            {
-                _marginSettings.HideMargin();
-                return;
-            }
+            _marginSettings.HideMargin();
+            return;
+        }
 
-            string path;
-            try
-            {
-                path = doc.FullName;
-            }
-            catch (Exception ex) when (ex is COMException or FileNotFoundException)
-            {
-                _marginSettings.HideMargin();
-                return;
-            }
+        Document doc;
+        try
+        {
+            doc = focused.Document;
+        }
+        catch (Exception ex) when (ex is NullReferenceException or COMException or FileNotFoundException)
+        {
+            _marginSettings.HideMargin();
+            return;
+        }
 
-            var isSupportedFile = _supportedFileChecker.IsSupported(path);
+        if (doc == null)
+        {
+            _marginSettings.HideMargin();
+            return;
+        }
 
-            var isTextDocument = false;
-            try
-            {
-                isTextDocument = doc.Object("TextDocument") is TextDocument;
-            }
-            catch (Exception ex) when (ex is COMException or FileNotFoundException)
-            {
-            }
+        string path;
+        try
+        {
+            path = doc.FullName;
+        }
+        catch (Exception ex) when (ex is NullReferenceException or COMException or FileNotFoundException)
+        {
+            _marginSettings.HideMargin();
+            return;
+        }
 
-            if (isSupportedFile && isTextDocument)
-            {
-                _marginSettings.NotifyScoreUpdated();
-                return;
-            }
+        var isSupportedFile = _supportedFileChecker.IsSupported(path);
+
+        var isTextDocument = false;
+        try
+        {
+            isTextDocument = doc.Object("TextDocument") is TextDocument;
+        }
+        catch (Exception ex) when (ex is NullReferenceException or COMException or FileNotFoundException)
+        {
+        }
+
+        if (isSupportedFile && isTextDocument)
+        {
+            _marginSettings.NotifyScoreUpdated();
+            return;
         }
 
         _marginSettings.HideMargin();


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9yz990 (CS-11351)

## Problem
Amplitude reported recurring NullReferenceException in OnActiveWindowChangeHandler when updating the editor margin on file re-focus (e.g. accessing Document/FullName while DTE returns null or throws from interop).

## Fix
- Guard non-document windows with early HideMargin return
- Wrap focused.Document, FullName, and TextDocument access in try/catch for NullReferenceException and existing COM/FileNotFound cases
- Avoid calling focused.Document.FullName twice (null doc no longer reaches FullName)

## Test plan
- [ ] Switch between document windows and non-document tool windows; margin hides without errors
- [ ] make iter passed