### PR TITLE
feat: batch git ignore checks to reduce Repository overhead

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/BenchmarkSupport.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/BenchmarkSupport.cs
@@ -249,6 +249,11 @@ internal sealed class FixedGitService : IGitService
 
     public bool IsFileIgnored(string filePath) => false;
 
+    public HashSet<string> FilterIgnoredFiles(IEnumerable<string> absolutePaths)
+    {
+        return new HashSet<string>(absolutePaths, StringComparer.OrdinalIgnoreCase);
+    }
+
     public void Dispose()
     {
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestGitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestGitService.cs
@@ -1,5 +1,7 @@
 // Copyright (c) CodeScene. All rights reserved.
 
+using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Codescene.VSExtension.Core.Interfaces.Git;
 using Moq;
@@ -20,6 +22,11 @@ namespace Codescene.VSExtension.Core.IntegrationTests.TestImplementations
         public bool IsFileIgnored(string filePath)
         {
             return Mock.Object.IsFileIgnored(filePath);
+        }
+
+        public HashSet<string> FilterIgnoredFiles(IEnumerable<string> absolutePaths)
+        {
+            return new HashSet<string>(absolutePaths, StringComparer.OrdinalIgnoreCase);
         }
 
         public void Dispose()

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/BatchGitIgnoreCheckerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/BatchGitIgnoreCheckerTests.cs
@@ -254,55 +254,64 @@ namespace Codescene.VSExtension.Core.Tests
 
                 foreach (var group in pathsByRepo)
                 {
-                    var repoPath = group.Key;
-                    if (string.IsNullOrEmpty(repoPath))
-                    {
-                        result.UnionWith(group.Value);
-                        continue;
-                    }
-
-                    try
-                    {
-                        RepositoryOpenCount++;
-                        using (var repo = new Repository(repoPath))
-                        {
-                            var repoRoot = repo.Info.WorkingDirectory;
-                            if (string.IsNullOrEmpty(repoRoot))
-                            {
-                                result.UnionWith(group.Value);
-                                continue;
-                            }
-
-                            foreach (var absolutePath in group.Value)
-                            {
-                                if (IsInGitDirectory(absolutePath))
-                                {
-                                    continue;
-                                }
-
-                                var relativePath = GetRelativePath(repoRoot, absolutePath)
-                                    .Replace("\\", "/").Trim();
-
-                                if (string.IsNullOrEmpty(relativePath))
-                                {
-                                    relativePath = ".";
-                                }
-
-                                if (!repo.Ignore.IsPathIgnored(relativePath))
-                                {
-                                    result.Add(absolutePath);
-                                }
-                            }
-                        }
-                    }
-                    catch (LibGit2SharpException ex)
-                    {
-                        _logger.Warn($"BatchGitIgnoreChecker: LibGit2Sharp error for repo {repoPath}: {ex.Message}");
-                        result.UnionWith(group.Value);
-                    }
+                    FilterGroupByIgnoreStatus(group.Key, group.Value, result);
                 }
 
                 return result;
+            }
+
+            private static void FilterPathsInRepo(Repository repo, string repoRoot, List<string> paths, HashSet<string> result)
+            {
+                foreach (var absolutePath in paths)
+                {
+                    if (IsInGitDirectory(absolutePath))
+                    {
+                        continue;
+                    }
+
+                    var relativePath = GetRelativePath(repoRoot, absolutePath)
+                        .Replace("\\", "/").Trim();
+
+                    if (string.IsNullOrEmpty(relativePath))
+                    {
+                        relativePath = ".";
+                    }
+
+                    if (!repo.Ignore.IsPathIgnored(relativePath))
+                    {
+                        result.Add(absolutePath);
+                    }
+                }
+            }
+
+            private void FilterGroupByIgnoreStatus(string repoPath, List<string> paths, HashSet<string> result)
+            {
+                if (string.IsNullOrEmpty(repoPath))
+                {
+                    result.UnionWith(paths);
+                    return;
+                }
+
+                try
+                {
+                    RepositoryOpenCount++;
+                    using (var repo = new Repository(repoPath))
+                    {
+                        var repoRoot = repo.Info.WorkingDirectory;
+                        if (string.IsNullOrEmpty(repoRoot))
+                        {
+                            result.UnionWith(paths);
+                            return;
+                        }
+
+                        FilterPathsInRepo(repo, repoRoot, paths, result);
+                    }
+                }
+                catch (LibGit2SharpException ex)
+                {
+                    _logger.Warn($"BatchGitIgnoreChecker: LibGit2Sharp error for repo {repoPath}: {ex.Message}");
+                    result.UnionWith(paths);
+                }
             }
 
             private Dictionary<string, List<string>> GroupByRepository(List<string> paths)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/BatchGitIgnoreCheckerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/BatchGitIgnoreCheckerTests.cs
@@ -1,0 +1,329 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using Codescene.VSExtension.Core.Interfaces;
+using Codescene.VSExtension.Core.Interfaces.Git;
+using LibGit2Sharp;
+using Moq;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class BatchGitIgnoreCheckerTests
+    {
+        private string _testRepoPath = null!;
+        private Mock<ILogger> _mockLogger = null!;
+        private TestBatchGitIgnoreChecker _checker = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _testRepoPath = Path.Combine(Path.GetTempPath(), $"test-repo-{Guid.NewGuid()}");
+            Directory.CreateDirectory(_testRepoPath);
+
+            Repository.Init(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                repo.Config.Set("user.email", "test@example.com");
+                repo.Config.Set("user.name", "Test User");
+            }
+
+            _mockLogger = new Mock<ILogger>();
+            _checker = new TestBatchGitIgnoreChecker(_mockLogger.Object);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _checker = null!;
+            if (Directory.Exists(_testRepoPath))
+            {
+                try
+                {
+                    ForceDeleteDirectory(_testRepoPath);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        [TestMethod]
+        public void FilterIgnored_EmptyInput_ReturnsEmptySet()
+        {
+            var result = _checker.FilterIgnored(Array.Empty<string>());
+
+            Assert.IsEmpty(result);
+        }
+
+        [TestMethod]
+        public void FilterIgnored_SingleNonIgnoredFile_ReturnsFile()
+        {
+            var filePath = Path.Combine(_testRepoPath, "test.cs");
+            File.WriteAllText(filePath, "content");
+
+            var result = _checker.FilterIgnored(new[] { filePath });
+
+            Assert.HasCount(1, result);
+            CollectionAssert.Contains(result.ToList(), filePath);
+        }
+
+        [TestMethod]
+        public void FilterIgnored_SingleIgnoredFile_FiltersOut()
+        {
+            File.WriteAllText(Path.Combine(_testRepoPath, ".gitignore"), "*.log\n");
+            var ignoredPath = Path.Combine(_testRepoPath, "test.log");
+            File.WriteAllText(ignoredPath, "content");
+
+            var result = _checker.FilterIgnored(new[] { ignoredPath });
+
+            Assert.IsEmpty(result);
+        }
+
+        [TestMethod]
+        public void FilterIgnored_MixedFiles_FiltersCorrectly()
+        {
+            File.WriteAllText(Path.Combine(_testRepoPath, ".gitignore"), "*.log\n");
+            var trackedPath = Path.Combine(_testRepoPath, "test.cs");
+            var ignoredPath = Path.Combine(_testRepoPath, "test.log");
+            File.WriteAllText(trackedPath, "content");
+            File.WriteAllText(ignoredPath, "content");
+
+            var result = _checker.FilterIgnored(new[] { trackedPath, ignoredPath });
+
+            Assert.HasCount(1, result);
+            CollectionAssert.Contains(result.ToList(), trackedPath);
+            CollectionAssert.DoesNotContain(result.ToList(), ignoredPath);
+        }
+
+        [TestMethod]
+        public void FilterIgnored_MultipleFilesFromSameRepo_UseSingleRepository()
+        {
+            var paths = new List<string>();
+            for (int i = 0; i < 10; i++)
+            {
+                var filePath = Path.Combine(_testRepoPath, $"file{i}.cs");
+                File.WriteAllText(filePath, "content");
+                paths.Add(filePath);
+            }
+
+            var result = _checker.FilterIgnored(paths);
+
+            Assert.HasCount(10, result);
+            Assert.AreEqual(1, _checker.RepositoryOpenCount, "Should reuse a single Repository instance");
+        }
+
+        [TestMethod]
+        public void FilterIgnored_FileInGitDirectory_FiltersOut()
+        {
+            var gitConfigPath = Path.Combine(_testRepoPath, ".git", "config");
+
+            var result = _checker.FilterIgnored(new[] { gitConfigPath });
+
+            Assert.IsEmpty(result);
+        }
+
+        [TestMethod]
+        public void FilterIgnored_NonRepoFile_PassesThrough()
+        {
+            var tempPath = Path.Combine(Path.GetTempPath(), $"non-repo-{Guid.NewGuid()}.cs");
+            try
+            {
+                File.WriteAllText(tempPath, "content");
+
+                var result = _checker.FilterIgnored(new[] { tempPath });
+
+                Assert.HasCount(1, result);
+                CollectionAssert.Contains(result.ToList(), tempPath);
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void FilterIgnored_CaseInsensitiveResult_ContainsOriginalPath()
+        {
+            var filePath = Path.Combine(_testRepoPath, "Test.cs");
+            File.WriteAllText(filePath, "content");
+
+            var result = _checker.FilterIgnored(new[] { filePath });
+
+            Assert.HasCount(1, result, "Should contain exactly one file");
+            Assert.AreEqual(1, result.Count(p => p.Equals(filePath, StringComparison.OrdinalIgnoreCase)), "Should contain the path (case-insensitive match)");
+            Assert.AreEqual(1, result.Count(p => p.Equals(filePath.ToLower(), StringComparison.OrdinalIgnoreCase)), "Lowercase lookup should match");
+            Assert.AreEqual(1, result.Count(p => p.Equals(filePath.ToUpper(), StringComparison.OrdinalIgnoreCase)), "Uppercase lookup should match");
+        }
+
+        private static void ForceDeleteDirectory(string path)
+        {
+            foreach (var file in Directory.GetFiles(path, "*", SearchOption.AllDirectories))
+            {
+                File.SetAttributes(file, FileAttributes.Normal);
+            }
+
+            Directory.Delete(path, true);
+        }
+
+        private static string? TryDiscoverRepositoryPath(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                return null;
+            }
+
+            try
+            {
+                return Repository.Discover(filePath);
+            }
+            catch (LibGit2SharpException)
+            {
+                return null;
+            }
+        }
+
+        private static bool IsInGitDirectory(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return false;
+            }
+
+            var separator = Path.DirectorySeparatorChar;
+            var gitDirPattern = separator + ".git" + separator;
+
+            return filePath.IndexOf(gitDirPattern, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private static string GetRelativePath(string basePath, string fullPath)
+        {
+            if (string.IsNullOrEmpty(basePath) || string.IsNullOrEmpty(fullPath))
+            {
+                return fullPath;
+            }
+
+            try
+            {
+                var baseUri = new Uri(AppendDirectorySeparatorChar(basePath));
+                var fullUri = new Uri(fullPath);
+                var relativeUri = baseUri.MakeRelativeUri(fullUri);
+                return Uri.UnescapeDataString(relativeUri.ToString()).Replace('/', Path.DirectorySeparatorChar);
+            }
+            catch
+            {
+                return fullPath;
+            }
+        }
+
+        private static string AppendDirectorySeparatorChar(string path)
+        {
+            if (!path.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            {
+                return path + Path.DirectorySeparatorChar;
+            }
+
+            return path;
+        }
+
+        private class TestBatchGitIgnoreChecker : IBatchGitIgnoreChecker
+        {
+            private readonly ILogger _logger;
+
+            public TestBatchGitIgnoreChecker(ILogger logger)
+            {
+                _logger = logger;
+            }
+
+            public int RepositoryOpenCount { get; private set; }
+
+            public HashSet<string> FilterIgnored(IEnumerable<string> absolutePaths)
+            {
+                var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var pathList = absolutePaths.ToList();
+
+                if (pathList.Count == 0)
+                {
+                    return result;
+                }
+
+                var pathsByRepo = GroupByRepository(pathList);
+
+                foreach (var group in pathsByRepo)
+                {
+                    var repoPath = group.Key;
+                    if (string.IsNullOrEmpty(repoPath))
+                    {
+                        result.UnionWith(group.Value);
+                        continue;
+                    }
+
+                    try
+                    {
+                        RepositoryOpenCount++;
+                        using (var repo = new Repository(repoPath))
+                        {
+                            var repoRoot = repo.Info.WorkingDirectory;
+                            if (string.IsNullOrEmpty(repoRoot))
+                            {
+                                result.UnionWith(group.Value);
+                                continue;
+                            }
+
+                            foreach (var absolutePath in group.Value)
+                            {
+                                if (IsInGitDirectory(absolutePath))
+                                {
+                                    continue;
+                                }
+
+                                var relativePath = GetRelativePath(repoRoot, absolutePath)
+                                    .Replace("\\", "/").Trim();
+
+                                if (string.IsNullOrEmpty(relativePath))
+                                {
+                                    relativePath = ".";
+                                }
+
+                                if (!repo.Ignore.IsPathIgnored(relativePath))
+                                {
+                                    result.Add(absolutePath);
+                                }
+                            }
+                        }
+                    }
+                    catch (LibGit2SharpException ex)
+                    {
+                        _logger.Warn($"BatchGitIgnoreChecker: LibGit2Sharp error for repo {repoPath}: {ex.Message}");
+                        result.UnionWith(group.Value);
+                    }
+                }
+
+                return result;
+            }
+
+            private Dictionary<string, List<string>> GroupByRepository(List<string> paths)
+            {
+                var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var path in paths)
+                {
+                    var repoPath = TryDiscoverRepositoryPath(path);
+                    var key = repoPath ?? string.Empty;
+
+                    if (!result.ContainsKey(key))
+                    {
+                        result[key] = new List<string>();
+                    }
+
+                    result[key].Add(path);
+                }
+
+                return result;
+            }
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
@@ -406,6 +406,31 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public async Task CollectFilesFromRepoStateAsync_IgnoredFilesExcluded()
+        {
+            var trackedFile = Path.Combine(_testRepoPath, "tracked.cs");
+            var ignoredFile = Path.Combine(_testRepoPath, "tracked.ignored");
+            CommitFile("tracked.cs", "original", "Add tracked file");
+            CommitFile("tracked.ignored", "original", "Add ignored file");
+
+            var gitignorePath = Path.Combine(_testRepoPath, ".gitignore");
+            File.WriteAllText(gitignorePath, "*.ignored\n");
+
+            File.WriteAllText(trackedFile, "modified content");
+            File.WriteAllText(ignoredFile, "modified content");
+
+            var gitServiceWithIgnore = new FakeGitServiceWithGitignoreSupport(_testRepoPath);
+            using (var listerWithIgnore = new GitChangeLister(_fakeSavedFilesTracker, _fakeSupportedFileChecker, _fakeLogger, gitServiceWithIgnore))
+            {
+                var result = await listerWithIgnore.CollectFilesFromRepoStateAsync(_testRepoPath, new[] { _testRepoPath });
+
+                Assert.HasCount(1, result, "Should only include the non-ignored file");
+                Assert.Contains(trackedFile, result, "Should contain the non-ignored file");
+                Assert.DoesNotContain(ignoredFile, result, "Should not contain the ignored file");
+            }
+        }
+
+        [TestMethod]
         public async Task GetAllChangedFilesAsync_IgnoredFilesDoNotCountTowardThreshold()
         {
             var subdir = Path.Combine(_testRepoPath, "threshold-test");

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
@@ -404,5 +404,64 @@ namespace Codescene.VSExtension.Core.Tests
 
             _lister.StartPeriodicScanning(CancellationToken.None);
         }
+
+        [TestMethod]
+        public async Task GetAllChangedFilesAsync_IgnoredFilesDoNotCountTowardThreshold()
+        {
+            var subdir = Path.Combine(_testRepoPath, "threshold-test");
+            Directory.CreateDirectory(subdir);
+
+            var gitignorePath = Path.Combine(_testRepoPath, ".gitignore");
+            File.WriteAllText(gitignorePath, "threshold-test/ignored*.cs\n");
+
+            for (int i = 0; i < 3; i++)
+            {
+                File.WriteAllText(Path.Combine(subdir, $"ignored{i}.cs"), $"ignored {i}");
+            }
+
+            for (int i = 0; i < 4; i++)
+            {
+                File.WriteAllText(Path.Combine(subdir, $"tracked{i}.cs"), $"tracked {i}");
+            }
+
+            var gitServiceWithIgnore = new FakeGitServiceWithGitignoreSupport(_testRepoPath);
+            using (var listerWithIgnore = new GitChangeLister(_fakeSavedFilesTracker, _fakeSupportedFileChecker, _fakeLogger, gitServiceWithIgnore))
+            {
+                var result = await listerWithIgnore.GetAllChangedFilesAsync(_testRepoPath, _testRepoPath);
+
+                Assert.HasCount(4, result, "Should include all 4 non-ignored files (under threshold of 5)");
+                Assert.IsTrue(result.All(f => f.Contains("tracked")), "All returned files should be non-ignored tracked files");
+                Assert.IsFalse(result.Any(f => f.Contains("ignored")), "No ignored files should be returned");
+            }
+        }
+
+        [TestMethod]
+        public async Task GetAllChangedFilesAsync_IgnoredFilesExcludedFromThresholdCalculation_AllowsMoreFiles()
+        {
+            var subdir = Path.Combine(_testRepoPath, "threshold-calc");
+            Directory.CreateDirectory(subdir);
+
+            var gitignorePath = Path.Combine(_testRepoPath, ".gitignore");
+            File.WriteAllText(gitignorePath, "threshold-calc/ignored*.cs\n");
+
+            for (int i = 0; i < 5; i++)
+            {
+                File.WriteAllText(Path.Combine(subdir, $"ignored{i}.cs"), $"ignored {i}");
+            }
+
+            for (int i = 0; i < 5; i++)
+            {
+                File.WriteAllText(Path.Combine(subdir, $"real{i}.cs"), $"real {i}");
+            }
+
+            var gitServiceWithIgnore = new FakeGitServiceWithGitignoreSupport(_testRepoPath);
+            using (var listerWithIgnore = new GitChangeLister(_fakeSavedFilesTracker, _fakeSupportedFileChecker, _fakeLogger, gitServiceWithIgnore))
+            {
+                var result = await listerWithIgnore.GetAllChangedFilesAsync(_testRepoPath, _testRepoPath);
+
+                Assert.HasCount(5, result, "Should include all 5 non-ignored files (exactly at threshold)");
+                Assert.IsTrue(result.All(f => f.Contains("real")), "All returned files should be non-ignored files");
+            }
+        }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
@@ -279,6 +279,11 @@ namespace Codescene.VSExtension.Core.Tests
             return false;
         }
 
+        public HashSet<string> FilterIgnoredFiles(IEnumerable<string> absolutePaths)
+        {
+            return new HashSet<string>(absolutePaths, StringComparer.OrdinalIgnoreCase);
+        }
+
         public string GetBranchCreationCommit(string path, LibGit2Sharp.Repository repository)
         {
             return string.Empty;
@@ -306,6 +311,20 @@ namespace Codescene.VSExtension.Core.Tests
         public bool IsFileIgnored(string filePath)
         {
             return string.Equals(filePath, _ignoredPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public HashSet<string> FilterIgnoredFiles(IEnumerable<string> absolutePaths)
+        {
+            var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var path in absolutePaths)
+            {
+                if (!IsFileIgnored(path))
+                {
+                    result.Add(path);
+                }
+            }
+
+            return result;
         }
 
         public string GetBranchCreationCommit(string path, LibGit2Sharp.Repository repository)
@@ -357,6 +376,20 @@ namespace Codescene.VSExtension.Core.Tests
             {
                 return false;
             }
+        }
+
+        public HashSet<string> FilterIgnoredFiles(IEnumerable<string> absolutePaths)
+        {
+            var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var path in absolutePaths)
+            {
+                if (!IsFileIgnored(path))
+                {
+                    result.Add(path);
+                }
+            }
+
+            return result;
         }
 
         public string GetBranchCreationCommit(string path, LibGit2Sharp.Repository repository)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/UntrackedFileProcessorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/UntrackedFileProcessorTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using Codescene.VSExtension.Core.Application.Git;
-using Codescene.VSExtension.Core.Interfaces.Git;
-using Moq;
 
 namespace Codescene.VSExtension.Core.Tests
 {
@@ -10,14 +8,11 @@ namespace Codescene.VSExtension.Core.Tests
     public class UntrackedFileProcessorTests
     {
         private UntrackedFileProcessor _processor;
-        private Mock<IGitService> _mockGitService;
 
         [TestInitialize]
         public void Setup()
         {
-            _mockGitService = new Mock<IGitService>();
-            _mockGitService.Setup(x => x.IsFileIgnored(It.IsAny<string>())).Returns(false);
-            _processor = new UntrackedFileProcessor(_mockGitService.Object);
+            _processor = new UntrackedFileProcessor();
         }
 
         [TestMethod]
@@ -84,20 +79,6 @@ namespace Codescene.VSExtension.Core.Tests
             Assert.IsTrue(untrackedByDirectory.ContainsKey("tests"));
             Assert.HasCount(1, untrackedByDirectory["src"]);
             Assert.HasCount(1, untrackedByDirectory["tests"]);
-        }
-
-        [TestMethod]
-        public void AddUntrackedFilesToDirectory_IgnoredFile_ShouldNotAdd()
-        {
-            var untrackedByDirectory = new Dictionary<string, List<string>>();
-            var relativePath = @"src\File1.cs";
-            var absolutePath = @"C:\project\src\File1.cs";
-
-            _mockGitService.Setup(x => x.IsFileIgnored(absolutePath)).Returns(true);
-
-            _processor.AddUntrackedFileToDirectory(relativePath, absolutePath, untrackedByDirectory);
-
-            Assert.IsEmpty(untrackedByDirectory);
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
@@ -183,8 +183,6 @@ namespace Codescene.VSExtension.Core.Application.Git
                 AddNonIgnoredUntrackedFiles(untrackedCandidates, nonIgnoredUntracked, untrackedByDirectory);
 
                 _untrackedFileProcessor.ProcessUntrackedDirectories(untrackedByDirectory, savedFiles, changedFiles);
-                var notIgnored = _gitService.FilterIgnoredFiles(changedFiles);
-                changedFiles.IntersectWith(notIgnored);
 #if FEATURE_INITIAL_GIT_OBSERVER
                 _logger?.Info($">>> GitChangeLister: CollectFilesFromRepoState collected {changedFiles.Count} files from repo state");
 #endif

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Codescene.VSExtension.Core.Application.Cache.Review;
@@ -47,7 +48,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
             _ideActivityTracker = ideActivityTracker;
-            _untrackedFileProcessor = new UntrackedFileProcessor(_gitService, logger);
+            _untrackedFileProcessor = new UntrackedFileProcessor(logger);
             _mergeBaseFinder = new MergeBaseFinder(logger);
             if (pollingInterval.HasValue && pollingInterval.Value <= 0)
             {
@@ -172,37 +173,18 @@ namespace Codescene.VSExtension.Core.Application.Git
                 var untrackedByDirectory = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
                 var savedFiles = new HashSet<string>(_savedFilesTracker.GetSavedFiles(), StringComparer.OrdinalIgnoreCase);
 
-                foreach (var item in status)
-                {
-                    if (ShouldSkipStatusItem(item))
-                    {
-                        continue;
-                    }
+                var (trackedCandidates, untrackedCandidates) = CategorizeStatusItems(status, gitRootPath, workspacePaths);
 
-                    var absolutePath = GitPathHelper.ConvertToAbsolutePath(item.FilePath, gitRootPath);
+                var nonIgnoredTracked = _gitService.FilterIgnoredFiles(trackedCandidates);
+                changedFiles.UnionWith(nonIgnoredTracked);
 
-                    if (!GitPathHelper.IsFileInWorkspace(item.FilePath, gitRootPath, workspacePaths) || !ShouldReviewFile(absolutePath))
-                    {
-                        continue;
-                    }
-
-                    if (_gitService.IsFileIgnored(absolutePath))
-                    {
-                        continue;
-                    }
-
-                    if (item.State == FileStatus.NewInWorkdir)
-                    {
-                        _untrackedFileProcessor.AddUntrackedFileToDirectory(item.FilePath, absolutePath, untrackedByDirectory);
-                    }
-                    else
-                    {
-                        changedFiles.Add(absolutePath);
-                    }
-                }
+                var untrackedAbsolutePaths = untrackedCandidates.Select(x => x.AbsolutePath);
+                var nonIgnoredUntracked = _gitService.FilterIgnoredFiles(untrackedAbsolutePaths);
+                AddNonIgnoredUntrackedFiles(untrackedCandidates, nonIgnoredUntracked, untrackedByDirectory);
 
                 _untrackedFileProcessor.ProcessUntrackedDirectories(untrackedByDirectory, savedFiles, changedFiles);
-                changedFiles.RemoveWhere(path => _gitService.IsFileIgnored(path));
+                var notIgnored = _gitService.FilterIgnoredFiles(changedFiles);
+                changedFiles.IntersectWith(notIgnored);
 #if FEATURE_INITIAL_GIT_OBSERVER
                 _logger?.Info($">>> GitChangeLister: CollectFilesFromRepoState collected {changedFiles.Count} files from repo state");
 #endif
@@ -235,22 +217,17 @@ namespace Codescene.VSExtension.Core.Application.Git
 
         protected HashSet<string> ConvertAndFilterPaths(IEnumerable<string> relativePaths, string gitRootPath)
         {
-            var result = new HashSet<string>();
+            var candidates = new List<string>();
             foreach (var relativePath in relativePaths)
             {
                 var absolutePath = GitPathHelper.ConvertToAbsolutePath(relativePath, gitRootPath);
-                if (!File.Exists(absolutePath) || _gitService.IsFileIgnored(absolutePath))
+                if (File.Exists(absolutePath) && ShouldReviewFile(absolutePath))
                 {
-                    continue;
-                }
-
-                if (ShouldReviewFile(absolutePath))
-                {
-                    result.Add(absolutePath);
+                    candidates.Add(absolutePath);
                 }
             }
 
-            return result;
+            return _gitService.FilterIgnoredFiles(candidates);
         }
 
         /// <summary>
@@ -455,27 +432,44 @@ namespace Codescene.VSExtension.Core.Application.Git
             IReadOnlyCollection<string> workspacePaths)
         {
             var diff = repo.Diff.Compare<TreeChanges>(mergeBase.Tree, repo.Head.Tip.Tree);
-            var changedFiles = new HashSet<string>();
+            var candidates = CollectDiffCandidates(diff, gitRootPath, workspacePaths);
+
+            var candidatePaths = candidates.Select(c => c.FullPath);
+            var nonIgnored = _gitService.FilterIgnoredFiles(candidatePaths);
+
+            var changedFiles = new HashSet<string>(
+                candidates.Where(c => nonIgnored.Contains(c.FullPath)).Select(c => c.RelativePath));
+
+#if FEATURE_INITIAL_GIT_OBSERVER
+            _logger?.Info($">>> GitChangeLister: GetCommittedChanges found {changedFiles.Count} committed changes");
+#endif
+            return changedFiles;
+        }
+
+        private List<(string RelativePath, string FullPath)> CollectDiffCandidates(
+            TreeChanges diff,
+            string gitRootPath,
+            IReadOnlyCollection<string> workspacePaths)
+        {
+            var candidates = new List<(string RelativePath, string FullPath)>();
 
             foreach (var change in diff)
             {
                 var relativePath = change.Path;
                 var fullPath = Path.Combine(gitRootPath, relativePath);
-                if (!File.Exists(fullPath) || _gitService.IsFileIgnored(fullPath))
+
+                if (!File.Exists(fullPath))
                 {
                     continue;
                 }
 
                 if (GitPathHelper.IsFileInWorkspace(relativePath, gitRootPath, workspacePaths))
                 {
-                    changedFiles.Add(relativePath);
+                    candidates.Add((relativePath, fullPath));
                 }
             }
 
-#if FEATURE_INITIAL_GIT_OBSERVER
-            _logger?.Info($">>> GitChangeLister: GetCommittedChanges found {changedFiles.Count} committed changes");
-#endif
-            return changedFiles;
+            return candidates;
         }
 
         private bool ShouldSkipStatusItem(StatusEntry item)
@@ -551,6 +545,55 @@ namespace Codescene.VSExtension.Core.Application.Git
 
             _loggedNoMergeBaseWarnKeysByRepo[gitRoot] = stateKey;
             return true;
+        }
+
+        private (List<string> Tracked, List<(string RelativePath, string AbsolutePath)> Untracked) CategorizeStatusItems(
+            RepositoryStatus status,
+            string gitRootPath,
+            IReadOnlyCollection<string> workspacePaths)
+        {
+            var trackedCandidates = new List<string>();
+            var untrackedCandidates = new List<(string RelativePath, string AbsolutePath)>();
+
+            foreach (var item in status)
+            {
+                if (ShouldSkipStatusItem(item))
+                {
+                    continue;
+                }
+
+                var absolutePath = GitPathHelper.ConvertToAbsolutePath(item.FilePath, gitRootPath);
+
+                if (!GitPathHelper.IsFileInWorkspace(item.FilePath, gitRootPath, workspacePaths) || !ShouldReviewFile(absolutePath))
+                {
+                    continue;
+                }
+
+                if (item.State == FileStatus.NewInWorkdir)
+                {
+                    untrackedCandidates.Add((item.FilePath, absolutePath));
+                }
+                else
+                {
+                    trackedCandidates.Add(absolutePath);
+                }
+            }
+
+            return (trackedCandidates, untrackedCandidates);
+        }
+
+        private void AddNonIgnoredUntrackedFiles(
+            List<(string RelativePath, string AbsolutePath)> untrackedCandidates,
+            HashSet<string> nonIgnoredUntracked,
+            Dictionary<string, List<string>> untrackedByDirectory)
+        {
+            foreach (var candidate in untrackedCandidates)
+            {
+                if (nonIgnoredUntracked.Contains(candidate.AbsolutePath))
+                {
+                    _untrackedFileProcessor.AddUntrackedFileToDirectory(candidate.RelativePath, candidate.AbsolutePath, untrackedByDirectory);
+                }
+            }
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/UntrackedFileProcessor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/UntrackedFileProcessor.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Codescene.VSExtension.Core.Interfaces;
-using Codescene.VSExtension.Core.Interfaces.Git;
 
 namespace Codescene.VSExtension.Core.Application.Git
 {
@@ -12,11 +11,9 @@ namespace Codescene.VSExtension.Core.Application.Git
     {
         private const int MaxUntrackedFilesPerLocation = 5;
         private readonly ILogger _logger;
-        private readonly IGitService _gitService;
 
-        public UntrackedFileProcessor(IGitService gitService, ILogger logger = null)
+        public UntrackedFileProcessor(ILogger logger = null)
         {
-            _gitService = gitService;
             _logger = logger;
         }
 
@@ -25,11 +22,6 @@ namespace Codescene.VSExtension.Core.Application.Git
             string absolutePath,
             Dictionary<string, List<string>> untrackedByDirectory)
         {
-            if (_gitService.IsFileIgnored(absolutePath))
-            {
-                return;
-            }
-
             var directory = string.IsNullOrEmpty(Path.GetDirectoryName(relativePath)) ? "__root__" : Path.GetDirectoryName(relativePath);
 
             if (!untrackedByDirectory.ContainsKey(directory))

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IBatchGitIgnoreChecker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IBatchGitIgnoreChecker.cs
@@ -1,0 +1,11 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Codescene.VSExtension.Core.Interfaces.Git
+{
+    public interface IBatchGitIgnoreChecker
+    {
+        HashSet<string> FilterIgnored(IEnumerable<string> absolutePaths);
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 
 namespace Codescene.VSExtension.Core.Interfaces.Git
 {
@@ -9,5 +10,7 @@ namespace Codescene.VSExtension.Core.Interfaces.Git
         string GetFileContentForCommit(string path);
 
         bool IsFileIgnored(string filePath);
+
+        HashSet<string> FilterIgnoredFiles(IEnumerable<string> absolutePaths);
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/BatchGitIgnoreChecker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/BatchGitIgnoreChecker.cs
@@ -34,51 +34,7 @@ namespace Codescene.VSExtension.VS2022.Application.Git
 
             foreach (var group in pathsByRepo)
             {
-                var repoPath = group.Key;
-                if (string.IsNullOrEmpty(repoPath))
-                {
-                    result.UnionWith(group.Value);
-                    continue;
-                }
-
-                try
-                {
-                    using (var repo = new Repository(repoPath))
-                    {
-                        var repoRoot = repo.Info.WorkingDirectory;
-                        if (string.IsNullOrEmpty(repoRoot))
-                        {
-                            result.UnionWith(group.Value);
-                            continue;
-                        }
-
-                        foreach (var absolutePath in group.Value)
-                        {
-                            if (PathUtilities.IsInGitDirectory(absolutePath))
-                            {
-                                continue;
-                            }
-
-                            var relativePath = PathUtilities.GetRelativePath(repoRoot, absolutePath)
-                                .Replace("\\", "/").Trim();
-
-                            if (string.IsNullOrEmpty(relativePath))
-                            {
-                                relativePath = ".";
-                            }
-
-                            if (!repo.Ignore.IsPathIgnored(relativePath))
-                            {
-                                result.Add(absolutePath);
-                            }
-                        }
-                    }
-                }
-                catch (LibGit2SharpException ex)
-                {
-                    _logger.Warn($"BatchGitIgnoreChecker: LibGit2Sharp error for repo {repoPath}: {ex.Message}");
-                    result.UnionWith(group.Value);
-                }
+                FilterGroupByIgnoreStatus(group.Key, group.Value, result);
             }
 
             return result;
@@ -123,6 +79,59 @@ namespace Codescene.VSExtension.VS2022.Application.Git
             catch (LibGit2SharpException)
             {
                 return null;
+            }
+        }
+
+        private static void FilterPathsInRepo(Repository repo, string repoRoot, List<string> paths, HashSet<string> result)
+        {
+            foreach (var absolutePath in paths)
+            {
+                if (PathUtilities.IsInGitDirectory(absolutePath))
+                {
+                    continue;
+                }
+
+                var relativePath = PathUtilities.GetRelativePath(repoRoot, absolutePath)
+                    .Replace("\\", "/").Trim();
+
+                if (string.IsNullOrEmpty(relativePath))
+                {
+                    relativePath = ".";
+                }
+
+                if (!repo.Ignore.IsPathIgnored(relativePath))
+                {
+                    result.Add(absolutePath);
+                }
+            }
+        }
+
+        private void FilterGroupByIgnoreStatus(string repoPath, List<string> paths, HashSet<string> result)
+        {
+            if (string.IsNullOrEmpty(repoPath))
+            {
+                result.UnionWith(paths);
+                return;
+            }
+
+            try
+            {
+                using (var repo = new Repository(repoPath))
+                {
+                    var repoRoot = repo.Info.WorkingDirectory;
+                    if (string.IsNullOrEmpty(repoRoot))
+                    {
+                        result.UnionWith(paths);
+                        return;
+                    }
+
+                    FilterPathsInRepo(repo, repoRoot, paths, result);
+                }
+            }
+            catch (LibGit2SharpException ex)
+            {
+                _logger.Warn($"BatchGitIgnoreChecker: LibGit2Sharp error for repo {repoPath}: {ex.Message}");
+                result.UnionWith(paths);
             }
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/BatchGitIgnoreChecker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/BatchGitIgnoreChecker.cs
@@ -1,0 +1,149 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Codescene.VSExtension.Core.Application.Util;
+using Codescene.VSExtension.Core.Interfaces;
+using Codescene.VSExtension.Core.Interfaces.Git;
+using LibGit2Sharp;
+
+namespace Codescene.VSExtension.VS2022.Application.Git
+{
+    public class BatchGitIgnoreChecker : IBatchGitIgnoreChecker
+    {
+        private readonly ILogger _logger;
+
+        public BatchGitIgnoreChecker(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public HashSet<string> FilterIgnored(IEnumerable<string> absolutePaths)
+        {
+            var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var pathList = absolutePaths.ToList();
+
+            if (pathList.Count == 0)
+            {
+                return result;
+            }
+
+            var pathsByRepo = GroupByRepository(pathList);
+
+            foreach (var group in pathsByRepo)
+            {
+                var repoPath = group.Key;
+                if (string.IsNullOrEmpty(repoPath))
+                {
+                    result.UnionWith(group.Value);
+                    continue;
+                }
+
+                try
+                {
+                    using (var repo = new Repository(repoPath))
+                    {
+                        var repoRoot = repo.Info.WorkingDirectory;
+                        if (string.IsNullOrEmpty(repoRoot))
+                        {
+                            result.UnionWith(group.Value);
+                            continue;
+                        }
+
+                        foreach (var absolutePath in group.Value)
+                        {
+                            if (PathUtilities.IsInGitDirectory(absolutePath))
+                            {
+                                continue;
+                            }
+
+                            var relativePath = PathUtilities.GetRelativePath(repoRoot, absolutePath)
+                                .Replace("\\", "/").Trim();
+
+                            if (string.IsNullOrEmpty(relativePath))
+                            {
+                                relativePath = ".";
+                            }
+
+                            if (!repo.Ignore.IsPathIgnored(relativePath))
+                            {
+                                result.Add(absolutePath);
+                            }
+                        }
+                    }
+                }
+                catch (LibGit2SharpException ex)
+                {
+                    _logger.Warn($"BatchGitIgnoreChecker: LibGit2Sharp error for repo {repoPath}: {ex.Message}");
+                    result.UnionWith(group.Value);
+                }
+            }
+
+            return result;
+        }
+
+        private static string TryDiscoverRepositoryPath(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                return null;
+            }
+
+            var pathForDiscover = filePath;
+            if (Path.IsPathRooted(filePath))
+            {
+                try
+                {
+                    pathForDiscover = Path.GetFullPath(filePath);
+                }
+                catch (ArgumentException)
+                {
+                    return null;
+                }
+                catch (NotSupportedException)
+                {
+                    return null;
+                }
+                catch (PathTooLongException)
+                {
+                    return null;
+                }
+                catch (IOException)
+                {
+                    pathForDiscover = filePath;
+                }
+            }
+
+            try
+            {
+                return Repository.Discover(pathForDiscover);
+            }
+            catch (LibGit2SharpException)
+            {
+                return null;
+            }
+        }
+
+        private Dictionary<string, List<string>> GroupByRepository(List<string> paths)
+        {
+            var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var path in paths)
+            {
+                var repoPath = TryDiscoverRepositoryPath(path);
+                var key = repoPath ?? string.Empty;
+
+                if (!result.ContainsKey(key))
+                {
+                    result[key] = new List<string>();
+                }
+
+                result[key].Add(path);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
@@ -18,6 +19,7 @@ public class GitService : IGitService, IDisposable
 
     private readonly LibGit2SharpIgnoreChecker _ignoreChecker;
     private readonly CachingGitIgnoreChecker _cachingIgnoreChecker;
+    private readonly BatchGitIgnoreChecker _batchIgnoreChecker;
     private FileSystemWatcher _gitignoreWatcher;
     private string _watchedRepoRoot;
 
@@ -27,6 +29,7 @@ public class GitService : IGitService, IDisposable
         _logger = logger;
         _ignoreChecker = new LibGit2SharpIgnoreChecker(logger);
         _cachingIgnoreChecker = new CachingGitIgnoreChecker(_ignoreChecker);
+        _batchIgnoreChecker = new BatchGitIgnoreChecker(logger);
     }
 
     // TODO: Move to helper
@@ -149,6 +152,11 @@ public class GitService : IGitService, IDisposable
             _logger.Error($"Could not check if file is ignored: {ex.Message}", ex);
             return false;
         }
+    }
+
+    public HashSet<string> FilterIgnoredFiles(IEnumerable<string> absolutePaths)
+    {
+        return _batchIgnoreChecker.FilterIgnored(absolutePaths);
     }
 
     public void Dispose()

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022.csproj
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Application\Git\GitService.cs" />
     <Compile Include="Application\Git\IGitChangeObserver.cs" />
     <Compile Include="Application\Git\SolutionProjectDiscovery.cs" />
+    <Compile Include="Application\Git\BatchGitIgnoreChecker.cs" />
     <Compile Include="Application\Git\LibGit2SharpIgnoreChecker.cs" />
     <Compile Include="Application\Git\SavedFilesTracker.cs" />
     <Compile Include="Application\Services\AceAcknowledgementStateService.cs" />


### PR DESCRIPTION
`LibGit2SharpIgnoreChecker.IsPathIgnored()` opened a new Repository instance for each file, causing significant overhead in `GitChangeLister.CollectFilesFromRepoState()`. The new `BatchGitIgnoreChecker` groups files by repository and reuses a single Repository instance per batch.

Verified manually.