### PR TITLE
feat: cache `GetDefaultBranch` calls to reduce redundant git operations

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/SubcutaneousGitTestInfrastructure.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/SubcutaneousGitTestInfrastructure.cs
@@ -55,6 +55,7 @@ public abstract class SubcutaneousGitTestBase
     {
         CacheGeneration.Reset();
         DeltaJobTracker.Clear();
+        MainBranchNames.ClearDefaultBranchCache();
         Journal = new EventJournal();
         Logger = new TestLogger(Journal);
         TaskScheduler = new RecordingAsyncTaskScheduler(Journal);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DefaultBranchGateTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DefaultBranchGateTests.cs
@@ -14,6 +14,7 @@ namespace Codescene.VSExtension.Core.Tests
         [TestInitialize]
         public void Setup()
         {
+            MainBranchNames.ClearDefaultBranchCache();
             _testRepoPath = Path.Combine(Path.GetTempPath(), $"test-default-branch-gate-{Guid.NewGuid()}");
             Directory.CreateDirectory(_testRepoPath);
             Repository.Init(_testRepoPath);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorTestBase.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorTestBase.cs
@@ -23,6 +23,8 @@ namespace Codescene.VSExtension.Core.Tests
         [TestInitialize]
         public void Setup()
         {
+            MainBranchNames.ClearDefaultBranchCache();
+
             _testRepoPath = Path.Combine(Path.GetTempPath(), $"test-git-detector-{Guid.NewGuid()}");
             Directory.CreateDirectory(_testRepoPath);
             Repository.Init(_testRepoPath);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
@@ -345,6 +345,8 @@ namespace Codescene.VSExtension.Core.Tests
                 repo.Refs.Remove("refs/remotes/origin/HEAD");
             }
 
+            MainBranchNames.ClearDefaultBranchCache(_testRepoPath);
+
             _fakeLogger.ClearWarnMessages();
             var withFallbackMergeBase = await _lister.GetChangedFilesVsMergeBaseAsync(_testRepoPath, _testRepoPath);
             Assert.IsNotEmpty(withFallbackMergeBase, "Should find merge base via fallback when origin/HEAD is unset");
@@ -354,6 +356,8 @@ namespace Codescene.VSExtension.Core.Tests
             {
                 repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
             }
+
+            MainBranchNames.ClearDefaultBranchCache(_testRepoPath);
 
             _fakeLogger.ClearWarnMessages();
             await _lister.GetChangedFilesVsMergeBaseAsync(_testRepoPath, _testRepoPath);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverTestBase.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverTestBase.cs
@@ -23,6 +23,8 @@ namespace Codescene.VSExtension.Core.Tests
         [TestInitialize]
         public void Setup()
         {
+            MainBranchNames.ClearDefaultBranchCache();
+
             _testRepoPath = Path.Combine(Path.GetTempPath(), $"test-git-repo-observer-{Guid.NewGuid()}");
 
             if (Directory.Exists(_testRepoPath))

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/MainBranchMergeBaseSelectorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/MainBranchMergeBaseSelectorTests.cs
@@ -14,6 +14,7 @@ namespace Codescene.VSExtension.Core.Tests
         [TestInitialize]
         public void Setup()
         {
+            MainBranchNames.ClearDefaultBranchCache();
             _testRepoPath = Path.Combine(Path.GetTempPath(), $"test-merge-base-{Guid.NewGuid()}");
             Directory.CreateDirectory(_testRepoPath);
             Repository.Init(_testRepoPath);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/MainBranchNamesTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/MainBranchNamesTests.cs
@@ -14,6 +14,8 @@ namespace Codescene.VSExtension.Core.Tests
         [TestInitialize]
         public void Setup()
         {
+            MainBranchNames.ClearDefaultBranchCache();
+
             _testRepoPath = Path.Combine(Path.GetTempPath(), $"test-main-branch-{Guid.NewGuid()}");
             Directory.CreateDirectory(_testRepoPath);
             Repository.Init(_testRepoPath);
@@ -362,6 +364,89 @@ namespace Codescene.VSExtension.Core.Tests
                     {
                     }
                 }
+            }
+        }
+
+        [TestMethod]
+        public void GetDefaultBranch_CachesResult()
+        {
+            using (var repo = new Repository(_testRepoPath))
+            {
+                repo.Refs.Add("refs/remotes/origin/main", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
+            }
+
+            string firstResult;
+            using (var repo = new Repository(_testRepoPath))
+            {
+                firstResult = MainBranchNames.GetDefaultBranch(repo);
+                Assert.AreEqual("main", firstResult, "First call should return main");
+            }
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                repo.Refs.Remove(repo.Refs["refs/remotes/origin/HEAD"]);
+                repo.Refs.Add("refs/remotes/origin/develop", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/develop"]);
+            }
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var cachedResult = MainBranchNames.GetDefaultBranch(repo);
+                Assert.AreEqual("main", cachedResult, "Should return cached result even though underlying state changed");
+            }
+        }
+
+        [TestMethod]
+        public void GetDefaultBranch_DoesNotCacheNullResult()
+        {
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var firstResult = MainBranchNames.GetDefaultBranch(repo);
+                Assert.IsNull(firstResult, "First call should return null when no origin/HEAD");
+            }
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                repo.Refs.Add("refs/remotes/origin/main", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
+            }
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var secondResult = MainBranchNames.GetDefaultBranch(repo);
+                Assert.AreEqual("main", secondResult, "Should return fresh result since null was not cached");
+            }
+        }
+
+        [TestMethod]
+        public void ClearDefaultBranchCache_InvalidatesCache()
+        {
+            using (var repo = new Repository(_testRepoPath))
+            {
+                repo.Refs.Add("refs/remotes/origin/main", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/main"]);
+            }
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var firstResult = MainBranchNames.GetDefaultBranch(repo);
+                Assert.AreEqual("main", firstResult);
+            }
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                repo.Refs.Remove(repo.Refs["refs/remotes/origin/HEAD"]);
+                repo.Refs.Add("refs/remotes/origin/develop", repo.Head.Tip.Id);
+                repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs["refs/remotes/origin/develop"]);
+            }
+
+            MainBranchNames.ClearDefaultBranchCache(_testRepoPath);
+
+            using (var repo = new Repository(_testRepoPath))
+            {
+                var freshResult = MainBranchNames.GetDefaultBranch(repo);
+                Assert.AreEqual("develop", freshResult, "Should return fresh result after cache clear");
             }
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeDetector.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeDetector.cs
@@ -33,6 +33,8 @@ namespace Codescene.VSExtension.Core.Application.Git
 
         public void ClearMainBranchCandidatesCache(string gitRootPath = null)
         {
+            MainBranchNames.ClearDefaultBranchCache(gitRootPath);
+
             if (_mainBranchCandidatesCache == null)
             {
                 return;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/MainBranchNames.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/MainBranchNames.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using LibGit2Sharp;
 
@@ -17,42 +18,59 @@ namespace Codescene.VSExtension.Core.Application.Git
         private const string OriginHeadRef = "refs/remotes/origin/HEAD";
         private const string OriginRemotePrefix = "refs/remotes/origin/";
 
+        private static readonly Dictionary<string, string> _defaultBranchCache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private static readonly object _cacheLock = new object();
+
         public static string GetDefaultBranch(Repository repo)
         {
             try
             {
                 var gitRoot = repo?.Info?.WorkingDirectory;
-                if (!string.IsNullOrEmpty(gitRoot))
+                if (string.IsNullOrEmpty(gitRoot))
                 {
-                    var configured = CodesceneRepoConfig.GetBaselineBranch(gitRoot);
-                    if (!string.IsNullOrEmpty(configured))
+                    return GetDefaultBranchUncached(repo);
+                }
+
+                var normalizedRoot = gitRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+                lock (_cacheLock)
+                {
+                    if (_defaultBranchCache.TryGetValue(normalizedRoot, out var cached))
                     {
-                        return configured;
+                        return cached;
                     }
                 }
 
-                var originHead = repo?.Refs[OriginHeadRef];
-                if (originHead == null)
+                var result = GetDefaultBranchUncached(repo);
+
+                if (result != null)
                 {
-                    return null;
+                    lock (_cacheLock)
+                    {
+                        _defaultBranchCache[normalizedRoot] = result;
+                    }
                 }
 
-                var target = originHead.TargetIdentifier;
-                if (string.IsNullOrEmpty(target))
-                {
-                    return null;
-                }
-
-                if (target.StartsWith(OriginRemotePrefix, StringComparison.Ordinal))
-                {
-                    return target.Substring(OriginRemotePrefix.Length);
-                }
-
-                return null;
+                return result;
             }
             catch
             {
                 return null;
+            }
+        }
+
+        public static void ClearDefaultBranchCache(string gitRootPath = null)
+        {
+            lock (_cacheLock)
+            {
+                if (string.IsNullOrEmpty(gitRootPath))
+                {
+                    _defaultBranchCache.Clear();
+                    return;
+                }
+
+                var normalizedRoot = gitRootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                _defaultBranchCache.Remove(normalizedRoot);
             }
         }
 
@@ -76,6 +94,38 @@ namespace Codescene.VSExtension.Core.Application.Git
         {
             return !string.IsNullOrEmpty(branchName)
                 && All.Contains(branchName, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static string GetDefaultBranchUncached(Repository repo)
+        {
+            var gitRoot = repo?.Info?.WorkingDirectory;
+            if (!string.IsNullOrEmpty(gitRoot))
+            {
+                var configured = CodesceneRepoConfig.GetBaselineBranch(gitRoot);
+                if (!string.IsNullOrEmpty(configured))
+                {
+                    return configured;
+                }
+            }
+
+            var originHead = repo?.Refs[OriginHeadRef];
+            if (originHead == null)
+            {
+                return null;
+            }
+
+            var target = originHead.TargetIdentifier;
+            if (string.IsNullOrEmpty(target))
+            {
+                return null;
+            }
+
+            if (target.StartsWith(OriginRemotePrefix, StringComparison.Ordinal))
+            {
+                return target.Substring(OriginRemotePrefix.Length);
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Adds static per-repository caching to `MainBranchNames.GetDefaultBranch()` to avoid repeated git lookups. This matches the optimization pattern from VS Code extension commit 57c9917.

Previously, `GetDefaultBranch` was called from multiple sites without consistent caching. Now all callers benefit from the cache automatically. The cache is cleared via `GitChangeDetector.ClearMainBranchCandidatesCache()` so both caches stay in sync when baseline branch configuration changes.

Verified manually.