### PR TITLE
feat: dynamically increase GitChangeLister period based on execution time

### DIFF
--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -1,8 +1,8 @@
 {
     "rule_sets": [
         {
-            "matching_content_path": "**/*Tests.cs",
-            "matching_content_path_doc": "All test files - relaxed rules for test code",
+            "matching_content_path": "**/{*Tests,Testable*}.cs",
+            "matching_content_path_doc": "All test files and test helpers - relaxed rules for test code",
             "rules": [
                 {
                     "name": "Code Duplication",
@@ -26,6 +26,10 @@
                 },
                 {
                     "name": "Bumpy Road Ahead",
+                    "weight": 0.0
+                },
+                {
+                    "name": "Constructor Over-Injection",
                     "weight": 0.0
                 }
             ],

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DroppingScheduledExecutorDynamicIntervalTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DroppingScheduledExecutorDynamicIntervalTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using Codescene.VSExtension.Core.Application.Util;
+using Moq;
+
+namespace Codescene.VSExtension.Core.Tests;
+
+[TestClass]
+public class DroppingScheduledExecutorDynamicIntervalTests : DroppingScheduledExecutorTestBase
+{
+    [TestMethod]
+    public void GetInterval_ReturnsInitialInterval()
+    {
+        var interval = TimeSpan.FromSeconds(9);
+        _executor = new DroppingScheduledExecutor(ct => Task.CompletedTask, CancellationToken.None, interval, _mockLogger.Object);
+
+        Assert.AreEqual(interval, _executor.GetInterval());
+    }
+
+    [TestMethod]
+    public void SetInterval_UpdatesInterval()
+    {
+        var initialInterval = TimeSpan.FromSeconds(9);
+        var newInterval = TimeSpan.FromSeconds(20);
+        _executor = new DroppingScheduledExecutor(ct => Task.CompletedTask, CancellationToken.None, initialInterval, _mockLogger.Object);
+
+        _executor.SetInterval(newInterval);
+
+        Assert.AreEqual(newInterval, _executor.GetInterval());
+    }
+
+    [TestMethod]
+    public void SetInterval_CanSetSmallerInterval()
+    {
+        var initialInterval = TimeSpan.FromSeconds(9);
+        var smallerInterval = TimeSpan.FromSeconds(5);
+        _executor = new DroppingScheduledExecutor(ct => Task.CompletedTask, CancellationToken.None, initialInterval, _mockLogger.Object);
+
+        _executor.SetInterval(smallerInterval);
+
+        Assert.AreEqual(smallerInterval, _executor.GetInterval());
+    }
+
+    [TestMethod]
+    public void SetInterval_WhenDisposed_DoesNothing()
+    {
+        var initialInterval = TimeSpan.FromSeconds(9);
+        var newInterval = TimeSpan.FromSeconds(20);
+        _executor = new DroppingScheduledExecutor(ct => Task.CompletedTask, CancellationToken.None, initialInterval, _mockLogger.Object);
+
+        _executor.Dispose();
+        _executor.SetInterval(newInterval);
+
+        Assert.AreEqual(initialInterval, _executor.GetInterval());
+    }
+
+    [TestMethod]
+    public void SetInterval_LogsIntervalUpdate()
+    {
+        var initialInterval = TimeSpan.FromSeconds(9);
+        var newInterval = TimeSpan.FromSeconds(20);
+        _executor = new DroppingScheduledExecutor(ct => Task.CompletedTask, CancellationToken.None, initialInterval, _mockLogger.Object);
+
+        _executor.SetInterval(newInterval);
+
+        _mockLogger.Verify(l => l.Debug(It.Is<string>(s => s.Contains("interval updated to") && s.Contains("20"))), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task SetInterval_WhenRunning_RestartsTimerWithNewInterval()
+    {
+        var executionCount = 0;
+        var initialInterval = TimeSpan.FromMilliseconds(100);
+        var newInterval = TimeSpan.FromMilliseconds(50);
+        var thirdExecutionSignal = new TaskCompletionSource<bool>();
+
+        _executor = new DroppingScheduledExecutor(
+            async ct =>
+            {
+                await Task.CompletedTask;
+                executionCount++;
+                if (executionCount >= 3)
+                {
+                    thirdExecutionSignal.TrySetResult(true);
+                }
+            },
+            CancellationToken.None,
+            initialInterval,
+            _mockLogger.Object);
+
+        _executor.Start();
+        await Task.Delay(TimeSpan.FromMilliseconds(150));
+        Assert.IsGreaterThanOrEqualTo(executionCount, 1);
+
+        _executor.SetInterval(newInterval);
+        Assert.AreEqual(newInterval, _executor.GetInterval());
+
+        var timeoutTask = Task.Delay(TimeSpan.FromSeconds(5));
+        var completedTask = await Task.WhenAny(thirdExecutionSignal.Task, timeoutTask);
+        Assert.AreNotEqual(timeoutTask, completedTask, "Executor should continue running after interval change");
+    }
+
+    [TestMethod]
+    public void SetInterval_WhenNotStarted_UpdatesIntervalWithoutStartingTimer()
+    {
+        var initialInterval = TimeSpan.FromSeconds(9);
+        var newInterval = TimeSpan.FromSeconds(20);
+        _executor = new DroppingScheduledExecutor(ct => Task.CompletedTask, CancellationToken.None, initialInterval, _mockLogger.Object);
+
+        _executor.SetInterval(newInterval);
+
+        Assert.AreEqual(newInterval, _executor.GetInterval());
+        _mockLogger.Verify(l => l.Debug(It.Is<string>(s => s.Contains("started"))), Times.Never);
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorTestBase.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorTestBase.cs
@@ -168,6 +168,7 @@ namespace Codescene.VSExtension.Core.Tests
         protected class FakeLogger : ILogger
         {
             private readonly List<string> _debugMessages = new List<string>();
+            private readonly List<string> _infoMessages = new List<string>();
             private readonly List<string> _warnMessages = new List<string>();
             private readonly List<(string, Exception)> _errorMessages = new List<(string, Exception)>();
 
@@ -183,6 +184,10 @@ namespace Codescene.VSExtension.Core.Tests
 
             public void Info(string message, bool statusBar = false)
             {
+                lock (_lock)
+                {
+                    _infoMessages.Add(message);
+                }
             }
 
             public void Warn(string message, bool statusBar = false)
@@ -222,6 +227,14 @@ namespace Codescene.VSExtension.Core.Tests
                 lock (_lock)
                 {
                     return new List<string>(_debugMessages);
+                }
+            }
+
+            public List<string> SnapshotInfoMessages()
+            {
+                lock (_lock)
+                {
+                    return new List<string>(_infoMessages);
                 }
             }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerDynamicPeriodTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerDynamicPeriodTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class GitChangeListerDynamicPeriodTests : GitChangeDetectorTestBase
+    {
+        [TestMethod]
+        public async Task PeriodicScan_WhenSlowExecution_IncreasesPeriod()
+        {
+            var basePeriodSeconds = 1;
+            var simulatedDuration = TimeSpan.FromSeconds(2);
+            var testableLister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                pollingInterval: basePeriodSeconds);
+
+            testableLister.Initialize(_testRepoPath, new[] { _testRepoPath });
+            testableLister.StartPeriodicScanning(CancellationToken.None);
+
+            var executor = testableLister.GetScheduledExecutorForTesting();
+            Assert.IsNotNull(executor, "Scheduled executor should exist after StartPeriodicScanning");
+            var initialPeriod = executor.GetInterval();
+            Assert.AreEqual(TimeSpan.FromSeconds(basePeriodSeconds), initialPeriod);
+
+            CreateFile("test.cs", "content");
+            testableLister.SimulatedScanDuration = simulatedDuration;
+
+            await testableLister.InvokePeriodicScanAsync();
+
+            var newPeriod = executor.GetInterval();
+            var minExpectedPeriod = (basePeriodSeconds * 2) + simulatedDuration.TotalSeconds;
+            Assert.IsGreaterThan(
+                initialPeriod.TotalSeconds,
+                newPeriod.TotalSeconds,
+                $"Period should be increased from {initialPeriod.TotalSeconds}s, got {newPeriod.TotalSeconds}s");
+            Assert.IsGreaterThanOrEqualTo(
+                minExpectedPeriod,
+                newPeriod.TotalSeconds,
+                $"Period should be at least {minExpectedPeriod}s, got {newPeriod.TotalSeconds}s");
+
+            var infoMessages = _fakeLogger.SnapshotDebugMessages();
+            Assert.IsTrue(
+                infoMessages.Exists(m => m.Contains("completed in")),
+                "Should log completion time");
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_WhenPeriodAlreadyHigher_DoesNotDecrease()
+        {
+            var basePeriodSeconds = 1;
+            var simulatedDuration = TimeSpan.FromSeconds(2);
+            var testableLister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                pollingInterval: basePeriodSeconds);
+
+            testableLister.Initialize(_testRepoPath, new[] { _testRepoPath });
+            testableLister.StartPeriodicScanning(CancellationToken.None);
+
+            var executor = testableLister.GetScheduledExecutorForTesting();
+            Assert.IsNotNull(executor);
+
+            var highPeriod = TimeSpan.FromSeconds(50);
+            executor.SetInterval(highPeriod);
+            Assert.AreEqual(highPeriod, executor.GetInterval());
+
+            CreateFile("test.cs", "content");
+            testableLister.SimulatedScanDuration = simulatedDuration;
+
+            await testableLister.InvokePeriodicScanAsync();
+
+            Assert.AreEqual(highPeriod, executor.GetInterval(), "Period should not decrease");
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_WhenFastExecution_KeepsBasePeriod()
+        {
+            var basePeriodSeconds = 5;
+            var testableLister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                pollingInterval: basePeriodSeconds);
+
+            testableLister.Initialize(_testRepoPath, new[] { _testRepoPath });
+            testableLister.StartPeriodicScanning(CancellationToken.None);
+
+            var executor = testableLister.GetScheduledExecutorForTesting();
+            Assert.IsNotNull(executor);
+            var initialPeriod = executor.GetInterval();
+            Assert.AreEqual(TimeSpan.FromSeconds(basePeriodSeconds), initialPeriod);
+
+            CreateFile("test.cs", "content");
+
+            await testableLister.InvokePeriodicScanAsync();
+
+            Assert.AreEqual(initialPeriod, executor.GetInterval(), "Period should remain unchanged for fast execution");
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_WhenExecutorNotStarted_DoesNotThrow()
+        {
+            var testableLister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                pollingInterval: 1);
+
+            testableLister.Initialize(_testRepoPath, new[] { _testRepoPath });
+
+            CreateFile("test.cs", "content");
+            testableLister.SimulatedScanDuration = TimeSpan.FromSeconds(2);
+
+            await testableLister.InvokePeriodicScanAsync();
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_LogsCompletionTime()
+        {
+            var testableLister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                pollingInterval: 5);
+
+            testableLister.Initialize(_testRepoPath, new[] { _testRepoPath });
+            testableLister.StartPeriodicScanning(CancellationToken.None);
+
+            CreateFile("test.cs", "content");
+
+            await testableLister.InvokePeriodicScanAsync();
+
+            var debugMessages = _fakeLogger.SnapshotDebugMessages();
+            Assert.IsTrue(
+                debugMessages.Exists(m => m.Contains("completed in") && m.Contains("s")),
+                "Should log completion time in debug messages");
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_WhenExceedsThreshold_LogsIncreaseMessage()
+        {
+            var basePeriodSeconds = 1;
+            var simulatedDuration = TimeSpan.FromSeconds(2);
+            var testableLister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                pollingInterval: basePeriodSeconds);
+
+            testableLister.Initialize(_testRepoPath, new[] { _testRepoPath });
+            testableLister.StartPeriodicScanning(CancellationToken.None);
+
+            CreateFile("test.cs", "content");
+            testableLister.SimulatedScanDuration = simulatedDuration;
+
+            await testableLister.InvokePeriodicScanAsync();
+
+            var infoMessages = _fakeLogger.SnapshotInfoMessages();
+            Assert.IsTrue(
+                infoMessages.Exists(m => m.Contains("increased period to")),
+                "Should log when period is increased");
+
+            testableLister.Dispose();
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TestableGitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TestableGitChangeLister.cs
@@ -1,6 +1,7 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using Codescene.VSExtension.Core.Application.Git;
+using Codescene.VSExtension.Core.Application.Util;
 using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Cli;
 using Codescene.VSExtension.Core.Interfaces.Git;
@@ -14,12 +15,25 @@ namespace Codescene.VSExtension.Core.Tests
             ISupportedFileChecker supportedFileChecker,
             ILogger logger,
             IGitService gitService,
-            IIdeActivityTracker ideActivityTracker = null)
+            IIdeActivityTracker ideActivityTracker)
             : base(savedFilesTracker, supportedFileChecker, logger, gitService, ideActivityTracker: ideActivityTracker)
         {
         }
 
+        public TestableGitChangeLister(
+            ISavedFilesTracker savedFilesTracker,
+            ISupportedFileChecker supportedFileChecker,
+            ILogger logger,
+            IGitService gitService,
+            int? pollingInterval = null,
+            IIdeActivityTracker ideActivityTracker = null)
+            : base(savedFilesTracker, supportedFileChecker, logger, gitService, pollingInterval, ideActivityTracker)
+        {
+        }
+
         public bool ThrowInGetAllChangedFilesAsync { get; set; }
+
+        public TimeSpan? SimulatedScanDuration { get; set; }
 
         public async Task InvokePeriodicScanAsync()
         {
@@ -50,7 +64,18 @@ namespace Codescene.VSExtension.Core.Tests
                 throw new Exception("Simulated exception in CollectFilesFromRepoStateAsync");
             }
 
+            if (SimulatedScanDuration.HasValue)
+            {
+                await Task.Delay(SimulatedScanDuration.Value, cancellationToken);
+            }
+
             return await base.GetAllChangedFilesAsync(gitRootPath, workspacePaths, cancellationToken);
+        }
+
+        public DroppingScheduledExecutor? GetScheduledExecutorForTesting()
+        {
+            var field = typeof(GitChangeLister).GetField("_scheduledExecutor", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            return field?.GetValue(this) as DroppingScheduledExecutor;
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
@@ -18,7 +18,8 @@ namespace Codescene.VSExtension.Core.Application.Git
 {
     public class GitChangeLister : IGitChangeLister, IDisposable
     {
-        private readonly int _pollingInterval = 9; // Default value, calculated based on core count.
+        private readonly int _basePollingInterval;
+        private readonly int _pollingInterval; // Calculated based on core count, may differ from base.
         private readonly ISavedFilesTracker _savedFilesTracker;
         private readonly ISupportedFileChecker _supportedFileChecker;
         private readonly ILogger _logger;
@@ -54,6 +55,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
 
             _pollingInterval = pollingInterval ?? CalculatePollingInterval();
+            _basePollingInterval = _pollingInterval;
         }
 
         public event EventHandler<HashSet<string>> FilesDetected;
@@ -333,6 +335,7 @@ namespace Codescene.VSExtension.Core.Application.Git
 
         private async Task PeriodicScanAsync(CancellationToken cancellationToken)
         {
+            var startTime = DateTime.UtcNow;
             try
             {
                 if (!ShouldRunPeriodicScan())
@@ -367,6 +370,28 @@ namespace Codescene.VSExtension.Core.Application.Git
             catch (Exception ex)
             {
                 _logger?.Error("GitChangeLister: Error during periodic scan", ex);
+            }
+            finally
+            {
+                AdjustIntervalIfNeeded(startTime);
+            }
+        }
+
+        private void AdjustIntervalIfNeeded(DateTime startTime)
+        {
+            var elapsedSeconds = (int)Math.Ceiling((DateTime.UtcNow - startTime).TotalSeconds);
+            _logger?.Debug($"Scheduled git change review completed in {elapsedSeconds}s");
+
+            var executor = _scheduledExecutor;
+            if (elapsedSeconds > _basePollingInterval && executor != null)
+            {
+                var newPeriodSeconds = (_basePollingInterval * 2) + elapsedSeconds;
+                var currentPeriodSeconds = (int)executor.GetInterval().TotalSeconds;
+                if (newPeriodSeconds > currentPeriodSeconds)
+                {
+                    executor.SetInterval(TimeSpan.FromSeconds(newPeriodSeconds));
+                    _logger?.Info($"Git change review took {elapsedSeconds}s, increased period to {newPeriodSeconds}s");
+                }
             }
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/DroppingScheduledExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/DroppingScheduledExecutor.cs
@@ -12,8 +12,9 @@ namespace Codescene.VSExtension.Core.Application.Util
         private readonly object _lock = new object();
         private readonly Func<CancellationToken, Task> _action;
         private readonly CancellationToken _cancellationToken;
-        private readonly TimeSpan _interval;
         private readonly ILogger _logger;
+
+        private TimeSpan _interval;
 
         private Timer _timer;
         private bool _isRunning;
@@ -57,6 +58,34 @@ namespace Codescene.VSExtension.Core.Application.Util
                 _timer?.Dispose();
                 _timer = null;
                 _logger.Debug("DroppingScheduledExecutor stopped");
+            }
+        }
+
+        public TimeSpan GetInterval()
+        {
+            lock (_lock)
+            {
+                return _interval;
+            }
+        }
+
+        public void SetInterval(TimeSpan newInterval)
+        {
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _interval = newInterval;
+                _logger.Debug($"DroppingScheduledExecutor interval updated to: {_interval.TotalSeconds}s");
+
+                if (_timer != null && !_stopped)
+                {
+                    _timer.Dispose();
+                    _timer = new Timer(OnTimerCallback, null, _interval, _interval);
+                }
             }
         }
 


### PR DESCRIPTION
When `GitChangeLister` calls take longer than the base period, the scheduler now dynamically increases its period to prevent excessive resource consumption. The new period is calculated as `basePeriod * 2 + elapsedSeconds` and only increases (never decreases) to avoid oscillation.

I tested manually that this works, using temp logging.

Ported from codescene-vscode commit 255f4f4.