### PR TITLE
 feat: skip GitChangeLister when analyses are running

### DIFF
--- a/.claude/skills/port.skill.md
+++ b/.claude/skills/port.skill.md
@@ -1,0 +1,15 @@
+# port
+
+Port a commit from ../codescene-vscode to this Visual Studio extension project.
+
+## Arguments
+
+- Commit SHA (required)
+
+## Instructions
+
+1. Run `git -C ../codescene-vscode show <sha>` to see the commit
+2. Port the changes faithfully while:
+   - Adding good test coverage
+   - Respecting VSSDK threading rules
+   - Honoring this project's customs (see CLAUDE.md)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerEdgeCasesTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerEdgeCasesTests.cs
@@ -1,6 +1,9 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using Codescene.VSExtension.Core.Application.Git;
+using Codescene.VSExtension.Core.Models;
+using Codescene.VSExtension.Core.Util;
+using WebComponentFile = Codescene.VSExtension.Core.Models.WebComponent.Data.File;
 
 namespace Codescene.VSExtension.Core.Tests
 {
@@ -19,6 +22,7 @@ namespace Codescene.VSExtension.Core.Tests
         public void CleanupLister()
         {
             _lister?.Dispose();
+            DeltaJobTracker.Clear();
         }
 
         [TestMethod]
@@ -252,6 +256,53 @@ namespace Codescene.VSExtension.Core.Tests
             finally
             {
                 testableInstance?.Dispose();
+            }
+        }
+
+        [TestMethod]
+        [DataRow(0, true, DisplayName = "proceeds when no analysis is running")]
+        [DataRow(1, false, DisplayName = "skips when analysis is running")]
+        public async Task PeriodicScanAsync_WhenAnalysisRunning_SkipsOrProceeds(int runningJobCount, bool expectEvent)
+        {
+            var jobs = new List<Job>();
+            for (int i = 0; i < runningJobCount; i++)
+            {
+                var job = new Job { Type = "deltaAnalysis", State = "running", File = new WebComponentFile { FileName = $"test{i}.cs" } };
+                DeltaJobTracker.Add(job);
+                jobs.Add(job);
+            }
+
+            var activityTracker = new FakeIdeActivityTracker();
+            activityTracker.SetActiveForTesting(true);
+
+            var testableInstance = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                activityTracker);
+
+            try
+            {
+                testableInstance.Initialize(_testRepoPath, new[] { _testRepoPath });
+
+                var newFile = Path.Combine(_testRepoPath, "analysis-check.cs");
+                System.IO.File.WriteAllText(newFile, "content");
+
+                var eventFired = false;
+                testableInstance.FilesDetected += (sender, files) => eventFired = true;
+
+                await testableInstance.InvokePeriodicScanAsync();
+
+                Assert.AreEqual(expectEvent, eventFired);
+            }
+            finally
+            {
+                testableInstance?.Dispose();
+                foreach (var job in jobs)
+                {
+                    DeltaJobTracker.Remove(job);
+                }
             }
         }
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
@@ -402,6 +402,12 @@ namespace Codescene.VSExtension.Core.Application.Git
                 return false;
             }
 
+            if (DeltaJobTracker.IsAnalysisRunning)
+            {
+                _logger?.Info("Skipping scheduled git change review: analysis in progress");
+                return false;
+            }
+
             return true;
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/DeltaJobTracker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Util/DeltaJobTracker.cs
@@ -19,6 +19,20 @@ namespace Codescene.VSExtension.Core.Util
         public static event Action<Job> JobFinished;
 
         /// <summary>
+        /// Gets a value indicating whether any delta analysis jobs are currently running.
+        /// </summary>
+        public static bool IsAnalysisRunning
+        {
+            get
+            {
+                lock (Running)
+                {
+                    return Running.Count > 0;
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets a thread-safe snapshot of all currently running delta jobs.
         /// </summary>
         public static IReadOnlyCollection<Job> RunningJobs


### PR DESCRIPTION
Prevents periodic git change scans when delta analyses are in progress, reducing unnecessary load since there's no point scanning for changes while actively processing them.

Port of codescene-vscode commit 11a73abf.

Verified manually.