### PR TITLE
perf: reduce sustained CPU on large-diff branches (CS-11658)

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/BenchmarkSupport.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/BenchmarkSupport.cs
@@ -232,6 +232,8 @@ internal sealed class FixedGitService : IGitService
         _defaultBaselineContent = defaultBaselineContent;
     }
 
+    public event EventHandler? GitIgnoreChanged;
+
     public void SetContent(string path, string content)
     {
         _pathContents[path] = content;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestGitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestGitService.cs
@@ -12,6 +12,12 @@ namespace Codescene.VSExtension.Core.IntegrationTests.TestImplementations
     {
         internal Mock<IGitService> Mock = new Mock<IGitService>();
 
+        public event EventHandler GitIgnoreChanged
+        {
+            add => Mock.Object.GitIgnoreChanged += value;
+            remove => Mock.Object.GitIgnoreChanged -= value;
+        }
+
         public string GetFileContentForCommit(string path)
         {
             return Mock.Object.GetFileContentForCommit(path);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingGitObservers.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingGitObservers.cs
@@ -45,6 +45,11 @@ public sealed class RecordingGitChangeLister : IGitChangeLister, IDisposable
         _inner.SetWorkspacePaths(workspacePaths);
     }
 
+    public void MarkDirty()
+    {
+        _inner.MarkDirty();
+    }
+
     public void StartPeriodicScanning(CancellationToken cancellationToken)
     {
         _journal.Record("lister.periodic.start");

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DetectedFilePrioritySorterTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DetectedFilePrioritySorterTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using Codescene.VSExtension.Core.Application.Git;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class DetectedFilePrioritySorterTests
+    {
+        [TestMethod]
+        public void SortByVisibility_PutsVisibleFilesFirst()
+        {
+            var files = new[] { "c:\\repo\\hidden.cs", "c:\\repo\\visible.cs", "c:\\repo\\other.cs" };
+            var visible = new[] { "c:\\repo\\visible.cs" };
+
+            var sorted = DetectedFilePrioritySorter.SortByVisibility(files, visible).ToList();
+
+            Assert.AreEqual("c:\\repo\\visible.cs", sorted[0]);
+            Assert.Contains("c:\\repo\\hidden.cs", sorted);
+            Assert.Contains("c:\\repo\\other.cs", sorted);
+        }
+
+        [TestMethod]
+        public void SortByVisibility_PutsActiveDocumentFirstAmongVisible()
+        {
+            var files = new[] { "c:\\repo\\b.cs", "c:\\repo\\a.cs", "c:\\repo\\hidden.cs" };
+            var visible = new[] { "c:\\repo\\a.cs", "c:\\repo\\b.cs" };
+
+            var sorted = DetectedFilePrioritySorter.SortByVisibility(files, visible, "c:\\repo\\b.cs").ToList();
+
+            Assert.AreEqual("c:\\repo\\b.cs", sorted[0]);
+            Assert.AreEqual("c:\\repo\\a.cs", sorted[1]);
+            Assert.AreEqual("c:\\repo\\hidden.cs", sorted[2]);
+        }
+
+        [TestMethod]
+        public void SortByVisibility_SortsAlphabeticallyWithinGroups()
+        {
+            var files = new[] { "c:\\repo\\z.cs", "c:\\repo\\a.cs", "c:\\repo\\m.cs" };
+
+            var sorted = DetectedFilePrioritySorter.SortByVisibility(files, Enumerable.Empty<string>()).ToList();
+
+            Assert.AreEqual("c:\\repo\\a.cs", sorted[0]);
+            Assert.AreEqual("c:\\repo\\m.cs", sorted[1]);
+            Assert.AreEqual("c:\\repo\\z.cs", sorted[2]);
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/FileChangeHandlerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/FileChangeHandlerTests.cs
@@ -1,6 +1,9 @@
 // Copyright (c) CodeScene. All rights reserved.
 
+using Codescene.VSExtension.Core.Application.Cache.Review;
 using Codescene.VSExtension.Core.Application.Git;
+using Codescene.VSExtension.Core.Models;
+using Codescene.VSExtension.Core.Models.Cache.Review;
 
 namespace Codescene.VSExtension.Core.Tests
 {
@@ -139,6 +142,29 @@ namespace Codescene.VSExtension.Core.Tests
 
             Assert.IsTrue(_trackerManager.Contains(testFile));
             Assert.IsGreaterThanOrEqualTo(_fakeCodeReviewer.ReviewCallCount, 1);
+        }
+
+        [TestMethod]
+        public async Task HandleFileChangeAsync_CachedContent_SkipsReviewer()
+        {
+            var testFile = Path.Combine(_testWorkspacePath, "cached.cs");
+            var content = "public class Cached {}";
+            File.WriteAllText(testFile, content);
+
+            var cache = new ReviewCacheService();
+            cache.Clear();
+            cache.Put(new ReviewCacheEntry(content, testFile, new FileReviewModel
+            {
+                FilePath = testFile,
+                Score = 8.0f,
+            }));
+
+            var changedFiles = new List<string> { "cached.cs" };
+            await _handler.HandleFileChangeAsync(testFile, changedFiles);
+
+            await Task.Delay(100);
+
+            Assert.AreEqual(0, _fakeCodeReviewer.ReviewCallCount);
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerScanTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerScanTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using Codescene.VSExtension.Core.Application.Git;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class GitChangeListerScanTests : GitChangeDetectorTestBase
+    {
+        [TestCleanup]
+        public void CleanupActivity()
+        {
+            WorkspaceActivityTracker.Reset();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_SecondIdleTick_SkipsFilesDetected()
+        {
+            var testableLister = CreateTestableLister();
+            var modifiedFile = Path.Combine(_testRepoPath, "idle-skip.cs");
+            File.WriteAllText(modifiedFile, "new content");
+
+            var detectionCount = 0;
+            testableLister.FilesDetected += (_, __) => detectionCount++;
+
+            await testableLister.InvokePeriodicScanAsync();
+            Assert.AreEqual(1, detectionCount, "First scan should detect files");
+
+            await testableLister.InvokePeriodicScanAsync();
+            Assert.AreEqual(1, detectionCount, "Idle second scan should not fire FilesDetected");
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_UnchangedFileSetWithActivity_SkipsFilesDetected()
+        {
+            var testableLister = CreateTestableLister();
+            var modifiedFile = Path.Combine(_testRepoPath, "unchanged-set.cs");
+            File.WriteAllText(modifiedFile, "new content");
+
+            var detectionCount = 0;
+            testableLister.FilesDetected += (_, __) => detectionCount++;
+
+            await testableLister.InvokePeriodicScanAsync();
+            Assert.AreEqual(1, detectionCount);
+
+            WorkspaceActivityTracker.MarkActivity();
+            await testableLister.InvokePeriodicScanAsync();
+            Assert.AreEqual(1, detectionCount, "Unchanged file set should not re-fire FilesDetected");
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_MarkDirty_ForcesRescanWhenIdle()
+        {
+            var testableLister = CreateTestableLister();
+            var modifiedFile = Path.Combine(_testRepoPath, "mark-dirty.cs");
+            File.WriteAllText(modifiedFile, "new content");
+
+            var detectionCount = 0;
+            testableLister.FilesDetected += (_, __) => detectionCount++;
+
+            await testableLister.InvokePeriodicScanAsync();
+            Assert.AreEqual(1, detectionCount);
+
+            testableLister.MarkDirty();
+            await testableLister.InvokePeriodicScanAsync();
+            Assert.AreEqual(2, detectionCount, "MarkDirty should force another FilesDetected even when idle");
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_WorkspaceActivity_ForcesGitScanWhenIdle()
+        {
+            var testableLister = CreateTestableLister();
+            var modifiedFile = Path.Combine(_testRepoPath, "activity.cs");
+            File.WriteAllText(modifiedFile, "new content");
+
+            var detectionCount = 0;
+            testableLister.FilesDetected += (_, __) => detectionCount++;
+
+            await testableLister.InvokePeriodicScanAsync();
+            Assert.AreEqual(1, detectionCount);
+
+            WorkspaceActivityTracker.MarkActivity();
+            testableLister.MarkDirty();
+            await testableLister.InvokePeriodicScanAsync();
+            Assert.AreEqual(2, detectionCount, "Activity plus dirty should allow another detection pass");
+
+            testableLister.Dispose();
+        }
+
+        private TestableGitChangeLister CreateTestableLister()
+        {
+            var lister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker, _fakeSupportedFileChecker, _fakeLogger, _fakeGitService);
+            lister.Initialize(_testRepoPath, new[] { _testRepoPath });
+            return lister;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
@@ -269,6 +269,8 @@ namespace Codescene.VSExtension.Core.Tests
 
     public class FakeGitService : IGitService
     {
+        public event EventHandler GitIgnoreChanged;
+
         public string GetFileContentForCommit(string path)
         {
             return string.Empty;
@@ -298,6 +300,8 @@ namespace Codescene.VSExtension.Core.Tests
             _ignoredPath = ignoredPath;
         }
 
+        public event EventHandler GitIgnoreChanged;
+
         public string GetFileContentForCommit(string path)
         {
             return string.Empty;
@@ -326,6 +330,8 @@ namespace Codescene.VSExtension.Core.Tests
         {
             _repoPath = repoPath;
         }
+
+        public event EventHandler GitIgnoreChanged;
 
         public string GetFileContentForCommit(string path)
         {
@@ -468,6 +474,10 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         public void SetWorkspacePaths(IReadOnlyCollection<string> workspacePaths)
+        {
+        }
+
+        public void MarkDirty()
         {
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ReviewCacheServiceTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ReviewCacheServiceTests.cs
@@ -123,6 +123,28 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public void IsCachedAtContent_ReturnsTrueWhenContentMatches()
+        {
+            var filePath = "test.cs";
+            var content = "public class Test { }";
+            var response = new FileReviewModel { FilePath = filePath, Score = 8.5f };
+            _cacheService.Put(new ReviewCacheEntry(content, filePath, response));
+
+            Assert.IsTrue(_cacheService.IsCachedAtContent(filePath, content));
+        }
+
+        [TestMethod]
+        public void IsCachedAtContent_ReturnsFalseWhenContentDiffers()
+        {
+            var filePath = "test.cs";
+            var content = "public class Test { }";
+            var response = new FileReviewModel { FilePath = filePath, Score = 8.5f };
+            _cacheService.Put(new ReviewCacheEntry(content, filePath, response));
+
+            Assert.IsFalse(_cacheService.IsCachedAtContent(filePath, "public class Other { }"));
+        }
+
+        [TestMethod]
         public void Invalidate_RemovesEntry()
         {
             // Arrange

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/WorkspaceActivityTrackerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/WorkspaceActivityTrackerTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using Codescene.VSExtension.Core.Application.Git;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class WorkspaceActivityTrackerTests
+    {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            WorkspaceActivityTracker.Reset();
+        }
+
+        [TestMethod]
+        public void ConsumeActivity_WhenNotMarked_ReturnsFalse()
+        {
+            WorkspaceActivityTracker.Reset();
+
+            Assert.IsFalse(WorkspaceActivityTracker.ConsumeActivity());
+        }
+
+        [TestMethod]
+        public void MarkActivity_ThenConsume_ReturnsTrueOnce()
+        {
+            WorkspaceActivityTracker.Reset();
+            WorkspaceActivityTracker.MarkActivity();
+
+            Assert.IsTrue(WorkspaceActivityTracker.ConsumeActivity());
+            Assert.IsFalse(WorkspaceActivityTracker.ConsumeActivity());
+        }
+
+        [TestMethod]
+        public void Reset_ClearsPendingActivity()
+        {
+            WorkspaceActivityTracker.MarkActivity();
+            WorkspaceActivityTracker.Reset();
+
+            Assert.IsFalse(WorkspaceActivityTracker.ConsumeActivity());
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cache/Review/ReviewCacheService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cache/Review/ReviewCacheService.cs
@@ -37,6 +37,16 @@ namespace Codescene.VSExtension.Core.Application.Cache.Review
             return null;
         }
 
+        public bool IsCachedAtContent(string filePath, string content, bool isBaseline = false)
+        {
+            if (string.IsNullOrWhiteSpace(filePath) || content == null)
+            {
+                return false;
+            }
+
+            return Get(new ReviewCacheQuery(content, filePath, isBaseline)) != null;
+        }
+
         public override void Put(ReviewCacheEntry entry, long? operationGeneration = null)
         {
             string cacheKey = GetCacheKey(entry.FilePath, entry.IsBaseline);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/DetectedFilePrioritySorter.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/DetectedFilePrioritySorter.cs
@@ -1,0 +1,49 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Codescene.VSExtension.Core.Application.Git
+{
+    internal static class DetectedFilePrioritySorter
+    {
+        public static IEnumerable<string> SortByVisibility(
+            IEnumerable<string> filePaths,
+            IEnumerable<string> visibleFileNames,
+            string activeDocumentPath = null)
+        {
+            var visible = new HashSet<string>(visibleFileNames ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            var visiblePaths = new List<string>();
+            var hiddenPaths = new List<string>();
+
+            foreach (var filePath in filePaths.Where(path => !string.IsNullOrWhiteSpace(path)))
+            {
+                if (visible.Contains(filePath))
+                {
+                    visiblePaths.Add(filePath);
+                }
+                else
+                {
+                    hiddenPaths.Add(filePath);
+                }
+            }
+
+            visiblePaths.Sort(StringComparer.OrdinalIgnoreCase);
+            hiddenPaths.Sort(StringComparer.OrdinalIgnoreCase);
+
+            if (!string.IsNullOrEmpty(activeDocumentPath))
+            {
+                var activeIndex = visiblePaths.FindIndex(path => string.Equals(path, activeDocumentPath, StringComparison.OrdinalIgnoreCase));
+                if (activeIndex > 0)
+                {
+                    var activePath = visiblePaths[activeIndex];
+                    visiblePaths.RemoveAt(activeIndex);
+                    visiblePaths.Insert(0, activePath);
+                }
+            }
+
+            return visiblePaths.Concat(hiddenPaths);
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeHandler.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeHandler.cs
@@ -6,10 +6,12 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Application.Cache.Review;
 using Codescene.VSExtension.Core.Application.Util;
 using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Cli;
 using Codescene.VSExtension.Core.Interfaces.Git;
+using Codescene.VSExtension.Core.Models;
 using Codescene.VSExtension.Core.Util;
 
 namespace Codescene.VSExtension.Core.Application.Git
@@ -171,37 +173,15 @@ namespace Codescene.VSExtension.Core.Application.Git
                 #if FEATURE_INITIAL_GIT_OBSERVER
                 _logger?.Info($">>> FileChangeHandler: Starting review for file: {filePath}");
                 #endif
-                string content = null;
-                if (_openDocumentContentProvider != null)
-                {
-                    try
-                    {
-                        content = await _openDocumentContentProvider.GetContentForReviewAsync(filePath, cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger?.Warn($"GitChangeObserver: Open document provider failed for {filePath}. {ex.Message}");
-                    }
-                }
-
-                content ??= File.ReadAllText(filePath);
-
+                var content = await GetReviewContentAsync(filePath, cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
-                var (review, delta) = await _codeReviewer.ReviewWithDeltaAsync(filePath, content, operationGeneration, cancellationToken).ConfigureAwait(false);
+                if (IsAlreadyCachedAtContent(filePath, content))
+                {
+                    return;
+                }
 
-                if (review != null)
-                {
-                    _logger?.Debug($"GitChangeObserver: File reviewed: {filePath}");
-                    #if FEATURE_INITIAL_GIT_OBSERVER
-                    _logger?.Info($">>> FileChangeHandler: Completed review for file: {filePath}");
-                    #endif
-                }
-                else
-                {
-                    #if FEATURE_INITIAL_GIT_OBSERVER
-                    _logger?.Info($">>> FileChangeHandler: Review returned null for file: {filePath}");
-                    #endif
-                }
+                var (review, delta) = await _codeReviewer.ReviewWithDeltaAsync(filePath, content, operationGeneration, cancellationToken).ConfigureAwait(false);
+                LogReviewOutcome(filePath, review);
             }
             catch (OperationCanceledException)
             {
@@ -210,6 +190,48 @@ namespace Codescene.VSExtension.Core.Application.Git
             {
                 _logger?.Error($"GitChangeObserver: Could not load file for review {filePath}", ex);
             }
+        }
+
+        private async Task<string> GetReviewContentAsync(string filePath, CancellationToken cancellationToken)
+        {
+            if (_openDocumentContentProvider != null)
+            {
+                try
+                {
+                    var openContent = await _openDocumentContentProvider.GetContentForReviewAsync(filePath, cancellationToken).ConfigureAwait(false);
+                    if (openContent != null)
+                    {
+                        return openContent;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger?.Warn($"GitChangeObserver: Open document provider failed for {filePath}. {ex.Message}");
+                }
+            }
+
+            return File.ReadAllText(filePath);
+        }
+
+        private bool IsAlreadyCachedAtContent(string filePath, string content)
+        {
+            return new ReviewCacheService().IsCachedAtContent(filePath, content);
+        }
+
+        private void LogReviewOutcome(string filePath, FileReviewModel review)
+        {
+            if (review != null)
+            {
+                _logger?.Debug($"GitChangeObserver: File reviewed: {filePath}");
+                #if FEATURE_INITIAL_GIT_OBSERVER
+                _logger?.Info($">>> FileChangeHandler: Completed review for file: {filePath}");
+                #endif
+                return;
+            }
+
+            #if FEATURE_INITIAL_GIT_OBSERVER
+            _logger?.Info($">>> FileChangeHandler: Review returned null for file: {filePath}");
+            #endif
         }
 
         private bool IsFileInChangedList(string filePath, List<string> changedFiles)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Codescene.VSExtension.Core.Application.Cache.Review;
@@ -30,6 +31,8 @@ namespace Codescene.VSExtension.Core.Application.Git
         private IReadOnlyCollection<string> _workspacePaths;
         private DroppingScheduledExecutor _scheduledExecutor;
         private ConcurrentDictionary<string, string> _loggedNoMergeBaseWarnKeysByRepo;
+        private string _lastChangedFileSetKey;
+        private bool _forceNextScan;
         private bool _disposed = false;
 
         public GitChangeLister(
@@ -92,9 +95,17 @@ namespace Codescene.VSExtension.Core.Application.Git
         {
             _gitRootPath = gitRootPath;
             _workspacePaths = workspacePaths ?? Array.Empty<string>();
+            _lastChangedFileSetKey = null;
+            _forceNextScan = true;
+            WorkspaceActivityTracker.Reset();
 #if FEATURE_INITIAL_GIT_OBSERVER
             _logger?.Info($">>> GitChangeLister: Initialized with gitRoot='{gitRootPath}', workspacePaths count={_workspacePaths.Count}");
 #endif
+        }
+
+        public void MarkDirty()
+        {
+            _forceNextScan = true;
         }
 
         public void SetWorkspacePaths(IReadOnlyCollection<string> workspacePaths)
@@ -332,21 +343,22 @@ namespace Codescene.VSExtension.Core.Application.Git
         {
             try
             {
-                _logger?.Info("Starting scheduled git change review");
                 cancellationToken.ThrowIfCancellationRequested();
-                var didCleanup = ReviewCacheCleanup.CleanupCaches(_gitRootPath);
-                var files = await GetAllChangedFilesAsync(_gitRootPath, _workspacePaths, cancellationToken);
-                cancellationToken.ThrowIfCancellationRequested();
-                if (didCleanup)
-                {
-                    files ??= new HashSet<string>();
-                    files.Add("~~cleanup~~");
-                }
-
-                if (files == null || files.Count == 0)
+                if (ShouldSkipIdleScan(WorkspaceActivityTracker.ConsumeActivity()))
                 {
                     return;
                 }
+
+                _logger?.Info("Starting scheduled git change review");
+                var files = await CollectPeriodicScanFilesAsync(cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!ShouldPublishPeriodicScan(files, out var changedFileSetKey))
+                {
+                    return;
+                }
+
+                _forceNextScan = false;
+                _lastChangedFileSetKey = changedFileSetKey;
 
 #if FEATURE_INITIAL_GIT_OBSERVER
                 _logger?.Info($">>> GitChangeLister: Periodic scan detected {files.Count} files");
@@ -360,6 +372,46 @@ namespace Codescene.VSExtension.Core.Application.Git
             {
                 _logger?.Error("GitChangeLister: Error during periodic scan", ex);
             }
+        }
+
+        private async Task<HashSet<string>> CollectPeriodicScanFilesAsync(CancellationToken cancellationToken)
+        {
+            var didCleanup = ReviewCacheCleanup.CleanupCaches(_gitRootPath);
+            var files = await GetAllChangedFilesAsync(_gitRootPath, _workspacePaths, cancellationToken);
+            if (didCleanup)
+            {
+                files ??= new HashSet<string>();
+                files.Add("~~cleanup~~");
+            }
+
+            return files;
+        }
+
+        private bool ShouldPublishPeriodicScan(HashSet<string> files, out string changedFileSetKey)
+        {
+            changedFileSetKey = null;
+            if (files == null || files.Count == 0)
+            {
+                return false;
+            }
+
+            changedFileSetKey = SerializeChangedFileSet(files);
+            return !IsUnchangedFileSet(changedFileSetKey);
+        }
+
+        private bool ShouldSkipIdleScan(bool hadWorkspaceActivity)
+        {
+            return !_forceNextScan && !hadWorkspaceActivity && _lastChangedFileSetKey != null;
+        }
+
+        private bool IsUnchangedFileSet(string changedFileSetKey)
+        {
+            return !_forceNextScan && changedFileSetKey == _lastChangedFileSetKey;
+        }
+
+        private string SerializeChangedFileSet(IEnumerable<string> filePaths)
+        {
+            return string.Join("\0", filePaths.OrderBy(path => path, StringComparer.OrdinalIgnoreCase));
         }
 
         private bool IsValidGitRoot(string gitRootPath)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
@@ -47,7 +47,6 @@ namespace Codescene.VSExtension.Core.Application.Git
         private Func<Task<List<string>>> _getChangedFilesCallback;
         private CodesceneFileWatcher _rulesFileWatcher;
         private CodesceneFileWatcher _configFileWatcher;
-        private GitIgnoreWatcher _gitIgnoreWatcher;
         private TaskCompletionSource<bool> _initializationComplete;
         private PerFileRequestQueue<string> _detectedFilesQueue = new PerFileRequestQueue<string>();
         private ConcurrentDictionary<string, SemaphoreSlim> _perFileProcessingLocks = new ConcurrentDictionary<string, SemaphoreSlim>(StringComparer.OrdinalIgnoreCase);
@@ -136,8 +135,8 @@ namespace Codescene.VSExtension.Core.Application.Git
                 "CodeScene config change detected.");
             _configFileWatcher.FileChanged += OnCodesceneConfigChanged;
 
-            _gitIgnoreWatcher = new GitIgnoreWatcher(_gitRootPath, _logger);
-            _gitIgnoreWatcher.GitIgnoreChanged += OnGitIgnoreChanged;
+            _gitService.GitIgnoreChanged += OnGitIgnoreChanged;
+            EnsureGitIgnoreWatcherInitialized();
 
             InitializeTracker();
         }
@@ -244,8 +243,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             _configFileWatcher?.Dispose();
             _configFileWatcher = null;
 
-            _gitIgnoreWatcher?.Dispose();
-            _gitIgnoreWatcher = null;
+            _gitService.GitIgnoreChanged -= OnGitIgnoreChanged;
 
             _eventProcessor?.Dispose();
             _eventProcessor = null;
@@ -258,10 +256,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             _gitChangeLister.StopPeriodicScanning();
             _eventProcessor?.DrainAndStop();
 
-            if (_gitIgnoreWatcher != null)
-            {
-                _gitIgnoreWatcher.GitIgnoreChanged -= OnGitIgnoreChanged;
-            }
+            _gitService.GitIgnoreChanged -= OnGitIgnoreChanged;
 
             _cts?.Cancel();
             _cts?.Dispose();
@@ -272,11 +267,10 @@ namespace Codescene.VSExtension.Core.Application.Git
             _detectedFilesQueue.Clear();
 
             ClearTrackerAndJobs();
+            _gitChangeLister.MarkDirty();
+            WorkspaceActivityTracker.Reset();
             _gitChangeLister.FilesDetected += OnGitChangeListerFilesDetected;
-            if (_gitIgnoreWatcher != null)
-            {
-                _gitIgnoreWatcher.GitIgnoreChanged += OnGitIgnoreChanged;
-            }
+            _gitService.GitIgnoreChanged += OnGitIgnoreChanged;
 
             _eventProcessor?.Start(TimeSpan.FromSeconds(1), _cts.Token);
             _gitChangeLister.StartPeriodicScanning(_cts.Token);
@@ -350,17 +344,20 @@ namespace Codescene.VSExtension.Core.Application.Git
 
         private void OnCodeHealthRulesChanged(object sender, EventArgs e)
         {
+            _gitChangeLister.MarkDirty();
             InvalidateTrackedFiles(onlyIgnored: false);
         }
 
         private void OnCodesceneConfigChanged(object sender, EventArgs e)
         {
+            _gitChangeLister.MarkDirty();
             _gitChangeDetector?.ClearMainBranchCandidatesCache(_gitRootPath);
             InvalidateTrackedFiles(onlyIgnored: false);
         }
 
         private void OnGitIgnoreChanged(object sender, EventArgs e)
         {
+            _gitChangeLister.MarkDirty();
             InvalidateTrackedFiles();
         }
 
@@ -405,7 +402,12 @@ namespace Codescene.VSExtension.Core.Application.Git
                 }
 
                 var token = cts.Token;
-                foreach (var path in absolutePaths.Where(path => !string.IsNullOrWhiteSpace(path)))
+                var sortedPaths = DetectedFilePrioritySorter.SortByVisibility(
+                    absolutePaths,
+                    _openFilesObserver.GetAllVisibleFileNames(),
+                    _openFilesObserver.GetActiveDocumentPath());
+
+                foreach (var path in sortedPaths)
                 {
                     if (_detectedFilesQueue.TryStart(path, path))
                     {
@@ -642,7 +644,24 @@ namespace Codescene.VSExtension.Core.Application.Git
                 return false;
             }
 
-            return GitPathHelper.IsPathUnderAnyRoot(e.FullPath, _workspacePaths);
+            if (!GitPathHelper.IsPathUnderAnyRoot(e.FullPath, _workspacePaths))
+            {
+                return false;
+            }
+
+            WorkspaceActivityTracker.MarkActivity();
+            return true;
+        }
+
+        private void EnsureGitIgnoreWatcherInitialized()
+        {
+            if (string.IsNullOrEmpty(_gitRootPath) || !Directory.Exists(_gitRootPath))
+            {
+                return;
+            }
+
+            var probePath = Path.Combine(_gitRootPath, ".gitignore");
+            _gitService.IsFileIgnored(probePath);
         }
 
         private async Task ProcessEventAsync(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration = null, CancellationToken cancellationToken = default)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/WorkspaceActivityTracker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/WorkspaceActivityTracker.cs
@@ -1,0 +1,26 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+namespace Codescene.VSExtension.Core.Application.Git
+{
+    public static class WorkspaceActivityTracker
+    {
+        private static bool _activitySinceLastScan;
+
+        public static void MarkActivity()
+        {
+            _activitySinceLastScan = true;
+        }
+
+        public static bool ConsumeActivity()
+        {
+            var hadActivity = _activitySinceLastScan;
+            _activitySinceLastScan = false;
+            return hadActivity;
+        }
+
+        public static void Reset()
+        {
+            _activitySinceLastScan = false;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitChangeLister.cs
@@ -19,6 +19,8 @@ namespace Codescene.VSExtension.Core.Interfaces.Git
 
         void SetWorkspacePaths(IReadOnlyCollection<string> workspacePaths);
 
+        void MarkDirty();
+
         void StartPeriodicScanning(CancellationToken cancellationToken);
 
         void StopPeriodicScanning();

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitService.cs
@@ -6,6 +6,8 @@ namespace Codescene.VSExtension.Core.Interfaces.Git
 {
     public interface IGitService : IDisposable
     {
+        event EventHandler GitIgnoreChanged;
+
         string GetFileContentForCommit(string path);
 
         bool IsFileIgnored(string filePath);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitService.cs
@@ -18,7 +18,7 @@ public class GitService : IGitService, IDisposable
 
     private readonly LibGit2SharpIgnoreChecker _ignoreChecker;
     private readonly CachingGitIgnoreChecker _cachingIgnoreChecker;
-    private FileSystemWatcher _gitignoreWatcher;
+    private GitIgnoreWatcher _gitignoreWatcher;
     private string _watchedRepoRoot;
 
     [ImportingConstructor]
@@ -28,6 +28,8 @@ public class GitService : IGitService, IDisposable
         _ignoreChecker = new LibGit2SharpIgnoreChecker(logger);
         _cachingIgnoreChecker = new CachingGitIgnoreChecker(_ignoreChecker);
     }
+
+    public event EventHandler GitIgnoreChanged;
 
     // TODO: Move to helper
     public static string GetRelativePath(string basePath, string fullPath)
@@ -155,6 +157,7 @@ public class GitService : IGitService, IDisposable
     {
         _gitignoreWatcher?.Dispose();
         _gitignoreWatcher = null;
+        _watchedRepoRoot = null;
     }
 
     // TODO: Move to helper
@@ -204,22 +207,14 @@ public class GitService : IGitService, IDisposable
             return;
         }
 
-        _gitignoreWatcher = new FileSystemWatcher(repoRoot)
-        {
-            Filter = ".gitignore",
-            IncludeSubdirectories = true,
-            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.CreationTime,
-        };
-
-        _gitignoreWatcher.Changed += OnGitignoreChanged;
-        _gitignoreWatcher.Created += OnGitignoreChanged;
-        _gitignoreWatcher.Deleted += OnGitignoreChanged;
-        _gitignoreWatcher.EnableRaisingEvents = true;
+        _gitignoreWatcher = new GitIgnoreWatcher(repoRoot, _logger);
+        _gitignoreWatcher.GitIgnoreChanged += OnGitignoreChanged;
     }
 
-    private void OnGitignoreChanged(object sender, FileSystemEventArgs e)
+    private void OnGitignoreChanged(object sender, EventArgs e)
     {
         ClearCache();
+        GitIgnoreChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private void ClearCache()


### PR DESCRIPTION
## Summary
- Make the 9s `GitChangeLister` periodic scan cheap by skipping idle ticks and unchanged file sets, with `MarkDirty`/workspace-activity wiring for out-of-IDE changes.
- Skip already-cached files in `FileChangeHandler` before `ReviewWithDeltaAsync` to avoid redundant disk/git/CLI work on periodic re-processing.
- Prioritize open/visible documents when enqueueing detected changed files.
- Consolidate duplicate `.gitignore` watchers into shared `GitService` with `GitIgnoreChanged`.

Ports the highest-impact fixes from VS Code CS-11648. ClickUp: [CS-11658](https://app.clickup.com/t/86caecf5f).

## Test plan
- [x] `make iter` (unit tests + CodeScene delta gate)
- [ ] Open a solution on a high-diff branch; confirm CPU drops after initial reviews settle
- [ ] Confirm open editor tabs get diagnostics before background changed files
- [ ] Confirm `git pull` / external file edits still trigger reviews on next scan or watcher event

Made with [Cursor](https://cursor.com)