### PR TITLE
feat: skip periodic GitChangeLister when VS window is not focused

### DIFF
--- a/.claude/skills/commit.skill.md
+++ b/.claude/skills/commit.skill.md
@@ -1,0 +1,15 @@
+# commit
+
+Create a git commit using Conventional Commits format.
+
+## Instructions
+
+1. Run `git status` and `git diff` to see what needs to be committed
+2. Run `git add` on specific files as needed
+3. Run `git diff --staged` to see what will be committed
+4. Analyze the changes and draft a Conventional Commits message
+5. Keep the message body concise - explain the what/why, not the how. Don't repeat what's already visible in the diff
+6, Ensure that the message body is wrapped at approximately 80 columns
+7. Surround all code references in backticks
+8. Create the commit
+9. Run `make lint`.

--- a/.claude/skills/commit.skill.md
+++ b/.claude/skills/commit.skill.md
@@ -12,4 +12,3 @@ Create a git commit using Conventional Commits format.
 6, Ensure that the message body is wrapped at approximately 80 columns
 7. Surround all code references in backticks
 8. Create the commit
-9. Run `make lint`.

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorTestBase.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorTestBase.cs
@@ -323,6 +323,21 @@ namespace Codescene.VSExtension.Core.Tests
             }
         }
 
+        protected class FakeIdeActivityTracker : IIdeActivityTracker
+        {
+            private bool _isActive = true;
+
+            public bool IsIdeWindowActive()
+            {
+                return _isActive;
+            }
+
+            public void SetActiveForTesting(bool active)
+            {
+                _isActive = active;
+            }
+        }
+
         protected class TestableGitChangeDetector : GitChangeDetector
         {
             public TestableGitChangeDetector(ILogger logger, ISupportedFileChecker supportedFileChecker, IGitService gitService)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerEdgeCasesTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerEdgeCasesTests.cs
@@ -187,5 +187,72 @@ namespace Codescene.VSExtension.Core.Tests
 
             Assert.IsNotNull(result, "Should handle corrupted main branch gracefully");
         }
+
+        [TestMethod]
+        public async Task PeriodicScanAsync_SkipsWhenIdeWindowNotFocused()
+        {
+            var activityTracker = new FakeIdeActivityTracker();
+            activityTracker.SetActiveForTesting(false);
+
+            var testableInstance = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                activityTracker);
+
+            try
+            {
+                testableInstance.Initialize(_testRepoPath, new[] { _testRepoPath });
+
+                var newFile = Path.Combine(_testRepoPath, "should-not-scan.cs");
+                File.WriteAllText(newFile, "content");
+
+                var eventFired = false;
+                testableInstance.FilesDetected += (sender, files) => eventFired = true;
+
+                await testableInstance.InvokePeriodicScanAsync();
+
+                Assert.IsFalse(eventFired, "Should not fire event when IDE window not focused");
+            }
+            finally
+            {
+                testableInstance?.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task PeriodicScanAsync_ProceedsWhenIdeWindowFocused()
+        {
+            var activityTracker = new FakeIdeActivityTracker();
+            activityTracker.SetActiveForTesting(true);
+
+            var testableInstance = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                activityTracker);
+
+            try
+            {
+                testableInstance.Initialize(_testRepoPath, new[] { _testRepoPath });
+
+                var newFile = Path.Combine(_testRepoPath, "should-scan.cs");
+                File.WriteAllText(newFile, "content");
+
+                HashSet<string> detectedFiles = null;
+                testableInstance.FilesDetected += (sender, files) => detectedFiles = files;
+
+                await testableInstance.InvokePeriodicScanAsync();
+
+                Assert.IsNotNull(detectedFiles, "Should fire event when IDE window is focused");
+                Assert.Contains(newFile, detectedFiles, "Should detect the new file");
+            }
+            finally
+            {
+                testableInstance?.Dispose();
+            }
+        }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TestableGitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TestableGitChangeLister.cs
@@ -13,8 +13,9 @@ namespace Codescene.VSExtension.Core.Tests
             ISavedFilesTracker savedFilesTracker,
             ISupportedFileChecker supportedFileChecker,
             ILogger logger,
-            IGitService gitService)
-            : base(savedFilesTracker, supportedFileChecker, logger, gitService)
+            IGitService gitService,
+            IIdeActivityTracker ideActivityTracker = null)
+            : base(savedFilesTracker, supportedFileChecker, logger, gitService, ideActivityTracker: ideActivityTracker)
         {
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
@@ -23,6 +23,7 @@ namespace Codescene.VSExtension.Core.Application.Git
         private readonly ISupportedFileChecker _supportedFileChecker;
         private readonly ILogger _logger;
         private readonly IGitService _gitService;
+        private readonly IIdeActivityTracker _ideActivityTracker;
         private readonly UntrackedFileProcessor _untrackedFileProcessor;
         private readonly MergeBaseFinder _mergeBaseFinder;
 
@@ -37,12 +38,14 @@ namespace Codescene.VSExtension.Core.Application.Git
             ISupportedFileChecker supportedFileChecker,
             ILogger logger,
             IGitService gitService,
-            int? pollingInterval = null)
+            int? pollingInterval = null,
+            IIdeActivityTracker ideActivityTracker = null)
         {
             _savedFilesTracker = savedFilesTracker ?? throw new ArgumentNullException(nameof(savedFilesTracker));
             _supportedFileChecker = supportedFileChecker ?? throw new ArgumentNullException(nameof(supportedFileChecker));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
+            _ideActivityTracker = ideActivityTracker;
             _untrackedFileProcessor = new UntrackedFileProcessor(_gitService, logger);
             _mergeBaseFinder = new MergeBaseFinder(logger);
             if (pollingInterval.HasValue && pollingInterval.Value <= 0)
@@ -332,6 +335,11 @@ namespace Codescene.VSExtension.Core.Application.Git
         {
             try
             {
+                if (!ShouldRunPeriodicScan())
+                {
+                    return;
+                }
+
                 _logger?.Info("Starting scheduled git change review");
                 cancellationToken.ThrowIfCancellationRequested();
                 var didCleanup = ReviewCacheCleanup.CleanupCaches(_gitRootPath);
@@ -360,6 +368,16 @@ namespace Codescene.VSExtension.Core.Application.Git
             {
                 _logger?.Error("GitChangeLister: Error during periodic scan", ex);
             }
+        }
+
+        private bool ShouldRunPeriodicScan()
+        {
+            if (_ideActivityTracker != null && !_ideActivityTracker.IsIdeWindowActive())
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private bool IsValidGitRoot(string gitRootPath)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/IIdeActivityTracker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/IIdeActivityTracker.cs
@@ -1,0 +1,11 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+namespace Codescene.VSExtension.Core.Interfaces
+{
+    public interface IIdeActivityTracker
+    {
+        bool IsIdeWindowActive();
+
+        void SetActiveForTesting(bool active);
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Adapters/IdeActivityTracker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Adapters/IdeActivityTracker.cs
@@ -1,0 +1,69 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.ComponentModel.Composition;
+using Codescene.VSExtension.Core.Interfaces;
+using Microsoft.VisualStudio.Shell;
+
+namespace Codescene.VSExtension.VS2022.Application.Adapters
+{
+    [Export(typeof(IIdeActivityTracker))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public class IdeActivityTracker : IIdeActivityTracker
+    {
+        private bool? _testOverride;
+        private volatile bool _isWindowActive = true;
+        private bool _initialized;
+
+        public IdeActivityTracker()
+        {
+            InitializeOnUIThread();
+        }
+
+        public bool IsIdeWindowActive()
+        {
+            if (_testOverride.HasValue)
+            {
+                return _testOverride.Value;
+            }
+
+            return _isWindowActive;
+        }
+
+        public void SetActiveForTesting(bool active)
+        {
+            _testOverride = active;
+        }
+
+        private void InitializeOnUIThread()
+        {
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                if (_initialized)
+                {
+                    return;
+                }
+
+                var mainWindow = System.Windows.Application.Current?.MainWindow;
+                if (mainWindow != null)
+                {
+                    _isWindowActive = mainWindow.IsActive;
+                    mainWindow.Activated += OnWindowActivated;
+                    mainWindow.Deactivated += OnWindowDeactivated;
+                    _initialized = true;
+                }
+            }).FileAndForget("IdeActivityTracker/Initialize");
+        }
+
+        private void OnWindowActivated(object sender, System.EventArgs e)
+        {
+            _isWindowActive = true;
+        }
+
+        private void OnWindowDeactivated(object sender, System.EventArgs e)
+        {
+            _isWindowActive = false;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitChangeListerService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitChangeListerService.cs
@@ -17,8 +17,9 @@ namespace Codescene.VSExtension.VS2022.Application.Git
             ISavedFilesTracker savedFilesTracker,
             ISupportedFileChecker supportedFileChecker,
             ILogger logger,
-            IGitService gitService)
-            : base(savedFilesTracker, supportedFileChecker, logger, gitService)
+            IGitService gitService,
+            IIdeActivityTracker ideActivityTracker)
+            : base(savedFilesTracker, supportedFileChecker, logger, gitService, ideActivityTracker: ideActivityTracker)
         {
         }
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022.csproj
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Application\ErrorHandling\OutputPaneManager.cs" />
     <Compile Include="Application\ErrorListWindowHandler\ErrorListWindowHandler.cs" />
     <Compile Include="Application\ErrorListWindowHandler\HierarchyHelper.cs" />
+    <Compile Include="Application\Adapters\IdeActivityTracker.cs" />
     <Compile Include="Application\Adapters\VsAsyncTaskScheduler.cs" />
     <Compile Include="Application\Adapters\VsDocumentSaveEventSource.cs" />
     <Compile Include="Application\Adapters\VsOpenFilesObserver.cs" />


### PR DESCRIPTION
Ports codescene-vscode commit 1dc0ec06fbc9c22c10ea54179f647ab4abd953c5.

When the Visual Studio window loses focus, periodic git change scans are
skipped as a performance improvement. The `IdeActivityTracker` subscribes
to WPF `Activated`/`Deactivated` events on the UI thread and caches the
state for thread-safe access from background threads.

I verified with temp logging that it works as intended.