### PR TITLE
feat: skip `GitChangeLister` and `GitChangeObserver` on default branch

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingGitObservers.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingGitObservers.cs
@@ -34,10 +34,10 @@ public sealed class RecordingGitChangeLister : IGitChangeLister, IDisposable
         return _inner.GetChangedFilesVsMergeBaseAsync(gitRootPath, workspacePath, cancellationToken);
     }
 
-    public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths)
+    public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths, DefaultBranchGate? defaultBranchGate = null)
     {
         _journal.Record("lister.initialize", gitRootPath, $"workspaceCount={workspacePaths.Count}");
-        _inner.Initialize(gitRootPath, workspacePaths);
+        _inner.Initialize(gitRootPath, workspacePaths, defaultBranchGate);
     }
 
     public void SetWorkspacePaths(IReadOnlyCollection<string> workspacePaths)
@@ -63,6 +63,11 @@ public sealed class RecordingGitChangeLister : IGitChangeLister, IDisposable
         var files = await _inner.CollectFilesFromRepoStateAsync(gitRootPath, workspacePaths, cancellationToken);
         _journal.Record("lister.collect.completed", detail: $"count={files.Count}");
         return files;
+    }
+
+    public void InvalidateDefaultBranchCache()
+    {
+        _inner.InvalidateDefaultBranchCache();
     }
 
     public void Dispose()

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DefaultBranchGateTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DefaultBranchGateTests.cs
@@ -1,0 +1,311 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Diagnostics;
+using Codescene.VSExtension.Core.Application.Git;
+using LibGit2Sharp;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class DefaultBranchGateTests
+    {
+        private string _testRepoPath;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _testRepoPath = Path.Combine(Path.GetTempPath(), $"test-default-branch-gate-{Guid.NewGuid()}");
+            Directory.CreateDirectory(_testRepoPath);
+            Repository.Init(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                repo.Config.Set("user.email", "test@example.com");
+                repo.Config.Set("user.name", "Test User");
+            }
+
+            CommitFile("README.md", "# Test", "Initial commit");
+            ExecGit("branch -m main");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (Directory.Exists(_testRepoPath))
+            {
+                try
+                {
+                    Directory.Delete(_testRepoPath, true);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ShouldSkip_WhenRepoIsNull_ReturnsFalse()
+        {
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            var result = gate.ShouldSkip(null);
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void ShouldSkip_WhenCurrentBranchIsEmpty_ReturnsFalse()
+        {
+            SetupOriginHead("main");
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                Commands.Checkout(repo, repo.Head.Tip);
+            }
+
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var result = gate.ShouldSkip(repo);
+
+                Assert.IsFalse(result, "Should return false in detached HEAD state");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldSkip_WhenOnMainBranchWithOriginHead_ReturnsTrue()
+        {
+            SetupOriginHead("main");
+
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var result = gate.ShouldSkip(repo);
+
+                Assert.IsTrue(result, "Should skip when current branch matches default branch");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldSkip_WhenOnFeatureBranch_ReturnsFalse()
+        {
+            SetupOriginHead("main");
+            ExecGit("checkout -b feature");
+
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var result = gate.ShouldSkip(repo);
+
+                Assert.IsFalse(result, "Should not skip when on feature branch");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldSkip_ComparisonIsCaseInsensitive()
+        {
+            SetupOriginHead("MAIN");
+
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var result = gate.ShouldSkip(repo);
+
+                Assert.IsTrue(result, "main should match MAIN case-insensitively");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldSkip_CachesDefaultBranchAfterFirstFetch()
+        {
+            SetupOriginHead("main");
+
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var firstResult = gate.ShouldSkip(repo);
+                Assert.IsTrue(firstResult);
+            }
+
+            SetupOriginHead("develop");
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var secondResult = gate.ShouldSkip(repo);
+
+                Assert.IsTrue(secondResult, "Should still use cached 'main' as default branch");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldSkip_CurrentBranchIsComputedFreshEachCall()
+        {
+            SetupOriginHead("main");
+
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var result = gate.ShouldSkip(repo);
+                Assert.IsTrue(result, "Should skip when on main");
+            }
+
+            ExecGit("checkout -b feature");
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var result = gate.ShouldSkip(repo);
+                Assert.IsFalse(result, "Should not skip when on feature branch");
+            }
+
+            ExecGit("checkout main");
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var result = gate.ShouldSkip(repo);
+                Assert.IsTrue(result, "Should skip again when back on main");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldSkip_WhenNoOriginHead_ReturnsFalse()
+        {
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var result = gate.ShouldSkip(repo);
+
+                Assert.IsFalse(result, "Should not skip when default branch cannot be determined");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldSkipForCurrentBranch_WhenOnMainBranch_ReturnsTrue()
+        {
+            SetupOriginHead("main");
+
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            var result = gate.ShouldSkipForCurrentBranch();
+
+            Assert.IsTrue(result, "Should skip when current branch matches default branch");
+        }
+
+        [TestMethod]
+        public void ShouldSkipForCurrentBranch_WhenOnFeatureBranch_ReturnsFalse()
+        {
+            SetupOriginHead("main");
+            ExecGit("checkout -b feature");
+
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            var result = gate.ShouldSkipForCurrentBranch();
+
+            Assert.IsFalse(result, "Should not skip when on feature branch");
+        }
+
+        [TestMethod]
+        public void ShouldSkip_UsesBaselineBranchFromConfig()
+        {
+            ExecGit("checkout -b develop");
+            WriteConfig("{\"baseline_branch\":\"develop\"}");
+
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var result = gate.ShouldSkip(repo);
+
+                Assert.IsTrue(result, "Should skip when current branch matches configured baseline branch");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldSkip_ConfigOverridesOriginHead()
+        {
+            SetupOriginHead("main");
+            ExecGit("checkout -b develop");
+            WriteConfig("{\"baseline_branch\":\"develop\"}");
+
+            var gate = new DefaultBranchGate(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var result = gate.ShouldSkip(repo);
+
+                Assert.IsTrue(result, "Should use configured baseline branch instead of origin/HEAD");
+            }
+        }
+
+        private void SetupOriginHead(string branchName)
+        {
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var existingOriginHead = repo.Refs[$"refs/remotes/origin/HEAD"];
+                if (existingOriginHead != null)
+                {
+                    repo.Refs.Remove(existingOriginHead);
+                }
+
+                var existingRef = repo.Refs[$"refs/remotes/origin/{branchName}"];
+                if (existingRef != null)
+                {
+                    repo.Refs.Remove(existingRef);
+                }
+
+                repo.Refs.Add($"refs/remotes/origin/{branchName}", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs[$"refs/remotes/origin/{branchName}"]);
+            }
+        }
+
+        private void WriteConfig(string json)
+        {
+            var codesceneDir = Path.Combine(_testRepoPath, CodesceneFileWatcher.CodesceneDir);
+            Directory.CreateDirectory(codesceneDir);
+            File.WriteAllText(Path.Combine(codesceneDir, CodesceneFileWatcher.ConfigFileName), json);
+        }
+
+        private void CommitFile(string filename, string content, string message)
+        {
+            var filePath = Path.Combine(_testRepoPath, filename);
+            File.WriteAllText(filePath, content);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                Commands.Stage(repo, filename);
+                var signature = new Signature("Test User", "test@example.com", DateTimeOffset.Now);
+                repo.Commit(message, signature, signature);
+            }
+        }
+
+        private void ExecGit(string args)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = args,
+                WorkingDirectory = _testRepoPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using (var process = Process.Start(psi))
+            {
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                {
+                    var error = process.StandardError.ReadToEnd();
+                    throw new Exception($"Git command failed: {args}\n{error}");
+                }
+            }
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/FileChangeEventProcessorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/FileChangeEventProcessorTests.cs
@@ -143,6 +143,38 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public async Task ProcessQueuedEvents_CoalescesDeleteFollowedByCreateChange_EmitsDelete()
+        {
+            var logger = new FakeLogger();
+            var taskScheduler = new FakeAsyncTaskScheduler();
+            var processedEvents = new List<FileChangeEvent>();
+
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            {
+                processedEvents.Add(evt);
+                return Task.CompletedTask;
+            }
+
+            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+
+            using (var processor = new FileChangeEventProcessor(logger, taskScheduler, ProcessEvent, GetChangedFiles))
+            {
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Delete, "file.cs"));
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Create, "file.cs"));
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Change, "file.cs"));
+                processor.Start(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (processedEvents.Count == 0 && DateTime.UtcNow < deadline)
+                {
+                    await Task.Delay(20);
+                }
+            }
+
+            Assert.HasCount(1, processedEvents);
+            Assert.AreEqual(FileChangeType.Delete, processedEvents[0].Type, "Delete should not be masked by subsequent Create/Change");
+        }
+
+        [TestMethod]
         public async Task ProcessQueuedEvents_DoesNotCoalesceDifferentPaths()
         {
             var logger = new FakeLogger();
@@ -266,6 +298,212 @@ namespace Codescene.VSExtension.Core.Tests
 
             Assert.IsTrue(firstInvoked);
             Assert.IsFalse(secondInvoked);
+        }
+
+        [TestMethod]
+        public async Task ProcessQueuedEvents_WhenShouldSkipReturnsTrue_SkipsNonDeleteEvents()
+        {
+            var logger = new FakeLogger();
+            var taskScheduler = new FakeAsyncTaskScheduler();
+            var processedEvents = new List<FileChangeEvent>();
+
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            {
+                processedEvents.Add(evt);
+                return Task.CompletedTask;
+            }
+
+            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+
+            using (var processor = new FileChangeEventProcessor(
+                logger,
+                taskScheduler,
+                ProcessEvent,
+                GetChangedFiles,
+                shouldSkipNonDeletesCallback: () => true))
+            {
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Create, "create.cs"));
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Change, "change.cs"));
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Delete, "delete.cs"));
+                processor.Start(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (processedEvents.Count == 0 && DateTime.UtcNow < deadline)
+                {
+                    await Task.Delay(20);
+                }
+
+                await Task.Delay(100);
+            }
+
+            Assert.HasCount(1, processedEvents);
+            Assert.AreEqual(FileChangeType.Delete, processedEvents[0].Type);
+            Assert.AreEqual("delete.cs", processedEvents[0].FilePath);
+        }
+
+        [TestMethod]
+        public async Task ProcessQueuedEvents_WhenShouldSkipReturnsTrue_StillProcessesDeleteEvents()
+        {
+            var logger = new FakeLogger();
+            var taskScheduler = new FakeAsyncTaskScheduler();
+            var processedEvents = new List<FileChangeEvent>();
+
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            {
+                processedEvents.Add(evt);
+                return Task.CompletedTask;
+            }
+
+            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+
+            using (var processor = new FileChangeEventProcessor(
+                logger,
+                taskScheduler,
+                ProcessEvent,
+                GetChangedFiles,
+                shouldSkipNonDeletesCallback: () => true))
+            {
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Delete, "first.cs"));
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Delete, "second.cs"));
+                processor.Start(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (processedEvents.Count < 2 && DateTime.UtcNow < deadline)
+                {
+                    await Task.Delay(20);
+                }
+            }
+
+            Assert.HasCount(2, processedEvents);
+            Assert.IsTrue(processedEvents.All(e => e.Type == FileChangeType.Delete));
+        }
+
+        [TestMethod]
+        public async Task ProcessQueuedEvents_WhenShouldSkipReturnsFalse_ProcessesAllEvents()
+        {
+            var logger = new FakeLogger();
+            var taskScheduler = new FakeAsyncTaskScheduler();
+            var processedEvents = new List<FileChangeEvent>();
+
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            {
+                processedEvents.Add(evt);
+                return Task.CompletedTask;
+            }
+
+            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+
+            using (var processor = new FileChangeEventProcessor(
+                logger,
+                taskScheduler,
+                ProcessEvent,
+                GetChangedFiles,
+                shouldSkipNonDeletesCallback: () => false))
+            {
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Create, "create.cs"));
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Change, "change.cs"));
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Delete, "delete.cs"));
+                processor.Start(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (processedEvents.Count < 3 && DateTime.UtcNow < deadline)
+                {
+                    await Task.Delay(20);
+                }
+            }
+
+            Assert.HasCount(3, processedEvents);
+        }
+
+        [TestMethod]
+        public async Task ProcessQueuedEvents_WhenShouldSkipCallbackIsNull_ProcessesAllEvents()
+        {
+            var logger = new FakeLogger();
+            var taskScheduler = new FakeAsyncTaskScheduler();
+            var processedEvents = new List<FileChangeEvent>();
+
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            {
+                processedEvents.Add(evt);
+                return Task.CompletedTask;
+            }
+
+            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+
+            using (var processor = new FileChangeEventProcessor(
+                logger,
+                taskScheduler,
+                ProcessEvent,
+                GetChangedFiles,
+                shouldSkipNonDeletesCallback: null))
+            {
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Create, "create.cs"));
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Change, "change.cs"));
+                processor.Start(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (processedEvents.Count < 2 && DateTime.UtcNow < deadline)
+                {
+                    await Task.Delay(20);
+                }
+            }
+
+            Assert.HasCount(2, processedEvents);
+        }
+
+        [TestMethod]
+        public async Task ProcessQueuedEvents_DynamicSkipCallback_ReEvaluatesOnEachProcessingCycle()
+        {
+            var logger = new FakeLogger();
+            var taskScheduler = new FakeAsyncTaskScheduler();
+            var processedEvents = new List<FileChangeEvent>();
+            var skipState = false;
+            var callbackInvocationCount = 0;
+
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            {
+                processedEvents.Add(evt);
+                return Task.CompletedTask;
+            }
+
+            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+
+            using (var processor = new FileChangeEventProcessor(
+                logger,
+                taskScheduler,
+                ProcessEvent,
+                GetChangedFiles,
+                shouldSkipNonDeletesCallback: () =>
+                {
+                    callbackInvocationCount++;
+                    return skipState;
+                }))
+            {
+                skipState = true;
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Create, "first.cs"));
+                processor.Start(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (callbackInvocationCount < 1 && DateTime.UtcNow < deadline)
+                {
+                    await Task.Delay(20);
+                }
+
+                await Task.Delay(100);
+
+                Assert.HasCount(0, processedEvents, "First event should be skipped when callback returns true");
+                Assert.AreEqual(1, callbackInvocationCount, "Callback should have been invoked for first processing cycle");
+
+                skipState = false;
+                processor.EnqueueEvent(new FileChangeEvent(FileChangeType.Change, "second.cs"));
+                deadline = DateTime.UtcNow.AddSeconds(5);
+                while (processedEvents.Count < 1 && DateTime.UtcNow < deadline)
+                {
+                    await Task.Delay(20);
+                }
+
+                await Task.Delay(100);
+
+                Assert.HasCount(1, processedEvents, "Second event should be processed when callback returns false");
+                Assert.AreEqual(FileChangeType.Change, processedEvents[0].Type);
+                Assert.AreEqual("second.cs", processedEvents[0].FilePath);
+                Assert.AreEqual(2, callbackInvocationCount, "Callback should have been invoked for second processing cycle");
+            }
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerEdgeCasesTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerEdgeCasesTests.cs
@@ -3,6 +3,7 @@
 using Codescene.VSExtension.Core.Application.Git;
 using Codescene.VSExtension.Core.Models;
 using Codescene.VSExtension.Core.Util;
+using LibGit2Sharp;
 using WebComponentFile = Codescene.VSExtension.Core.Models.WebComponent.Data.File;
 
 namespace Codescene.VSExtension.Core.Tests
@@ -303,6 +304,44 @@ namespace Codescene.VSExtension.Core.Tests
                 {
                     DeltaJobTracker.Remove(job);
                 }
+            }
+        }
+
+        [TestMethod]
+        public async Task PeriodicScanAsync_SkipsWhenOnDefaultBranch()
+        {
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var currentBranch = repo.Head.FriendlyName;
+                repo.Refs.Add($"refs/remotes/origin/{currentBranch}", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs[$"refs/remotes/origin/{currentBranch}"]);
+            }
+
+            var defaultBranchGate = new DefaultBranchGate(_testRepoPath);
+
+            var testableInstance = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService);
+
+            try
+            {
+                testableInstance.Initialize(_testRepoPath, new[] { _testRepoPath }, defaultBranchGate);
+
+                var newFile = Path.Combine(_testRepoPath, "should-not-scan-on-main.cs");
+                File.WriteAllText(newFile, "content");
+
+                var eventFired = false;
+                testableInstance.FilesDetected += (sender, files) => eventFired = true;
+
+                await testableInstance.InvokePeriodicScanAsync();
+
+                Assert.IsFalse(eventFired, "Should not fire event when on default branch");
+            }
+            finally
+            {
+                testableInstance?.Dispose();
             }
         }
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
@@ -488,5 +488,20 @@ namespace Codescene.VSExtension.Core.Tests
                 Assert.IsTrue(result.All(f => f.Contains("real")), "All returned files should be non-ignored files");
             }
         }
+
+        [TestMethod]
+        public async Task GetAllChangedFilesAsync_NullDefaultBranchGate_DoesNotSkip()
+        {
+            var listerWithoutGate = new GitChangeLister(_fakeSavedFilesTracker, _fakeSupportedFileChecker, _fakeLogger, _fakeGitService);
+            listerWithoutGate.Initialize(null, new[] { _testRepoPath });
+
+            var newFile = Path.Combine(_testRepoPath, "new-file.cs");
+            File.WriteAllText(newFile, "public class NewClass { }");
+
+            var result = await listerWithoutGate.GetAllChangedFilesAsync(_testRepoPath, _testRepoPath);
+
+            Assert.HasCount(1, result, "Should detect file even when _defaultBranchGate is null");
+            Assert.Contains(newFile, result, "Should contain the new file");
+        }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
@@ -496,7 +496,7 @@ namespace Codescene.VSExtension.Core.Tests
             return Task.FromResult(new HashSet<string>());
         }
 
-        public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths)
+        public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths, DefaultBranchGate defaultBranchGate = null)
         {
         }
 
@@ -520,6 +520,10 @@ namespace Codescene.VSExtension.Core.Tests
             }
 
             return Task.FromResult(FilesToReturn);
+        }
+
+        public void InvalidateDefaultBranchCache()
+        {
         }
 
         public void SimulateFilesDetected(HashSet<string> files)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/DefaultBranchGate.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/DefaultBranchGate.cs
@@ -8,6 +8,7 @@ namespace Codescene.VSExtension.Core.Application.Git
     public class DefaultBranchGate
     {
         private readonly string _gitRootPath;
+        private readonly object _cacheLock = new object();
         private string _cachedDefaultBranch;
         private bool _hasFetched;
 
@@ -66,19 +67,25 @@ namespace Codescene.VSExtension.Core.Application.Git
 
         public void InvalidateCache()
         {
-            _cachedDefaultBranch = null;
-            _hasFetched = false;
+            lock (_cacheLock)
+            {
+                _cachedDefaultBranch = null;
+                _hasFetched = false;
+            }
         }
 
         private string GetDefaultBranchCached(Repository repo)
         {
-            if (!_hasFetched)
+            lock (_cacheLock)
             {
-                _cachedDefaultBranch = MainBranchNames.GetDefaultBranch(repo);
-                _hasFetched = true;
-            }
+                if (!_hasFetched)
+                {
+                    _cachedDefaultBranch = MainBranchNames.GetDefaultBranch(repo);
+                    _hasFetched = true;
+                }
 
-            return _cachedDefaultBranch;
+                return _cachedDefaultBranch;
+            }
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/DefaultBranchGate.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/DefaultBranchGate.cs
@@ -1,0 +1,84 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using LibGit2Sharp;
+
+namespace Codescene.VSExtension.Core.Application.Git
+{
+    public class DefaultBranchGate
+    {
+        private readonly string _gitRootPath;
+        private string _cachedDefaultBranch;
+        private bool _hasFetched;
+
+        public DefaultBranchGate(string gitRootPath)
+        {
+            _gitRootPath = gitRootPath;
+        }
+
+        public bool ShouldSkip(Repository repo)
+        {
+            if (repo == null)
+            {
+                return false;
+            }
+
+            var currentBranch = repo.Head?.FriendlyName;
+            if (string.IsNullOrEmpty(currentBranch))
+            {
+                return false;
+            }
+
+            var defaultBranch = GetDefaultBranchCached(repo);
+            if (string.IsNullOrEmpty(defaultBranch))
+            {
+                return false;
+            }
+
+            return string.Equals(currentBranch, defaultBranch, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public bool ShouldSkipForCurrentBranch()
+        {
+            if (string.IsNullOrEmpty(_gitRootPath))
+            {
+                return false;
+            }
+
+            try
+            {
+                var repoPath = Repository.Discover(_gitRootPath);
+                if (string.IsNullOrEmpty(repoPath))
+                {
+                    return false;
+                }
+
+                using (var repo = new Repository(repoPath))
+                {
+                    return ShouldSkip(repo);
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        public void InvalidateCache()
+        {
+            _cachedDefaultBranch = null;
+            _hasFetched = false;
+        }
+
+        private string GetDefaultBranchCached(Repository repo)
+        {
+            if (!_hasFetched)
+            {
+                _cachedDefaultBranch = MainBranchNames.GetDefaultBranch(repo);
+                _hasFetched = true;
+            }
+
+            return _cachedDefaultBranch;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeEventProcessor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeEventProcessor.cs
@@ -19,6 +19,7 @@ namespace Codescene.VSExtension.Core.Application.Git
         private readonly ILogger _logger;
         private readonly Func<FileChangeEvent, List<string>, long?, CancellationToken, Task> _processEventCallback;
         private readonly Func<Task<List<string>>> _getChangedFilesCallback;
+        private readonly Func<bool> _shouldSkipNonDeletesCallback;
         private readonly IAsyncTaskScheduler _taskScheduler;
         private Timer _scheduledTimer;
         private CancellationToken _cancellationToken;
@@ -27,12 +28,14 @@ namespace Codescene.VSExtension.Core.Application.Git
             ILogger logger,
             IAsyncTaskScheduler taskScheduler,
             Func<FileChangeEvent, List<string>, long?, CancellationToken, Task> processEventCallback,
-            Func<Task<List<string>>> getChangedFilesCallback)
+            Func<Task<List<string>>> getChangedFilesCallback,
+            Func<bool> shouldSkipNonDeletesCallback = null)
         {
             _logger = logger;
             _taskScheduler = taskScheduler;
             _processEventCallback = processEventCallback;
             _getChangedFilesCallback = getChangedFilesCallback;
+            _shouldSkipNonDeletesCallback = shouldSkipNonDeletesCallback;
 
             var numberOfThreads = CoreCountUtils.GetParallelizationCountByCoreCount(Environment.ProcessorCount);
             _concurrencySemaphore = new SemaphoreSlim(numberOfThreads, numberOfThreads);
@@ -69,19 +72,32 @@ namespace Codescene.VSExtension.Core.Application.Git
             _concurrencySemaphore?.Dispose();
         }
 
-        /// <summary>
-        /// Merges multiple events for the same path into one event per path.
-        /// It selects the last event in the queue per file.
-        ///
-        /// It will return either Delete or Change (Create is converted) per file.
-        /// </summary>
+        private static bool HasDeleteEvents(List<FileChangeEvent> events)
+        {
+            foreach (var evt in events)
+            {
+                if (evt.Type == FileChangeType.Delete)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private static List<FileChangeEvent> CoalesceByPath(List<FileChangeEvent> events)
         {
             var byPath = new Dictionary<string, FileChangeType>(StringComparer.OrdinalIgnoreCase);
+            var hadDelete = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var evt in events)
             {
                 var path = evt.FilePath;
+                if (evt.Type == FileChangeType.Delete)
+                {
+                    hadDelete.Add(path);
+                }
+
                 byPath[path] = evt.Type == FileChangeType.Delete
                     ? FileChangeType.Delete
                     : FileChangeType.Change;
@@ -90,7 +106,8 @@ namespace Codescene.VSExtension.Core.Application.Git
             var result = new List<FileChangeEvent>(byPath.Count);
             foreach (var kv in byPath)
             {
-                result.Add(new FileChangeEvent(kv.Value, kv.Key));
+                var type = hadDelete.Contains(kv.Key) ? FileChangeType.Delete : kv.Value;
+                result.Add(new FileChangeEvent(type, kv.Key));
             }
 
             return result;
@@ -138,6 +155,14 @@ namespace Codescene.VSExtension.Core.Application.Git
                 return;
             }
 
+            var shouldSkipNonDeletes = _shouldSkipNonDeletesCallback?.Invoke() ?? false;
+
+            if (shouldSkipNonDeletes && !HasDeleteEvents(coalesced))
+            {
+                _logger?.Debug("FileChangeEventProcessor: Skipping all events - current branch matches default branch and no deletes pending");
+                return;
+            }
+
             var changedFiles = await _getChangedFilesCallback();
 
             if (_cancellationToken.IsCancellationRequested)
@@ -145,7 +170,7 @@ namespace Codescene.VSExtension.Core.Application.Git
                 return;
             }
 
-            ScheduleCoalescedEvents(coalesced, changedFiles, operationGeneration);
+            ScheduleCoalescedEvents(coalesced, changedFiles, operationGeneration, shouldSkipNonDeletes);
         }
 
         private List<FileChangeEvent> DrainQueue()
@@ -159,11 +184,17 @@ namespace Codescene.VSExtension.Core.Application.Git
             return events;
         }
 
-        private void ScheduleCoalescedEvents(List<FileChangeEvent> coalesced, List<string> changedFiles, long? operationGeneration)
+        private void ScheduleCoalescedEvents(List<FileChangeEvent> coalesced, List<string> changedFiles, long? operationGeneration, bool shouldSkipNonDeletes)
         {
             var token = _cancellationToken;
             foreach (var evt in coalesced)
             {
+                if (shouldSkipNonDeletes && evt.Type != FileChangeType.Delete)
+                {
+                    _logger?.Debug($"FileChangeEventProcessor: Skipping {evt.Type} event for {evt.FilePath} - current branch matches default branch");
+                    continue;
+                }
+
                 var capturedEvt = evt;
                 var capturedChangedFiles = changedFiles;
                 _taskScheduler.Schedule(() => ProcessOneEventAsync(capturedEvt, capturedChangedFiles, operationGeneration, token));

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
@@ -29,6 +29,7 @@ namespace Codescene.VSExtension.Core.Application.Git
         private readonly UntrackedFileProcessor _untrackedFileProcessor;
         private readonly MergeBaseFinder _mergeBaseFinder;
 
+        private DefaultBranchGate _defaultBranchGate;
         private string _gitRootPath;
         private IReadOnlyCollection<string> _workspacePaths;
         private DroppingScheduledExecutor _scheduledExecutor;
@@ -94,10 +95,11 @@ namespace Codescene.VSExtension.Core.Application.Git
             return ExecuteAndLogAsync(gitRootPath, workspacePaths, "getting changed files vs merge base", "GetChangedFilesVsMergeBaseAsync found", GetChangedFilesVsMergeBase, cancellationToken);
         }
 
-        public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths)
+        public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths, DefaultBranchGate defaultBranchGate = null)
         {
             _gitRootPath = gitRootPath;
             _workspacePaths = workspacePaths ?? Array.Empty<string>();
+            _defaultBranchGate = defaultBranchGate ?? (!string.IsNullOrEmpty(gitRootPath) ? new DefaultBranchGate(gitRootPath) : null);
 #if FEATURE_INITIAL_GIT_OBSERVER
             _logger?.Info($">>> GitChangeLister: Initialized with gitRoot='{gitRootPath}', workspacePaths count={_workspacePaths.Count}");
 #endif
@@ -145,6 +147,11 @@ namespace Codescene.VSExtension.Core.Application.Git
         public virtual Task<HashSet<string>> CollectFilesFromRepoStateAsync(string gitRootPath, IReadOnlyCollection<string> workspacePaths, CancellationToken cancellationToken = default)
         {
             return ExecuteAndLogAsync(gitRootPath, workspacePaths, "collecting files from repo state", "CollectFilesFromRepoStateAsync collected", CollectFilesFromRepoState, cancellationToken);
+        }
+
+        public void InvalidateDefaultBranchCache()
+        {
+            _defaultBranchGate?.InvalidateCache();
         }
 
         public void Dispose()
@@ -313,7 +320,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             var startTime = DateTime.UtcNow;
             try
             {
-                if (!ShouldRunPeriodicScan())
+                if (!ShouldStartPeriodicScan())
                 {
                     return;
                 }
@@ -370,7 +377,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
         }
 
-        private bool ShouldRunPeriodicScan()
+        private bool ShouldStartPeriodicScan()
         {
             if (_ideActivityTracker != null && !_ideActivityTracker.IsIdeWindowActive())
             {
@@ -383,7 +390,18 @@ namespace Codescene.VSExtension.Core.Application.Git
                 return false;
             }
 
+            if (ShouldSkipBasedOnDefaultBranch())
+            {
+                _logger?.Debug("GitChangeLister: Skipping processing - current branch matches default branch");
+                return false;
+            }
+
             return true;
+        }
+
+        private bool ShouldSkipBasedOnDefaultBranch()
+        {
+            return _defaultBranchGate?.ShouldSkipForCurrentBranch() ?? false;
         }
 
         private bool IsValidGitRoot(string gitRootPath)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.DefaultBranchGate.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.DefaultBranchGate.cs
@@ -1,0 +1,20 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+namespace Codescene.VSExtension.Core.Application.Git
+{
+    public partial class GitChangeObserverCore
+    {
+        private void InitializeDefaultBranchGate()
+        {
+            if (!string.IsNullOrEmpty(_gitRootPath))
+            {
+                _defaultBranchGate = new DefaultBranchGate(_gitRootPath);
+            }
+        }
+
+        private bool ShouldSkipBasedOnDefaultBranch()
+        {
+            return _defaultBranchGate?.ShouldSkipForCurrentBranch() ?? false;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
@@ -48,6 +48,7 @@ namespace Codescene.VSExtension.Core.Application.Git
         private CodesceneFileWatcher _rulesFileWatcher;
         private CodesceneFileWatcher _configFileWatcher;
         private GitIgnoreWatcher _gitIgnoreWatcher;
+        private DefaultBranchGate _defaultBranchGate;
         private TaskCompletionSource<bool> _initializationComplete;
         private PerFileRequestQueue<string> _detectedFilesQueue = new PerFileRequestQueue<string>();
         private ConcurrentDictionary<string, SemaphoreSlim> _perFileProcessingLocks = new ConcurrentDictionary<string, SemaphoreSlim>(StringComparer.OrdinalIgnoreCase);
@@ -96,19 +97,20 @@ namespace Codescene.VSExtension.Core.Application.Git
             _openFilesObserver = openFilesObserver;
             _getChangedFilesCallback = getChangedFilesCallback ?? GetChangedFilesVsBaselineAsync;
             _gitChangeDetector = new GitChangeDetector(_logger, _supportedFileChecker, _gitService);
-
-            _eventProcessor = new FileChangeEventProcessor(_logger, _taskScheduler, ProcessEventAsync, _getChangedFilesCallback);
             _cts = new CancellationTokenSource();
 
             InitializeGitPaths();
+            InitializeDefaultBranchGate();
             LogIdentifiedBaselineBranch();
+
+            _eventProcessor = new FileChangeEventProcessor(_logger, _taskScheduler, ProcessEventAsync, _getChangedFilesCallback, ShouldSkipBasedOnDefaultBranch);
 
 #if FEATURE_INITIAL_GIT_OBSERVER
             _logger?.Info($">>> GitChangeObserverCore: Initialized with solution='{_solutionPath}', gitRoot='{_gitRootPath}', workspace='{_workspacePath}'");
 #endif
 
             _workspacePaths = watchPaths != null && watchPaths.Count > 0 ? watchPaths : new[] { _workspacePath };
-            _gitChangeLister.Initialize(_gitRootPath, _workspacePaths);
+            _gitChangeLister.Initialize(_gitRootPath, _workspacePaths, _defaultBranchGate);
             _gitChangeLister.FilesDetected += OnGitChangeListerFilesDetected;
 
             _fileChangeHandler = new FileChangeHandler(_logger, _codeReviewer, _supportedFileChecker, _workspacePaths, _trackerManager, _gitService, _gitRootPath, OnFileDeleted, openDocumentContentProvider);
@@ -356,6 +358,8 @@ namespace Codescene.VSExtension.Core.Application.Git
         private void OnCodesceneConfigChanged(object sender, EventArgs e)
         {
             _gitChangeDetector?.ClearMainBranchCandidatesCache(_gitRootPath);
+            _defaultBranchGate?.InvalidateCache();
+            _gitChangeLister?.InvalidateDefaultBranchCache();
             InvalidateTrackedFiles(onlyIgnored: false);
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitChangeLister.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Application.Git;
 
 namespace Codescene.VSExtension.Core.Interfaces.Git
 {
@@ -15,7 +16,7 @@ namespace Codescene.VSExtension.Core.Interfaces.Git
 
         Task<HashSet<string>> GetChangedFilesVsMergeBaseAsync(string gitRootPath, string workspacePath, CancellationToken cancellationToken = default);
 
-        void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths);
+        void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths, DefaultBranchGate defaultBranchGate = null);
 
         void SetWorkspacePaths(IReadOnlyCollection<string> workspacePaths);
 
@@ -24,5 +25,7 @@ namespace Codescene.VSExtension.Core.Interfaces.Git
         void StopPeriodicScanning();
 
         Task<HashSet<string>> CollectFilesFromRepoStateAsync(string gitRootPath, IReadOnlyCollection<string> workspacePaths, CancellationToken cancellationToken = default);
+
+        void InvalidateDefaultBranchCache();
     }
 }


### PR DESCRIPTION
When the current branch equals the repository's default branch, `GitChangeLister` and `GitChangeObserverCore` skip processing file changes. This avoids unnecessary computational work since diff-based analysis against the default branch produces no meaningful results.

Introduces `DefaultBranchGate` class that lazily fetches and caches the default branch name, while computing the current branch fresh on each check. File deletions are exempt from skip logic to ensure proper cleanup.

Port of codescene-vscode commit fba0a8993aa3f07a410969c587ae66a72798fb63.

Verified manually.