### PR TITLE
fix: hide ACE ad in code smell docs when no auth token

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CodeSmellDocumentationMapperTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CodeSmellDocumentationMapperTests.cs
@@ -213,6 +213,26 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public void Map_AceAcknowledgedFalse_NoAuthToken_SetsActivatedTrue()
+        {
+            SetupAuthToken(string.Empty);
+
+            var result = _mapper.Map(CreateModel(), CreateFnToRefactor(), aceAcknowledged: false);
+
+            Assert.IsTrue(result.AutoRefactor.Activated);
+        }
+
+        [TestMethod]
+        public void Map_AceAcknowledgedFalse_WhitespaceAuthToken_SetsActivatedTrue()
+        {
+            SetupAuthToken("   ");
+
+            var result = _mapper.Map(CreateModel(), CreateFnToRefactor(), aceAcknowledged: false);
+
+            Assert.IsTrue(result.AutoRefactor.Activated);
+        }
+
+        [TestMethod]
         public void Map_AutoRefactorVisibleAlwaysTrue()
         {
             var result = _mapper.Map(CreateModel(), CreateFnToRefactor());

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Mappers/CodeSmellDocumentationMapper.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Mappers/CodeSmellDocumentationMapper.cs
@@ -37,7 +37,7 @@ namespace Codescene.VSExtension.Core.Application.Mappers
                 AutoRefactor = new AutoRefactorConfig
                 {
                     Visible = true,
-                    Activated = aceAcknowledged,
+                    Activated = AutoRefactorConfigUtils.ComputeActivated(aceAcknowledged, hasToken),
                     Disabled = !hasToken || fnToRefactor == null,
                 },
                 FileData = new FileDataModel

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/AutoRefactorConfigUtils.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/AutoRefactorConfigUtils.cs
@@ -1,0 +1,10 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+namespace Codescene.VSExtension.Core.Util
+{
+    public static class AutoRefactorConfigUtils
+    {
+        public static bool ComputeActivated(bool aceAcknowledged, bool hasToken) =>
+            !(!aceAcknowledged && hasToken);
+    }
+}


### PR DESCRIPTION
## Summary
- Hide ACE activation promo in code smell documentation unless an auth token is configured and ACE has not been acknowledged
- Port JetBrains PR https://github.com/codescene-oss/codescene-jetbrains/pull/153 logic via `AutoRefactorConfigUtils.ComputeActivated`
- Add unit tests for no-token and whitespace-token cases

Closes CS-11347

## Test plan
- [x] `make iter` (21 tests passed)
- [ ] Fresh install / no auth token → open refactorable code smell docs → no ACE ad
- [ ] Set auth token, reset `AceAcknowledged` in `HKCU\Software\Codescene\VSExtension` → open docs → ACE ad shown
- [ ] Acknowledge ACE → reopen docs → no ad

Made with [Cursor](https://cursor.com)