### PR TITLE
fix: use configured baseline exclusively for merge-base resolution

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorChangedFilesTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorChangedFilesTests.cs
@@ -26,6 +26,28 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public async Task GetChangedFilesVsBaselineAsync_RepeatedNoMergeBaseState_LogsOnce()
+        {
+            using (var repo = new Repository(_testRepoPath))
+            {
+                repo.Refs.Add("refs/remotes/origin/main", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
+            }
+
+            _fakeLogger.ClearDebugMessages();
+
+            await _detector.GetChangedFilesVsBaselineAsync(
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+            await _detector.GetChangedFilesVsBaselineAsync(
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+
+            var noMergeBaseLogs = _fakeLogger.SnapshotDebugMessages()
+                .Count(m => m.Contains("No merge base commit found, using working directory changes only"));
+
+            Assert.AreEqual(1, noMergeBaseLogs, "Should log no merge base state only once until repo state changes");
+        }
+
+        [TestMethod]
         public async Task GetChangedFilesVsBaselineAsync_FindsMergeBaseWithMainBranch()
         {
             using (var repo = new Repository(_testRepoPath))

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorChangedFilesTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorChangedFilesTests.cs
@@ -28,11 +28,25 @@ namespace Codescene.VSExtension.Core.Tests
         [TestMethod]
         public async Task GetChangedFilesVsBaselineAsync_RepeatedNoMergeBaseState_LogsOnce()
         {
+            string originalBranch;
             using (var repo = new Repository(_testRepoPath))
             {
-                repo.Refs.Add("refs/remotes/origin/main", repo.Head.Tip.Id);
+                originalBranch = repo.Head.FriendlyName;
+            }
+
+            ExecGit("checkout --orphan unrelated-main");
+            var unrelatedReadme = Path.Combine(_testRepoPath, "unrelated.md");
+            File.WriteAllText(unrelatedReadme, "# Unrelated");
+            using (var repo = new Repository(_testRepoPath))
+            {
+                LibGit2Sharp.Commands.Stage(repo, "unrelated.md");
+                var signature = new Signature("Test User", "test@example.com", DateTimeOffset.Now);
+                var unrelatedCommitId = repo.Commit("Unrelated commit", signature, signature).Id;
+                repo.Refs.Add("refs/remotes/origin/main", unrelatedCommitId);
                 repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
             }
+
+            ExecGit($"checkout {originalBranch}");
 
             _fakeLogger.ClearDebugMessages();
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorChangedFilesTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorChangedFilesTests.cs
@@ -62,6 +62,47 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public async Task ClearMainBranchCandidatesCache_ClearsNoMergeBaseLogThrottle()
+        {
+            string originalBranch;
+            using (var repo = new Repository(_testRepoPath))
+            {
+                originalBranch = repo.Head.FriendlyName;
+            }
+
+            ExecGit("checkout --orphan unrelated-main");
+            var unrelatedReadme = Path.Combine(_testRepoPath, "unrelated.md");
+            File.WriteAllText(unrelatedReadme, "# Unrelated");
+            using (var repo = new Repository(_testRepoPath))
+            {
+                LibGit2Sharp.Commands.Stage(repo, "unrelated.md");
+                var signature = new Signature("Test User", "test@example.com", DateTimeOffset.Now);
+                var unrelatedCommitId = repo.Commit("Unrelated commit", signature, signature).Id;
+                repo.Refs.Add("refs/remotes/origin/main", unrelatedCommitId);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
+            }
+
+            ExecGit($"checkout {originalBranch}");
+
+            _fakeLogger.ClearDebugMessages();
+
+            await _detector.GetChangedFilesVsBaselineAsync(
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+            await _detector.GetChangedFilesVsBaselineAsync(
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+
+            _detector.ClearMainBranchCandidatesCache();
+
+            await _detector.GetChangedFilesVsBaselineAsync(
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+
+            var noMergeBaseLogs = _fakeLogger.SnapshotDebugMessages()
+                .Count(m => m.Contains("No merge base commit found, using working directory changes only"));
+
+            Assert.AreEqual(2, noMergeBaseLogs, "Clearing candidate cache should reset no-merge-base log throttle");
+        }
+
+        [TestMethod]
         public async Task GetChangedFilesVsBaselineAsync_FindsMergeBaseWithMainBranch()
         {
             using (var repo = new Repository(_testRepoPath))

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorTestBase.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorTestBase.cs
@@ -364,11 +364,11 @@ namespace Codescene.VSExtension.Core.Tests
                 return candidates;
             }
 
-            protected override Commit? GetMergeBaseCommit(Repository repo)
+            protected override (Commit? baseCommit, IReadOnlyList<string>? noMergeBaseCandidates) GetMergeBaseCommit(Repository repo)
             {
                 if (SimulateInvalidCurrentBranch)
                 {
-                    return null;
+                    return (null, null);
                 }
 
                 if (ThrowInGetMergeBaseCommit)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
@@ -280,6 +280,40 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public async Task GetChangedFilesVsMergeBaseAsync_RepeatedNoMergeBaseState_LogsWarnOnce()
+        {
+            CommitFile("README.md", "# Master", "Initial on master");
+            ExecGit("branch -m master");
+            CommitFile("master-only.cs", "class M {}", "Master commit");
+
+            ExecGit("checkout --orphan main");
+            var mainFile = Path.Combine(_testRepoPath, "main.md");
+            File.WriteAllText(mainFile, "# Main");
+            using (var repo = new Repository(_testRepoPath))
+            {
+                Commands.Stage(repo, "main.md");
+                var signature = new Signature("Test User", "test@example.com", DateTimeOffset.Now);
+                repo.Commit("Initial on main", signature, signature);
+                repo.Refs.Add("refs/remotes/origin/main", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
+            }
+
+            ExecGit("checkout master");
+            ExecGit("checkout -b feature-branch");
+            CommitFile("feature.cs", "class Feature {}", "Add feature");
+
+            _fakeLogger.ClearWarnMessages();
+
+            await _lister.GetChangedFilesVsMergeBaseAsync(_testRepoPath, _testRepoPath);
+            await _lister.GetChangedFilesVsMergeBaseAsync(_testRepoPath, _testRepoPath);
+
+            var warnCount = _fakeLogger.SnapshotWarnMessages()
+                .Count(m => m.Contains("can't determine merge-base"));
+
+            Assert.AreEqual(1, warnCount, "Should warn about missing merge base only once until repo state changes");
+        }
+
+        [TestMethod]
         public void Initialize_SetsGitRootAndWorkspacePath()
         {
             _lister.Initialize(_testRepoPath, new[] { _testRepoPath });

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
@@ -314,6 +314,67 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public async Task GetChangedFilesVsMergeBaseAsync_ClearsWarnStateWhenMergeBaseFound()
+        {
+            CommitFile("README.md", "# Master", "Initial on master");
+            ExecGit("branch -m master");
+            CommitFile("master-only.cs", "class M {}", "Master commit");
+
+            ExecGit("checkout --orphan main");
+            var mainFile = Path.Combine(_testRepoPath, "main.md");
+            File.WriteAllText(mainFile, "# Main");
+            using (var repo = new Repository(_testRepoPath))
+            {
+                Commands.Stage(repo, "main.md");
+                var signature = new Signature("Test User", "test@example.com", DateTimeOffset.Now);
+                repo.Commit("Initial on main", signature, signature);
+                repo.Refs.Add("refs/remotes/origin/main", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
+            }
+
+            ExecGit("checkout master");
+            ExecGit("checkout -b feature-branch");
+            CommitFile("feature.cs", "class Feature {}", "Add feature");
+
+            _fakeLogger.ClearWarnMessages();
+            await _lister.GetChangedFilesVsMergeBaseAsync(_testRepoPath, _testRepoPath);
+            Assert.HasCount(1, _fakeLogger.SnapshotWarnMessages(), "Should warn when default baseline has no merge base");
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                repo.Refs.Remove("refs/remotes/origin/HEAD");
+            }
+
+            _fakeLogger.ClearWarnMessages();
+            var withFallbackMergeBase = await _lister.GetChangedFilesVsMergeBaseAsync(_testRepoPath, _testRepoPath);
+            Assert.IsNotEmpty(withFallbackMergeBase, "Should find merge base via fallback when origin/HEAD is unset");
+            Assert.IsEmpty(_fakeLogger.SnapshotWarnMessages(), "Should not warn when merge base is found");
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
+            }
+
+            _fakeLogger.ClearWarnMessages();
+            await _lister.GetChangedFilesVsMergeBaseAsync(_testRepoPath, _testRepoPath);
+            await _lister.GetChangedFilesVsMergeBaseAsync(_testRepoPath, _testRepoPath);
+            Assert.HasCount(1, _fakeLogger.SnapshotWarnMessages(), "Warn throttle should reset after a successful merge-base lookup");
+        }
+
+        [TestMethod]
+        public async Task GetChangedFilesVsMergeBaseAsync_WithUnbornFeatureHead_DoesNotWarn()
+        {
+            ExecGit("checkout --orphan feature-unborn");
+
+            _fakeLogger.ClearWarnMessages();
+            await _lister.GetChangedFilesVsMergeBaseAsync(_testRepoPath, _testRepoPath);
+
+            Assert.IsEmpty(
+                _fakeLogger.SnapshotWarnMessages(),
+                "Unborn feature branch should not emit merge-base warning");
+        }
+
+        [TestMethod]
         public void Initialize_SetsGitRootAndWorkspacePath()
         {
             _lister.Initialize(_testRepoPath, new[] { _testRepoPath });

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/MainBranchMergeBaseSelectorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/MainBranchMergeBaseSelectorTests.cs
@@ -109,15 +109,14 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
-        public void FindClosest_WhenDefaultBranchHasNoResolvableRef_FallsBackToAllBranches()
+        public void FindClosest_WhenDefaultBranchHasNoResolvableRef_DoesNotFallBackToAllBranches()
         {
             CommitFile("README.md", "# Test", "Initial commit");
-            ExecGit("branch -m main");
+            ExecGit("branch -m master");
 
             using (var repo = new Repository(_testRepoPath))
             {
-                repo.Refs.Add("refs/remotes/origin/ghost", repo.Head.Tip.Id);
-                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/ghost"]);
+                repo.Refs.Add("refs/remotes/origin/HEAD", "refs/remotes/origin/missing-main");
             }
 
             ExecGit("checkout -b feature-branch");
@@ -127,7 +126,62 @@ namespace Codescene.VSExtension.Core.Tests
             {
                 var result = MainBranchMergeBaseSelector.FindClosest(repo);
 
-                Assert.IsNotNull(result, "Should find merge base via fallback when default branch ref is not local");
+                Assert.IsNull(result, "Should not fall back to master when configured default branch is missing");
+            }
+        }
+
+        [TestMethod]
+        public void FindClosest_WhenDefaultBranchIsMain_DoesNotFallBackToMaster()
+        {
+            CommitFile("README.md", "# Master", "Initial on master");
+            ExecGit("branch -m master");
+            CommitFile("master-only.cs", "class M {}", "Master commit");
+
+            ExecGit("checkout --orphan main");
+            var mainFile = Path.Combine(_testRepoPath, "main.md");
+            File.WriteAllText(mainFile, "# Main");
+            using (var repo = new Repository(_testRepoPath))
+            {
+                Commands.Stage(repo, "main.md");
+                var signature = new Signature("Test User", "test@example.com", DateTimeOffset.Now);
+                repo.Commit("Initial on main", signature, signature);
+                repo.Refs.Add("refs/remotes/origin/main", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
+            }
+
+            ExecGit("checkout master");
+            ExecGit("checkout -b feature-branch");
+            CommitFile("feature.cs", "class Feature {}", "Add feature");
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var selection = MainBranchMergeBaseSelector.Select(repo);
+
+                Assert.IsNull(selection.Commit, "Should not use master when origin/HEAD default is main");
+            }
+        }
+
+        [TestMethod]
+        public void Select_WhenDefaultBranchYieldsMergeBase_ReportsBaselineBranchName()
+        {
+            CommitFile("README.md", "# Test", "Initial commit");
+            ExecGit("branch -m main");
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                repo.Refs.Add("refs/remotes/origin/main", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
+            }
+
+            ExecGit("checkout -b feature-branch");
+            CommitFile("feature.cs", "class Feature {}", "Add feature");
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var selection = MainBranchMergeBaseSelector.Select(repo);
+
+                Assert.IsNotNull(selection.Commit, "Should find a merge base");
+                Assert.AreEqual("main", selection.BaselineBranchName, "Should report the default baseline branch");
             }
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeDetector.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeDetector.cs
@@ -1,6 +1,7 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -21,8 +22,7 @@ namespace Codescene.VSExtension.Core.Application.Git
         private readonly ISupportedFileChecker _supportedFileChecker;
         private readonly IGitService _gitService;
         private Dictionary<string, List<string>> _mainBranchCandidatesCache;
-        private Dictionary<string, string> _loggedNoMergeBaseKeysByRepo;
-        private IReadOnlyList<string> _pendingNoMergeBaseCandidates;
+        private ConcurrentDictionary<string, string> _loggedNoMergeBaseKeysByRepo;
 
         public GitChangeDetector(ILogger logger, ISupportedFileChecker supportedFileChecker, IGitService gitService)
         {
@@ -156,10 +156,10 @@ namespace Codescene.VSExtension.Core.Application.Git
             _logger?.Info($">>> GitChangeDetector: Getting changed files from repository on branch '{currentBranch}'");
             #endif
 
-            var baseCommit = GetMergeBaseCommit(repo);
+            var (baseCommit, noMergeBaseCandidates) = GetMergeBaseCommit(repo);
             if (baseCommit == null)
             {
-                LogNoMergeBaseStateOnce(repo, _pendingNoMergeBaseCandidates);
+                LogNoMergeBaseStateOnce(repo, noMergeBaseCandidates);
             }
 
             var filesToExclude = BuildExclusionSet(context.SavedFilesTracker, context.OpenFilesObserver);
@@ -177,23 +177,20 @@ namespace Codescene.VSExtension.Core.Application.Git
             return changedFiles.Distinct().ToList();
         }
 
-        protected virtual Commit GetMergeBaseCommit(Repository repo)
+        protected virtual (Commit baseCommit, IReadOnlyList<string> noMergeBaseCandidates) GetMergeBaseCommit(Repository repo)
         {
-            _pendingNoMergeBaseCandidates = null;
-
             try
             {
                 var currentBranch = repo.Head;
                 if (!IsValidBranch(currentBranch))
                 {
-                    return null;
+                    return (null, null);
                 }
 
                 var mainBranchCandidates = GetMainBranchCandidates(repo);
-                _pendingNoMergeBaseCandidates = mainBranchCandidates;
                 if (mainBranchCandidates.Count == 0)
                 {
-                    return null;
+                    return (null, mainBranchCandidates);
                 }
 
                 foreach (var candidateName in mainBranchCandidates)
@@ -202,16 +199,16 @@ namespace Codescene.VSExtension.Core.Application.Git
                     if (mergeBase != null)
                     {
                         ClearNoMergeBaseLogState(repo.Info.WorkingDirectory);
-                        return mergeBase;
+                        return (mergeBase, mainBranchCandidates);
                     }
                 }
 
-                return null;
+                return (null, mainBranchCandidates);
             }
             catch (Exception ex)
             {
                 _logger?.Debug($"GitChangeObserver: Could not determine merge base: {ex.Message}");
-                return null;
+                return (null, null);
             }
         }
 
@@ -356,7 +353,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
 
             var key = gitRootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            _loggedNoMergeBaseKeysByRepo.Remove(key);
+            _loggedNoMergeBaseKeysByRepo.TryRemove(key, out _);
             if (_loggedNoMergeBaseKeysByRepo.Count == 0)
             {
                 _loggedNoMergeBaseKeysByRepo = null;
@@ -395,7 +392,7 @@ namespace Codescene.VSExtension.Core.Application.Git
 
             if (_loggedNoMergeBaseKeysByRepo == null)
             {
-                _loggedNoMergeBaseKeysByRepo = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                _loggedNoMergeBaseKeysByRepo = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
 
             if (_loggedNoMergeBaseKeysByRepo.TryGetValue(gitRoot, out var lastStateKey) &&

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeDetector.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeDetector.cs
@@ -21,6 +21,8 @@ namespace Codescene.VSExtension.Core.Application.Git
         private readonly ISupportedFileChecker _supportedFileChecker;
         private readonly IGitService _gitService;
         private Dictionary<string, List<string>> _mainBranchCandidatesCache;
+        private Dictionary<string, string> _loggedNoMergeBaseKeysByRepo;
+        private IReadOnlyList<string> _pendingNoMergeBaseCandidates;
 
         public GitChangeDetector(ILogger logger, ISupportedFileChecker supportedFileChecker, IGitService gitService)
         {
@@ -39,6 +41,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             if (string.IsNullOrEmpty(gitRootPath))
             {
                 _mainBranchCandidatesCache = null;
+                ClearNoMergeBaseLogState();
                 return;
             }
 
@@ -48,6 +51,8 @@ namespace Codescene.VSExtension.Core.Application.Git
             {
                 _mainBranchCandidatesCache = null;
             }
+
+            ClearNoMergeBaseLogState(gitRootPath);
         }
 
         public virtual async Task<List<string>> GetChangedFilesVsBaselineAsync(string gitRootPath, IReadOnlyCollection<string> workspacePaths, ISavedFilesTracker savedFilesTracker, IOpenFilesObserver openFilesObserver, CancellationToken cancellationToken = default)
@@ -154,7 +159,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             var baseCommit = GetMergeBaseCommit(repo);
             if (baseCommit == null)
             {
-                _logger?.Debug("GitChangeObserver: No merge base commit found, using working directory changes only");
+                LogNoMergeBaseStateOnce(repo, _pendingNoMergeBaseCandidates);
             }
 
             var filesToExclude = BuildExclusionSet(context.SavedFilesTracker, context.OpenFilesObserver);
@@ -174,6 +179,8 @@ namespace Codescene.VSExtension.Core.Application.Git
 
         protected virtual Commit GetMergeBaseCommit(Repository repo)
         {
+            _pendingNoMergeBaseCandidates = null;
+
             try
             {
                 var currentBranch = repo.Head;
@@ -183,9 +190,9 @@ namespace Codescene.VSExtension.Core.Application.Git
                 }
 
                 var mainBranchCandidates = GetMainBranchCandidates(repo);
+                _pendingNoMergeBaseCandidates = mainBranchCandidates;
                 if (mainBranchCandidates.Count == 0)
                 {
-                    _logger?.Debug("GitChangeObserver: No main branch candidates found");
                     return null;
                 }
 
@@ -194,11 +201,11 @@ namespace Codescene.VSExtension.Core.Application.Git
                     var mergeBase = TryFindMergeBase(repo, currentBranch, candidateName);
                     if (mergeBase != null)
                     {
+                        ClearNoMergeBaseLogState(repo.Info.WorkingDirectory);
                         return mergeBase;
                     }
                 }
 
-                _logger?.Debug("GitChangeObserver: No merge base found with any main branch candidate");
                 return null;
             }
             catch (Exception ex)
@@ -333,6 +340,72 @@ namespace Codescene.VSExtension.Core.Application.Git
             {
                 exclusionSet.Add(file);
             }
+        }
+
+        private void ClearNoMergeBaseLogState(string gitRootPath = null)
+        {
+            if (_loggedNoMergeBaseKeysByRepo == null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(gitRootPath))
+            {
+                _loggedNoMergeBaseKeysByRepo = null;
+                return;
+            }
+
+            var key = gitRootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            _loggedNoMergeBaseKeysByRepo.Remove(key);
+            if (_loggedNoMergeBaseKeysByRepo.Count == 0)
+            {
+                _loggedNoMergeBaseKeysByRepo = null;
+            }
+        }
+
+        private void LogNoMergeBaseStateOnce(Repository repo, IReadOnlyList<string> candidates)
+        {
+            if (!TryMarkNoMergeBaseLogged(repo, candidates))
+            {
+                return;
+            }
+
+            if (candidates == null || candidates.Count == 0)
+            {
+                _logger?.Debug("GitChangeObserver: No main branch candidates found");
+            }
+            else
+            {
+                _logger?.Debug("GitChangeObserver: No merge base found with any main branch candidate");
+            }
+
+            _logger?.Debug("GitChangeObserver: No merge base commit found, using working directory changes only");
+        }
+
+        private bool TryMarkNoMergeBaseLogged(Repository repo, IReadOnlyList<string> candidates)
+        {
+            var gitRoot = repo?.Info?.WorkingDirectory?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (string.IsNullOrEmpty(gitRoot) || repo?.Head?.Tip == null)
+            {
+                return false;
+            }
+
+            var candidateKey = candidates == null ? string.Empty : string.Join(",", candidates);
+            var stateKey = $"{repo.Head.Tip.Sha}|{candidateKey}";
+
+            if (_loggedNoMergeBaseKeysByRepo == null)
+            {
+                _loggedNoMergeBaseKeysByRepo = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            if (_loggedNoMergeBaseKeysByRepo.TryGetValue(gitRoot, out var lastStateKey) &&
+                string.Equals(lastStateKey, stateKey, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            _loggedNoMergeBaseKeysByRepo[gitRoot] = stateKey;
+            return true;
         }
 
         private bool IsValidBranch(Branch branch)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
@@ -28,6 +28,7 @@ namespace Codescene.VSExtension.Core.Application.Git
         private string _gitRootPath;
         private IReadOnlyCollection<string> _workspacePaths;
         private DroppingScheduledExecutor _scheduledExecutor;
+        private Dictionary<string, string> _loggedNoMergeBaseWarnKeysByRepo;
         private bool _disposed = false;
 
         public GitChangeLister(
@@ -383,13 +384,11 @@ namespace Codescene.VSExtension.Core.Application.Git
             var mergeBase = _mergeBaseFinder.GetMergeBaseCommit(repo);
             if (mergeBase == null)
             {
-                if (repo.Head != null && !_mergeBaseFinder.IsMainBranch(repo, repo.Head.FriendlyName))
-                {
-                    _logger?.Warn("GitChangeLister: On non-main branch but can't determine merge-base");
-                }
-
+                LogNoMergeBaseWarnOnce(repo);
                 return new HashSet<string>();
             }
+
+            ClearNoMergeBaseWarnLogState(repo.Info.WorkingDirectory);
 
             if (repo.Head?.Tip == null)
             {
@@ -440,6 +439,68 @@ namespace Codescene.VSExtension.Core.Application.Git
         private bool ShouldReviewFile(string absolutePath)
         {
             return _supportedFileChecker.IsSupported(absolutePath);
+        }
+
+        private void LogNoMergeBaseWarnOnce(Repository repo)
+        {
+            if (repo?.Head == null || _mergeBaseFinder.IsMainBranch(repo, repo.Head.FriendlyName))
+            {
+                return;
+            }
+
+            if (!TryMarkNoMergeBaseWarnLogged(repo))
+            {
+                return;
+            }
+
+            _logger?.Warn("GitChangeLister: On non-main branch but can't determine merge-base");
+        }
+
+        private void ClearNoMergeBaseWarnLogState(string gitRootPath = null)
+        {
+            if (_loggedNoMergeBaseWarnKeysByRepo == null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(gitRootPath))
+            {
+                _loggedNoMergeBaseWarnKeysByRepo = null;
+                return;
+            }
+
+            var key = gitRootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            _loggedNoMergeBaseWarnKeysByRepo.Remove(key);
+            if (_loggedNoMergeBaseWarnKeysByRepo.Count == 0)
+            {
+                _loggedNoMergeBaseWarnKeysByRepo = null;
+            }
+        }
+
+        private bool TryMarkNoMergeBaseWarnLogged(Repository repo)
+        {
+            var gitRoot = repo?.Info?.WorkingDirectory?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (string.IsNullOrEmpty(gitRoot) || repo?.Head?.Tip == null)
+            {
+                return false;
+            }
+
+            var defaultBranch = MainBranchNames.GetDefaultBranch(repo) ?? string.Empty;
+            var stateKey = $"{repo.Head.Tip.Sha}|{repo.Head.FriendlyName}|{defaultBranch}";
+
+            if (_loggedNoMergeBaseWarnKeysByRepo == null)
+            {
+                _loggedNoMergeBaseWarnKeysByRepo = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            if (_loggedNoMergeBaseWarnKeysByRepo.TryGetValue(gitRoot, out var lastStateKey) &&
+                string.Equals(lastStateKey, stateKey, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            _loggedNoMergeBaseWarnKeysByRepo[gitRoot] = stateKey;
+            return true;
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
@@ -1,6 +1,7 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -28,7 +29,7 @@ namespace Codescene.VSExtension.Core.Application.Git
         private string _gitRootPath;
         private IReadOnlyCollection<string> _workspacePaths;
         private DroppingScheduledExecutor _scheduledExecutor;
-        private Dictionary<string, string> _loggedNoMergeBaseWarnKeysByRepo;
+        private ConcurrentDictionary<string, string> _loggedNoMergeBaseWarnKeysByRepo;
         private bool _disposed = false;
 
         public GitChangeLister(
@@ -470,7 +471,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
 
             var key = gitRootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            _loggedNoMergeBaseWarnKeysByRepo.Remove(key);
+            _loggedNoMergeBaseWarnKeysByRepo.TryRemove(key, out _);
             if (_loggedNoMergeBaseWarnKeysByRepo.Count == 0)
             {
                 _loggedNoMergeBaseWarnKeysByRepo = null;
@@ -490,7 +491,7 @@ namespace Codescene.VSExtension.Core.Application.Git
 
             if (_loggedNoMergeBaseWarnKeysByRepo == null)
             {
-                _loggedNoMergeBaseWarnKeysByRepo = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                _loggedNoMergeBaseWarnKeysByRepo = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
 
             if (_loggedNoMergeBaseWarnKeysByRepo.TryGetValue(gitRoot, out var lastStateKey) &&

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/MainBranchMergeBaseSelector.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/MainBranchMergeBaseSelector.cs
@@ -87,7 +87,10 @@ namespace Codescene.VSExtension.Core.Application.Git
                 if (mergeBase != null)
                 {
                     candidates.MergeBases[mergeBase.Sha] = mergeBase;
-                    candidates.BaselineBranches[mergeBase.Sha] = mainBranchName;
+                    if (!candidates.BaselineBranches.ContainsKey(mergeBase.Sha))
+                    {
+                        candidates.BaselineBranches[mergeBase.Sha] = mainBranchName;
+                    }
                 }
             }
             catch (Exception e)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/MainBranchMergeBaseSelector.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/MainBranchMergeBaseSelector.cs
@@ -17,50 +17,59 @@ namespace Codescene.VSExtension.Core.Application.Git
         /// </summary>
         public static Commit FindClosest(Repository repo, ILogger logger = null)
         {
+            return Select(repo, logger).Commit;
+        }
+
+        public static MergeBaseSelection Select(Repository repo, ILogger logger = null)
+        {
             if (repo?.Head?.Tip == null)
             {
-                return null;
+                return default;
             }
 
             var currentBranchName = repo.Head.FriendlyName;
             var candidates = CollectCandidates(repo, currentBranchName, logger);
 
-            if (candidates.Count == 0)
+            if (candidates.MergeBases.Count == 0)
             {
-                return null;
+                return default;
             }
 
-            var closest = FindClosestReachable(repo, candidates);
-            return closest ?? candidates.Values.First();
+            var closestSha = FindClosestReachableSha(repo, candidates.MergeBases);
+            if (closestSha == null)
+            {
+                closestSha = candidates.MergeBases.Keys.First();
+            }
+
+            candidates.MergeBases.TryGetValue(closestSha, out var commit);
+            candidates.BaselineBranches.TryGetValue(closestSha, out var baselineBranchName);
+            return new MergeBaseSelection(commit, baselineBranchName);
         }
 
-        private static Dictionary<string, Commit> CollectCandidates(Repository repo, string currentBranch, ILogger logger)
+        private static CandidateCollection CollectCandidates(Repository repo, string currentBranch, ILogger logger)
         {
-            var mergeBases = new Dictionary<string, Commit>(StringComparer.OrdinalIgnoreCase);
+            var candidates = new CandidateCollection();
 
             var defaultBranch = MainBranchNames.GetDefaultBranch(repo);
             if (!string.IsNullOrEmpty(defaultBranch))
             {
-                TryAddCandidate(repo, currentBranch, defaultBranch, mergeBases, logger);
-                if (mergeBases.Count > 0)
-                {
-                    return mergeBases;
-                }
+                TryAddCandidate(repo, currentBranch, defaultBranch, candidates, logger);
+                return candidates;
             }
 
             foreach (var mainBranchName in MainBranchNames.All)
             {
-                TryAddCandidate(repo, currentBranch, mainBranchName, mergeBases, logger);
+                TryAddCandidate(repo, currentBranch, mainBranchName, candidates, logger);
             }
 
-            return mergeBases;
+            return candidates;
         }
 
         private static void TryAddCandidate(
             Repository repo,
             string currentBranch,
             string mainBranchName,
-            IDictionary<string, Commit> mergeBases,
+            CandidateCollection candidates,
             ILogger logger)
         {
             var mainBranch = repo.Branches[mainBranchName]
@@ -77,7 +86,8 @@ namespace Codescene.VSExtension.Core.Application.Git
                 var mergeBase = repo.ObjectDatabase.FindMergeBase(repo.Head.Tip, mainBranch.Tip);
                 if (mergeBase != null)
                 {
-                    mergeBases[mergeBase.Sha] = mergeBase;
+                    candidates.MergeBases[mergeBase.Sha] = mergeBase;
+                    candidates.BaselineBranches[mergeBase.Sha] = mainBranchName;
                 }
             }
             catch (Exception e)
@@ -86,7 +96,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
         }
 
-        private static Commit FindClosestReachable(Repository repo, IReadOnlyDictionary<string, Commit> mergeBases)
+        private static string FindClosestReachableSha(Repository repo, IReadOnlyDictionary<string, Commit> mergeBases)
         {
             foreach (var commit in repo.Commits.QueryBy(new CommitFilter
                      {
@@ -94,13 +104,20 @@ namespace Codescene.VSExtension.Core.Application.Git
                          SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Time,
                      }))
             {
-                if (mergeBases.TryGetValue(commit.Sha, out var closestMergeBase))
+                if (mergeBases.ContainsKey(commit.Sha))
                 {
-                    return closestMergeBase;
+                    return commit.Sha;
                 }
             }
 
             return null;
+        }
+
+        private sealed class CandidateCollection
+        {
+            public Dictionary<string, Commit> MergeBases { get; } = new Dictionary<string, Commit>(StringComparer.OrdinalIgnoreCase);
+
+            public Dictionary<string, string> BaselineBranches { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/MergeBaseFinder.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/MergeBaseFinder.cs
@@ -28,10 +28,14 @@ namespace Codescene.VSExtension.Core.Application.Git
                 _logger?.Info($">>> MergeBaseFinder: Finding merge base for branch '{repo.Head.FriendlyName}'");
                 #endif
 
-                var mergeBase = MainBranchMergeBaseSelector.FindClosest(repo, _logger);
+                var selection = MainBranchMergeBaseSelector.Select(repo, _logger);
+                var mergeBase = selection.Commit;
                 if (mergeBase != null)
                 {
-                    _logger?.Debug($"GitChangeLister: Found merge base using branch reachable from HEAD ({mergeBase.Sha})");
+                    var branchLabel = string.IsNullOrEmpty(selection.BaselineBranchName)
+                        ? "closest main branch"
+                        : selection.BaselineBranchName;
+                    _logger?.Debug($"GitChangeLister: Found merge base using branch '{branchLabel}' ({mergeBase.Sha})");
                     #if FEATURE_INITIAL_GIT_OBSERVER
                     _logger?.Info($">>> MergeBaseFinder: Found merge base commit {mergeBase.Sha.Substring(0, 8)} for branch '{repo.Head.FriendlyName}'");
                     #endif

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/MergeBaseSelection.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/MergeBaseSelection.cs
@@ -1,0 +1,19 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using LibGit2Sharp;
+
+namespace Codescene.VSExtension.Core.Application.Git
+{
+    public readonly struct MergeBaseSelection
+    {
+        public MergeBaseSelection(Commit commit, string baselineBranchName)
+        {
+            Commit = commit;
+            BaselineBranchName = baselineBranchName;
+        }
+
+        public Commit Commit { get; }
+
+        public string BaselineBranchName { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- Make config/`origin/HEAD` baseline authoritative in `MainBranchMergeBaseSelector` so periodic scans no longer fall back to `master`/`develop` when the default branch has no merge base.
- Log the selected baseline branch name from merge-base lookups instead of the ambiguous "reachable from HEAD" message.
- Deduplicate repeated no-merge-base warnings/logs in `GitChangeLister` and `GitChangeDetector` for unchanged repo state.

## Test plan
- [x] `make iter` passes (unit tests for selector, lister, and detector)
- [ ] Open `C:\Git\test-master-main-confusion` on branch `test` and confirm baseline is `main`, no master merge-base fallback, and no-merge-base warn/log appears once per state
- [ ] Verify `.codescene/config.json` `baseline_branch` still overrides `origin/HEAD`
