### PR TITLE
feat: cache baseline commit to eliminate redundant git merge-base calls

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/BenchmarkSupport.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/BenchmarkSupport.cs
@@ -239,6 +239,11 @@ internal sealed class FixedGitService : IGitService
 
     public string GetFileContentForCommit(string path)
     {
+        return GetFileContentForCommit(path, string.Empty);
+    }
+
+    public string GetFileContentForCommit(string path, string baselineCommit)
+    {
         if (path != null && _pathContents.TryGetValue(path, out var content))
         {
             return content;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/BenchmarkSupport.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Benchmarks/BenchmarkSupport.cs
@@ -237,6 +237,11 @@ internal sealed class FixedGitService : IGitService
         _pathContents[path] = content;
     }
 
+    public string GetBaselineCommit(string repoRootPath)
+    {
+        return string.Empty;
+    }
+
     public string GetFileContentForCommit(string path)
     {
         return GetFileContentForCommit(path, string.Empty);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestGitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestGitService.cs
@@ -19,6 +19,11 @@ namespace Codescene.VSExtension.Core.IntegrationTests.TestImplementations
             return Mock.Object.GetFileContentForCommit(path);
         }
 
+        public string GetFileContentForCommit(string path, string baselineCommit)
+        {
+            return Mock.Object.GetFileContentForCommit(path, baselineCommit);
+        }
+
         public bool IsFileIgnored(string filePath)
         {
             return Mock.Object.IsFileIgnored(filePath);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestGitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.IntegrationTests/TestImplementations/TestGitService.cs
@@ -14,6 +14,11 @@ namespace Codescene.VSExtension.Core.IntegrationTests.TestImplementations
     {
         internal Mock<IGitService> Mock = new Mock<IGitService>();
 
+        public string GetBaselineCommit(string repoRootPath)
+        {
+            return Mock.Object.GetBaselineCommit(repoRootPath);
+        }
+
         public string GetFileContentForCommit(string path)
         {
             return Mock.Object.GetFileContentForCommit(path);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/GitServiceSubcutaneousTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/GitServiceSubcutaneousTests.cs
@@ -71,11 +71,8 @@ public class GitServiceSubcutaneousTests : SubcutaneousGitTestBase
         CheckoutBranch("feature/test-suppression2", create: true);
         await WriteWorkingFileAsync(relativePath, FeatureContent);
 
-        using (var repo = new Repository(RepositoryRoot))
-        {
-            var baselineCommit = GitService.GetBaselineCommit(repo);
-            Assert.AreEqual(developCommit, baselineCommit);
-        }
+        var baselineCommit = GitService.GetBaselineCommit(RepositoryRoot);
+        Assert.AreEqual(developCommit, baselineCommit);
 
         var baselineContent = GitService.GetFileContentForCommit(AbsolutePath(relativePath));
         Assert.AreEqual(NormalizeLineEndings(DevelopContent), NormalizeLineEndings(baselineContent));

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingCodeReviewer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingCodeReviewer.cs
@@ -44,17 +44,17 @@ public sealed class RecordingCodeReviewer : ICodeReviewer
         return _inner.ReviewAsync(path, content, isBaseline, operationGeneration, cancellationToken);
     }
 
-    public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string? precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default)
+    public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string? precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default, string? baselineCommit = null)
     {
-        return _inner.DeltaAsync(review, currentCode, precomputedBaselineRawScore, operationGeneration, cancellationToken);
+        return _inner.DeltaAsync(review, currentCode, precomputedBaselineRawScore, operationGeneration, cancellationToken, baselineCommit);
     }
 
-    public Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default)
+    public Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default, string? baselineCommit = null)
     {
-        return _inner.ReviewAndBaselineAsync(path, currentCode, operationGeneration, cancellationToken);
+        return _inner.ReviewAndBaselineAsync(path, currentCode, operationGeneration, cancellationToken, baselineCommit);
     }
 
-    public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default)
+    public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default, string? baselineCommit = null)
     {
         _reviewWithDeltaCalls.AddOrUpdate(path, 1, (_, count) => count + 1);
         var activeCount = _activeReviewWithDeltaCalls.AddOrUpdate(path, 1, (_, count) => count + 1);
@@ -69,7 +69,7 @@ public sealed class RecordingCodeReviewer : ICodeReviewer
 
         try
         {
-            var result = await _inner.ReviewWithDeltaAsync(path, content, operationGeneration, cancellationToken);
+            var result = await _inner.ReviewWithDeltaAsync(path, content, operationGeneration, cancellationToken, baselineCommit);
             _journal.Record("review.completed", path, $"delta={result.delta != null}");
             return result;
         }
@@ -84,9 +84,9 @@ public sealed class RecordingCodeReviewer : ICodeReviewer
         }
     }
 
-    public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default)
+    public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default, string? baselineCommit = null)
     {
-        return _inner.GetOrComputeBaselineRawScoreAsync(path, baselineContent, operationGeneration, cancellationToken);
+        return _inner.GetOrComputeBaselineRawScoreAsync(path, baselineContent, operationGeneration, cancellationToken, baselineCommit);
     }
 }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingGitObservers.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingGitObservers.cs
@@ -103,10 +103,10 @@ public sealed class RecordingGitChangeObserverCore : GitChangeObserverCore
         _journal = journal;
     }
 
-    public override async Task<List<string>> GetChangedFilesVsBaselineAsync()
+    public override async Task<List<string>> GetChangedFilesVsBaselineAsync(string baselineCommit)
     {
         _journal.Record("observer.changed-files.started");
-        var files = await base.GetChangedFilesVsBaselineAsync();
+        var files = await base.GetChangedFilesVsBaselineAsync(baselineCommit);
         _journal.Record("observer.changed-files.completed", detail: $"count={files.Count}");
         return files;
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/CancellationTokenTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/CancellationTokenTests.cs
@@ -46,10 +46,10 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
             var callerToken = cts.Token;
             var capturedToken = CancellationToken.None;
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(path)).Returns("old code");
+            _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns("old code");
             _mockInnerReviewer
-                .Setup(r => r.DeltaAsync(review, currentCode, precomputedScore, null, It.IsAny<CancellationToken>()))
-                .Returns<FileReviewModel, string, string, long?, CancellationToken>(async (_, _, _, _, token) =>
+                .Setup(r => r.DeltaAsync(review, currentCode, precomputedScore, null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .Returns<FileReviewModel, string, string, long?, CancellationToken, string>(async (_, _, _, _, token, _) =>
                 {
                     capturedToken = token;
                     entered.TrySetResult(true);
@@ -69,7 +69,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
 
             Assert.AreEqual(expectedDelta, secondResult);
             Assert.AreEqual(CancellationToken.None, capturedToken);
-            _mockInnerReviewer.Verify(r => r.DeltaAsync(review, currentCode, precomputedScore, null, It.IsAny<CancellationToken>()), Times.Once);
+            _mockInnerReviewer.Verify(r => r.DeltaAsync(review, currentCode, precomputedScore, null, It.IsAny<CancellationToken>(), It.IsAny<string>()), Times.Once);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_ContentUnchanged_SkipsDeltaTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_ContentUnchanged_SkipsDeltaTests.cs
@@ -59,7 +59,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 RawScore = "rawscore123",
             };
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(content);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(content);
 
             var result = await _cachingReviewer.DeltaAsync(review, content);
 
@@ -78,7 +78,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 RawScore = "raw456",
             };
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(content);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(content);
 
             await _cachingReviewer.DeltaAsync(review, content);
 
@@ -97,7 +97,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 RawScore = "score789",
             };
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(content);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(content);
 
             await _cachingReviewer.DeltaAsync(review, content);
 
@@ -116,7 +116,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 RawScore = "raw999",
             };
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(content);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(content);
 
             await _cachingReviewer.DeltaAsync(review, content);
 
@@ -140,7 +140,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                     RawScore = "raw999",
                 };
                 _deltaCacheService.Put(new DeltaCacheEntry(filePath, content, baselineContent, new DeltaResponseModel()));
-                _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(content);
+                _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(content);
 
                 await _cachingReviewer.DeltaAsync(review, content);
 
@@ -169,7 +169,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 RawScore = "empty123",
             };
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(string.Empty);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(string.Empty);
 
             var result = await _cachingReviewer.DeltaAsync(review, content);
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_ContentUnchanged_SkipsDeltaTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_ContentUnchanged_SkipsDeltaTests.cs
@@ -101,7 +101,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
 
             await _cachingReviewer.DeltaAsync(review, content);
 
-            _mockInnerReviewer.Verify(r => r.DeltaAsync(It.IsAny<FileReviewModel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()), Times.Never);
+            _mockInnerReviewer.Verify(r => r.DeltaAsync(It.IsAny<FileReviewModel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()), Times.Never);
         }
 
         [TestMethod]
@@ -175,7 +175,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
 
             Assert.IsNull(result);
             _mockLogger.Verify(l => l.Debug(It.Is<string>(msg => msg.Contains("Delta analysis skipped") && msg.Contains("content unchanged"))), Times.Once);
-            _mockInnerReviewer.Verify(r => r.DeltaAsync(It.IsAny<FileReviewModel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()), Times.Never);
+            _mockInnerReviewer.Verify(r => r.DeltaAsync(It.IsAny<FileReviewModel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()), Times.Never);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_DelegatesToInnerReviewerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_DelegatesToInnerReviewerTests.cs
@@ -45,13 +45,13 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
             _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
 
             _mockInnerReviewer
-                .Setup(r => r.DeltaAsync(review, currentCode, precomputedScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+                .Setup(r => r.DeltaAsync(review, currentCode, precomputedScore, It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync(expectedDelta);
 
             var result = await _cachingReviewer.DeltaAsync(review, currentCode, precomputedScore);
 
             Assert.AreEqual(expectedDelta, result);
-            _mockInnerReviewer.Verify(r => r.DeltaAsync(review, currentCode, precomputedScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()), Times.Once);
+            _mockInnerReviewer.Verify(r => r.DeltaAsync(review, currentCode, precomputedScore, It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()), Times.Once);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_DelegatesToInnerReviewerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_DelegatesToInnerReviewerTests.cs
@@ -42,7 +42,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
             var precomputedScore = "baseline123";
             var expectedDelta = new DeltaResponseModel();
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(path)).Returns(oldCode);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
 
             _mockInnerReviewer
                 .Setup(r => r.DeltaAsync(review, currentCode, precomputedScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()))

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_DeltaCacheHit_ReturnsCachedDeltaTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_DeltaCacheHit_ReturnsCachedDeltaTests.cs
@@ -70,7 +70,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
             };
 
             _deltaCacheService.Put(new DeltaCacheEntry(_tempFilePath, baselineCode, currentCode, cachedDelta));
-            _mockGitService.Setup(g => g.GetFileContentForCommit(_tempFilePath)).Returns(baselineCode);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(_tempFilePath, It.IsAny<string>())).Returns(baselineCode);
 
             var result = await _cachingReviewer.DeltaAsync(review, currentCode);
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_IdenticalScores_SkipsDeltaTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_IdenticalScores_SkipsDeltaTests.cs
@@ -58,7 +58,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 RawScore = identicalRawScore,
             };
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(oldContent);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(oldContent);
             _baselineCacheService.Put(filePath, oldContent, identicalRawScore);
 
             var result = await _cachingReviewer.DeltaAsync(review, currentContent);
@@ -81,7 +81,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 RawScore = identicalRawScore,
             };
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(oldContent);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(oldContent);
             _baselineCacheService.Put(filePath, oldContent, identicalRawScore);
 
             await _cachingReviewer.DeltaAsync(review, currentContent);
@@ -104,7 +104,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 RawScore = identicalRawScore,
             };
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(oldContent);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(oldContent);
             _baselineCacheService.Put(filePath, oldContent, identicalRawScore);
 
             await _cachingReviewer.DeltaAsync(review, currentContent);
@@ -127,7 +127,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 RawScore = identicalRawScore,
             };
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(oldContent);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(oldContent);
             _baselineCacheService.Put(filePath, oldContent, identicalRawScore);
 
             await _cachingReviewer.DeltaAsync(review, currentContent);
@@ -151,7 +151,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 RawScore = identicalRawScore,
             };
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(oldContent);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(oldContent);
 
             var result = await _cachingReviewer.DeltaAsync(review, currentContent, identicalRawScore);
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_InFlightCoalescingTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_InFlightCoalescingTests.cs
@@ -46,7 +46,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
 
             _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockInnerReviewer
-                .Setup(r => r.DeltaAsync(review, currentCode, precomputedBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+                .Setup(r => r.DeltaAsync(review, currentCode, precomputedBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .Returns(async () =>
                 {
                     entered.TrySetResult(true);
@@ -59,7 +59,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
 
             await entered.Task;
             _mockInnerReviewer.Verify(
-                r => r.DeltaAsync(review, currentCode, precomputedBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()),
+                r => r.DeltaAsync(review, currentCode, precomputedBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()),
                 Times.Once);
 
             gate.TrySetResult(true);
@@ -69,7 +69,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
             Assert.AreEqual(expectedDelta, firstResult);
             Assert.AreEqual(expectedDelta, secondResult);
             _mockInnerReviewer.Verify(
-                r => r.DeltaAsync(review, currentCode, precomputedBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()),
+                r => r.DeltaAsync(review, currentCode, precomputedBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()),
                 Times.Once);
         }
 
@@ -88,7 +88,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
 
             _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockInnerReviewer
-                .Setup(r => r.DeltaAsync(review, currentCode, firstBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+                .Setup(r => r.DeltaAsync(review, currentCode, firstBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .Returns(async () =>
                 {
                     firstEntered.TrySetResult(true);
@@ -96,7 +96,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                     return new DeltaResponseModel();
                 });
             _mockInnerReviewer
-                .Setup(r => r.DeltaAsync(review, currentCode, secondBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+                .Setup(r => r.DeltaAsync(review, currentCode, secondBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .Returns(async () =>
                 {
                     secondEntered.TrySetResult(true);
@@ -110,10 +110,10 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
             await Task.WhenAll(firstEntered.Task, secondEntered.Task);
 
             _mockInnerReviewer.Verify(
-                r => r.DeltaAsync(review, currentCode, firstBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()),
+                r => r.DeltaAsync(review, currentCode, firstBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()),
                 Times.Once);
             _mockInnerReviewer.Verify(
-                r => r.DeltaAsync(review, currentCode, secondBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()),
+                r => r.DeltaAsync(review, currentCode, secondBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()),
                 Times.Once);
 
             gate.TrySetResult(true);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_InFlightCoalescingTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_InFlightCoalescingTests.cs
@@ -44,7 +44,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
             var entered = new TaskCompletionSource<bool>();
             var gate = new TaskCompletionSource<bool>();
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(path)).Returns(oldCode);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockInnerReviewer
                 .Setup(r => r.DeltaAsync(review, currentCode, precomputedBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
                 .Returns(async () =>
@@ -86,7 +86,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
             var secondEntered = new TaskCompletionSource<bool>();
             var gate = new TaskCompletionSource<bool>();
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(path)).Returns(oldCode);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockInnerReviewer
                 .Setup(r => r.DeltaAsync(review, currentCode, firstBaselineRawScore, It.IsAny<long?>(), It.IsAny<CancellationToken>()))
                 .Returns(async () =>

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_WithNotifier_CallsNotifierTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_WithNotifier_CallsNotifierTests.cs
@@ -53,7 +53,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
 
             _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockInnerReviewer
-                .Setup(r => r.DeltaAsync(review, currentCode, It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+                .Setup(r => r.DeltaAsync(review, currentCode, It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync(expectedDelta);
 
             await _cachingReviewer.DeltaAsync(review, currentCode);
@@ -72,7 +72,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
 
             _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockInnerReviewer
-                .Setup(r => r.DeltaAsync(review, currentCode, It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+                .Setup(r => r.DeltaAsync(review, currentCode, It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ThrowsAsync(new Exception("Test exception"));
 
             await _cachingReviewer.DeltaAsync(review, currentCode);
@@ -91,7 +91,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
 
             _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockInnerReviewer
-                .Setup(r => r.DeltaAsync(review, currentCode, It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+                .Setup(r => r.DeltaAsync(review, currentCode, It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ThrowsAsync(new OperationCanceledException());
 
             await Assert.ThrowsAsync<OperationCanceledException>(() => _cachingReviewer.DeltaAsync(review, currentCode));

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_WithNotifier_CallsNotifierTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_WithNotifier_CallsNotifierTests.cs
@@ -51,7 +51,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
             var oldCode = "old code";
             var expectedDelta = new DeltaResponseModel();
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(path)).Returns(oldCode);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockInnerReviewer
                 .Setup(r => r.DeltaAsync(review, currentCode, It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(expectedDelta);
@@ -70,7 +70,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
             var currentCode = "current code";
             var oldCode = "old code";
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(path)).Returns(oldCode);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockInnerReviewer
                 .Setup(r => r.DeltaAsync(review, currentCode, It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Test exception"));
@@ -89,7 +89,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
             var currentCode = "current code";
             var oldCode = "old code";
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(path)).Returns(oldCode);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockInnerReviewer
                 .Setup(r => r.DeltaAsync(review, currentCode, It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new OperationCanceledException());

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_WithTelemetryManager_SendsTelemetryTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_WithTelemetryManager_SendsTelemetryTests.cs
@@ -98,7 +98,8 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<long?>(),
-                It.IsAny<CancellationToken>())).ReturnsAsync(expectedDelta);
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string>())).ReturnsAsync(expectedDelta);
 
             var result = await _cachingReviewer.DeltaAsync(review, currentContent);
 
@@ -143,7 +144,8 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<long?>(),
-                It.IsAny<CancellationToken>())).ReturnsAsync(expectedDelta);
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string>())).ReturnsAsync(expectedDelta);
 
             var result = await _cachingReviewer.DeltaAsync(review, currentContent);
 
@@ -191,7 +193,8 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<long?>(),
-                It.IsAny<CancellationToken>())).ReturnsAsync(expectedDelta);
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string>())).ReturnsAsync(expectedDelta);
 
             var result = await cachingReviewerWithoutTelemetry.DeltaAsync(review, currentContent);
 
@@ -234,7 +237,8 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<long?>(),
-                It.IsAny<CancellationToken>())).ReturnsAsync(expectedDelta);
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string>())).ReturnsAsync(expectedDelta);
 
             var result = await _cachingReviewer.DeltaAsync(review, currentContent);
 
@@ -288,7 +292,8 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<long?>(),
-                It.IsAny<CancellationToken>())).ReturnsAsync(CreateDeltaResponse(0.5m));
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string>())).ReturnsAsync(CreateDeltaResponse(0.5m));
 
             var result1 = await _cachingReviewer.DeltaAsync(review1, currentContent1);
             var result2 = await _cachingReviewer.DeltaAsync(review2, currentContent2);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_WithTelemetryManager_SendsTelemetryTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/DeltaAsync_WithTelemetryManager_SendsTelemetryTests.cs
@@ -91,7 +91,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 .Callback(() => telemetrySent.TrySetResult(true))
                 .Returns(Task.CompletedTask);
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(oldContent);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(oldContent);
             _baselineCacheService.Put(filePath, oldContent, oldRawScore);
             _mockInnerReviewer.Setup(r => r.DeltaAsync(
                 It.IsAny<FileReviewModel>(),
@@ -136,7 +136,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 .Callback(() => telemetrySent.TrySetResult(true))
                 .Returns(Task.CompletedTask);
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(oldContent);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(oldContent);
             _baselineCacheService.Put(filePath, oldContent, oldRawScore);
             _mockInnerReviewer.Setup(r => r.DeltaAsync(
                 It.IsAny<FileReviewModel>(),
@@ -184,7 +184,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
 
             var expectedDelta = CreateDeltaResponse(0.0m);
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(oldContent);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(oldContent);
             _baselineCacheService.Put(filePath, oldContent, oldRawScore);
             _mockInnerReviewer.Setup(r => r.DeltaAsync(
                 It.IsAny<FileReviewModel>(),
@@ -222,7 +222,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 .Callback(() => telemetrySent.TrySetResult(true))
                 .Returns(Task.CompletedTask);
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath)).Returns(oldContent);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath, It.IsAny<string>())).Returns(oldContent);
             _mockInnerReviewer.Setup(r => r.ReviewAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
@@ -279,8 +279,8 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
                 .Callback(() => telemetrySent.TrySetResult(true))
                 .Returns(Task.CompletedTask);
 
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath1)).Returns(oldContent1);
-            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath2)).Returns(oldContent2);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath1, It.IsAny<string>())).Returns(oldContent1);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(filePath2, It.IsAny<string>())).Returns(oldContent2);
             _baselineCacheService.Put(filePath1, oldContent1, "oldScore1");
             _baselineCacheService.Put(filePath2, oldContent2, "oldScore2");
             _mockInnerReviewer.Setup(r => r.DeltaAsync(

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/ReviewAndBaselineAsync_CacheHit_ReturnsCachedReviewTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/ReviewAndBaselineAsync_CacheHit_ReturnsCachedReviewTests.cs
@@ -56,7 +56,7 @@ namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
 
             _reviewCacheService.Put(new ReviewCacheEntry(currentCode, path.ToLowerInvariant(), cachedReview));
             _baselineCacheService.Put(path, baselineCode, cachedBaselineRawScore);
-            _mockGitService.Setup(g => g.GetFileContentForCommit(path)).Returns(baselineCode);
+            _mockGitService.Setup(g => g.GetFileContentForCommit(path, It.IsAny<string>())).Returns(baselineCode);
 
             var result = await _cachingReviewer.ReviewAndBaselineAsync(path, currentCode);
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/ReviewWithDeltaAsync_BaselineCommit_UsesProvidedCommitTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CachingCodeReviewerTests/ReviewWithDeltaAsync_BaselineCommit_UsesProvidedCommitTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Collections.Concurrent;
+using Codescene.VSExtension.Core.Application.Cache.Review;
+using Codescene.VSExtension.Core.Application.Cli;
+using Codescene.VSExtension.Core.Interfaces;
+using Codescene.VSExtension.Core.Interfaces.Cli;
+using Codescene.VSExtension.Core.Interfaces.Git;
+using Codescene.VSExtension.Core.Models;
+using Codescene.VSExtension.Core.Models.Cache.Review;
+using Codescene.VSExtension.Core.Models.Cli.Delta;
+using Moq;
+
+namespace Codescene.VSExtension.Core.Tests.CachingCodeReviewerTests
+{
+    [TestClass]
+    public class ReviewWithDeltaAsync_BaselineCommit_UsesProvidedCommitTests
+    {
+        private Mock<ICodeReviewer> _mockInnerReviewer;
+        private Mock<ILogger> _mockLogger;
+        private Mock<IGitService> _mockGitService;
+        private ReviewCacheService _cacheService;
+        private CachingCodeReviewer _cachingReviewer;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _mockInnerReviewer = new Mock<ICodeReviewer>();
+            _mockLogger = new Mock<ILogger>();
+            _mockGitService = new Mock<IGitService>();
+            _cacheService = new ReviewCacheService(new ConcurrentDictionary<string, ReviewCacheItem>());
+            _cachingReviewer = new CachingCodeReviewer(_mockInnerReviewer.Object, _cacheService, null, null, _mockLogger.Object, _mockGitService.Object, null);
+        }
+
+        [TestMethod]
+        public async Task DeltaAsync_WithBaselineCommit_UsesProvidedCommitForFileContent()
+        {
+            var path = "test.cs";
+            var review = new FileReviewModel { FilePath = path, Score = 8.0f, RawScore = "9.5" };
+            var currentCode = "current code";
+            var oldCode = "old code";
+            var baselineCommit = "abc123";
+            var expectedDelta = new DeltaResponseModel();
+
+            _mockGitService.Setup(g => g.GetFileContentForCommit(path, baselineCommit)).Returns(oldCode);
+
+            _mockInnerReviewer
+                .Setup(r => r.DeltaAsync(review, currentCode, It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .ReturnsAsync(expectedDelta);
+
+            await _cachingReviewer.DeltaAsync(review, currentCode, null, null, default, baselineCommit);
+
+            _mockGitService.Verify(g => g.GetFileContentForCommit(path, baselineCommit), Times.Once);
+            _mockGitService.Verify(g => g.GetFileContentForCommit(It.IsAny<string>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task DeltaAsync_WithoutBaselineCommit_CallsSingleArgOverload()
+        {
+            var path = "test.cs";
+            var review = new FileReviewModel { FilePath = path, Score = 8.0f, RawScore = "9.5" };
+            var currentCode = "current code";
+            var oldCode = "old code";
+            var expectedDelta = new DeltaResponseModel();
+
+            _mockGitService.Setup(g => g.GetFileContentForCommit(path, null)).Returns(oldCode);
+
+            _mockInnerReviewer
+                .Setup(r => r.DeltaAsync(review, currentCode, It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .ReturnsAsync(expectedDelta);
+
+            await _cachingReviewer.DeltaAsync(review, currentCode, null, null, default, null);
+
+            _mockGitService.Verify(g => g.GetFileContentForCommit(path, null), Times.Once);
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CodeReviewerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CodeReviewerTests.cs
@@ -211,7 +211,7 @@ namespace Codescene.VSExtension.Core.Tests
             var review = new FileReviewModel { FilePath = "test.cs", RawScore = "raw" };
             var expectedException = new Exception("Git error");
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>()))
+            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>(), It.IsAny<string>()))
                 .Throws(expectedException);
 
             var result = await _codeReviewer.DeltaAsync(review, "current code");
@@ -226,7 +226,7 @@ namespace Codescene.VSExtension.Core.Tests
             var review = new FileReviewModel { FilePath = "test.cs", RawScore = "raw" };
             var expectedException = new InvalidOperationException("delta failed");
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>())).Returns("old");
+            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>(), It.IsAny<string>())).Returns("old");
             _mockExecutor.Setup(x => x.ReviewContentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CliReviewModel { RawScore = "old-raw" });
             _mockMapper.Setup(x => x.Map(It.IsAny<string>(), It.IsAny<CliReviewModel>()))
@@ -246,7 +246,7 @@ namespace Codescene.VSExtension.Core.Tests
             // Arrange
             var review = new FileReviewModel { FilePath = "test.cs", RawScore = null };
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>()))
+            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns("old code");
             _mockExecutor.Setup(x => x.ReviewContentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CliReviewModel { RawScore = "old-raw" });
@@ -269,7 +269,7 @@ namespace Codescene.VSExtension.Core.Tests
             var review = new FileReviewModel { FilePath = "test.cs", RawScore = "raw-score" };
             var expectedDelta = new DeltaResponseModel { ScoreChange = 0m };
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>()))
+            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(currentCode);
             _mockExecutor.Setup(x => x.ReviewDeltaAsync(It.IsAny<ReviewDeltaRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(expectedDelta);
@@ -289,7 +289,7 @@ namespace Codescene.VSExtension.Core.Tests
             var review = new FileReviewModel { FilePath = "test.cs", RawScore = identicalRawScore };
             var expectedDelta = new DeltaResponseModel { ScoreChange = 0m };
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>()))
+            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(oldCode);
             _mockExecutor.Setup(x => x.ReviewContentAsync(It.IsAny<string>(), oldCode, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CliReviewModel { RawScore = identicalRawScore });
@@ -312,7 +312,7 @@ namespace Codescene.VSExtension.Core.Tests
             var currentCode = "public class Test { int x; }";
             var review = new FileReviewModel { FilePath = "test.cs", RawScore = "new-raw" };
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>()))
+            _mockGitService.Setup(x => x.GetFileContentForCommit(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(oldCode);
             _mockExecutor.Setup(x => x.ReviewContentAsync(It.IsAny<string>(), oldCode, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CliReviewModel { RawScore = "old-raw" });
@@ -339,7 +339,7 @@ namespace Codescene.VSExtension.Core.Tests
             var cliReview = new CliReviewModel { RawScore = "current-raw" };
             var baselineCliReview = new CliReviewModel { RawScore = "baseline-raw" };
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(path)).Returns(oldCode);
+            _mockGitService.Setup(x => x.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockExecutor.Setup(x => x.ReviewContentAsync("test.cs", currentCode, false, It.IsAny<CancellationToken>())).ReturnsAsync(cliReview);
             _mockExecutor.Setup(x => x.ReviewContentAsync("test.cs", oldCode, true, It.IsAny<CancellationToken>())).ReturnsAsync(baselineCliReview);
             _mockMapper.Setup(x => x.Map(path, cliReview)).Returns(review);
@@ -360,7 +360,7 @@ namespace Codescene.VSExtension.Core.Tests
             var cliReview = new CliReviewModel { RawScore = "current-raw" };
             var review = new FileReviewModel { FilePath = path, RawScore = "current-raw" };
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(path)).Returns((string)null);
+            _mockGitService.Setup(x => x.GetFileContentForCommit(path, It.IsAny<string>())).Returns((string)null);
             _mockExecutor.Setup(x => x.ReviewContentAsync("test.cs", currentCode, false, It.IsAny<CancellationToken>())).ReturnsAsync(cliReview);
             _mockMapper.Setup(x => x.Map(path, cliReview)).Returns(review);
 
@@ -429,7 +429,7 @@ namespace Codescene.VSExtension.Core.Tests
             var content = "public class Test { }";
             var review = new FileReviewModel { FilePath = path, RawScore = null };
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(path)).Returns("old code");
+            _mockGitService.Setup(x => x.GetFileContentForCommit(path, It.IsAny<string>())).Returns("old code");
             _mockExecutor.Setup(x => x.ReviewContentAsync("test.cs", content, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CliReviewModel { RawScore = null });
             _mockMapper.Setup(x => x.Map(path, It.IsAny<CliReviewModel>())).Returns(review);
@@ -468,7 +468,7 @@ namespace Codescene.VSExtension.Core.Tests
                 null,
                 mockPreflight.Object);
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(path)).Returns("old");
+            _mockGitService.Setup(x => x.GetFileContentForCommit(path, It.IsAny<string>())).Returns("old");
             _mockExecutor.Setup(x => x.ReviewContentAsync(It.IsAny<string>(), "old", true, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new CliReviewModel { RawScore = "old-raw" });
             _mockMapper.Setup(x => x.Map(It.IsAny<string>(), It.IsAny<CliReviewModel>()))
@@ -505,7 +505,7 @@ namespace Codescene.VSExtension.Core.Tests
                 null,
                 mockPreflight.Object);
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(path)).Returns("old");
+            _mockGitService.Setup(x => x.GetFileContentForCommit(path, It.IsAny<string>())).Returns("old");
             _mockExecutor.Setup(x => x.ReviewDeltaAsync(It.IsAny<ReviewDeltaRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(delta);
             mockPreflight.Setup(x => x.GetPreflightResponseAsync(It.IsAny<CancellationToken>()))
@@ -545,7 +545,7 @@ namespace Codescene.VSExtension.Core.Tests
                 null,
                 mockPreflight.Object);
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(path)).Returns("old");
+            _mockGitService.Setup(x => x.GetFileContentForCommit(path, It.IsAny<string>())).Returns("old");
             _mockExecutor.Setup(x => x.ReviewDeltaAsync(It.IsAny<ReviewDeltaRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(delta);
             mockPreflight.Setup(x => x.GetPreflightResponseAsync(It.IsAny<CancellationToken>()))

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CodeReviewerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CodeReviewerTests.cs
@@ -372,7 +372,7 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
-        public async Task GetOrComputeBaselineRawScoreAsync_WhenBaselineContentEmpty_ReturnsEmptyWithoutCallingExecutor()
+        public async Task GetOrComputeBaselineRawScoreAsync_WhenBaselineContentEmptyAndNoCommit_ReturnsEmptyWithoutCallingExecutor()
         {
             var path = "test.cs";
             var baselineContent = string.Empty;
@@ -381,6 +381,28 @@ namespace Codescene.VSExtension.Core.Tests
 
             Assert.AreEqual(string.Empty, result);
             _mockExecutor.Verify(x => x.ReviewContentAsync(It.IsAny<string>(), It.Is<string>(s => string.IsNullOrWhiteSpace(s)), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task GetOrComputeBaselineRawScoreAsync_WhenBaselineContentEmptyButCommitProvided_RetrievesFromGit()
+        {
+            var path = "test.cs";
+            var baselineContent = string.Empty;
+            var baselineCommit = "abc123";
+            var gitContent = "public class FromGit { }";
+            var expectedRawScore = "git-raw-score";
+
+            _mockGitService.Setup(x => x.GetFileContentForCommit(path, baselineCommit)).Returns(gitContent);
+            _mockExecutor.Setup(x => x.ReviewContentAsync(path, gitContent, true, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CliReviewModel { RawScore = expectedRawScore });
+            _mockMapper.Setup(x => x.Map(path, It.IsAny<CliReviewModel>()))
+                .Returns(new FileReviewModel { RawScore = expectedRawScore });
+
+            var result = await _codeReviewer.GetOrComputeBaselineRawScoreAsync(path, baselineContent, baselineCommit: baselineCommit);
+
+            Assert.AreEqual(expectedRawScore, result);
+            _mockGitService.Verify(x => x.GetFileContentForCommit(path, baselineCommit), Times.Once);
+            _mockExecutor.Verify(x => x.ReviewContentAsync(path, gitContent, true, It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/FileChangeEventProcessorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/FileChangeEventProcessorTests.cs
@@ -17,7 +17,7 @@ namespace Codescene.VSExtension.Core.Tests
             FileChangeEvent capturedEvt = null;
             List<string> capturedChangedFiles = null;
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processEventInvoked = true;
                 capturedEvt = evt;
@@ -58,7 +58,7 @@ namespace Codescene.VSExtension.Core.Tests
                 && entry.Ex != null
                 && entry.Ex.Message.Contains("simulated error");
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct) =>
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit) =>
                 throw new InvalidOperationException("simulated error");
 
             Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
@@ -84,7 +84,7 @@ namespace Codescene.VSExtension.Core.Tests
             var taskScheduler = new FakeAsyncTaskScheduler();
             var processedEvents = new List<FileChangeEvent>();
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processedEvents.Add(evt);
                 return Task.CompletedTask;
@@ -117,7 +117,7 @@ namespace Codescene.VSExtension.Core.Tests
             var taskScheduler = new FakeAsyncTaskScheduler();
             var processedEvents = new List<FileChangeEvent>();
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processedEvents.Add(evt);
                 return Task.CompletedTask;
@@ -149,7 +149,7 @@ namespace Codescene.VSExtension.Core.Tests
             var taskScheduler = new FakeAsyncTaskScheduler();
             var processedEvents = new List<FileChangeEvent>();
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processedEvents.Add(evt);
                 return Task.CompletedTask;
@@ -181,7 +181,7 @@ namespace Codescene.VSExtension.Core.Tests
             var taskScheduler = new FakeAsyncTaskScheduler();
             var processedEvents = new List<FileChangeEvent>();
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processedEvents.Add(evt);
                 return Task.CompletedTask;
@@ -214,7 +214,7 @@ namespace Codescene.VSExtension.Core.Tests
             var taskScheduler = new FakeAsyncTaskScheduler();
             var processEventInvoked = false;
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processEventInvoked = true;
                 return Task.CompletedTask;
@@ -243,7 +243,7 @@ namespace Codescene.VSExtension.Core.Tests
             var taskScheduler = new FakeAsyncTaskScheduler();
             var processEventInvoked = false;
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processEventInvoked = true;
                 return Task.CompletedTask;
@@ -270,7 +270,7 @@ namespace Codescene.VSExtension.Core.Tests
 
             using (var cts = new CancellationTokenSource())
             {
-                Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+                Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
                 {
                     if (evt.FilePath == "first.cs")
                     {
@@ -307,7 +307,7 @@ namespace Codescene.VSExtension.Core.Tests
             var taskScheduler = new FakeAsyncTaskScheduler();
             var processedEvents = new List<FileChangeEvent>();
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processedEvents.Add(evt);
                 return Task.CompletedTask;
@@ -347,7 +347,7 @@ namespace Codescene.VSExtension.Core.Tests
             var taskScheduler = new FakeAsyncTaskScheduler();
             var processedEvents = new List<FileChangeEvent>();
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processedEvents.Add(evt);
                 return Task.CompletedTask;
@@ -383,7 +383,7 @@ namespace Codescene.VSExtension.Core.Tests
             var taskScheduler = new FakeAsyncTaskScheduler();
             var processedEvents = new List<FileChangeEvent>();
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processedEvents.Add(evt);
                 return Task.CompletedTask;
@@ -419,7 +419,7 @@ namespace Codescene.VSExtension.Core.Tests
             var taskScheduler = new FakeAsyncTaskScheduler();
             var processedEvents = new List<FileChangeEvent>();
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processedEvents.Add(evt);
                 return Task.CompletedTask;
@@ -456,7 +456,7 @@ namespace Codescene.VSExtension.Core.Tests
             var skipState = false;
             var callbackInvocationCount = 0;
 
-            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct)
+            Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit)
             {
                 processedEvents.Add(evt);
                 return Task.CompletedTask;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/FileChangeEventProcessorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/FileChangeEventProcessorTests.cs
@@ -25,7 +25,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string> { "file1.cs" });
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string> { "file1.cs" });
 
             using (var processor = new FileChangeEventProcessor(logger, taskScheduler, ProcessEvent, GetChangedFiles))
             {
@@ -61,7 +61,7 @@ namespace Codescene.VSExtension.Core.Tests
             Task ProcessEvent(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken ct, string baselineCommit) =>
                 throw new InvalidOperationException("simulated error");
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var processor = new FileChangeEventProcessor(logger, taskScheduler, ProcessEvent, GetChangedFiles))
             {
@@ -90,7 +90,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var processor = new FileChangeEventProcessor(logger, taskScheduler, ProcessEvent, GetChangedFiles))
             {
@@ -123,7 +123,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var processor = new FileChangeEventProcessor(logger, taskScheduler, ProcessEvent, GetChangedFiles))
             {
@@ -155,7 +155,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var processor = new FileChangeEventProcessor(logger, taskScheduler, ProcessEvent, GetChangedFiles))
             {
@@ -187,7 +187,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var processor = new FileChangeEventProcessor(logger, taskScheduler, ProcessEvent, GetChangedFiles))
             {
@@ -220,7 +220,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var cts = new CancellationTokenSource())
             {
@@ -249,7 +249,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var processor = new FileChangeEventProcessor(logger, taskScheduler, ProcessEvent, GetChangedFiles))
             {
@@ -285,7 +285,7 @@ namespace Codescene.VSExtension.Core.Tests
                     return Task.CompletedTask;
                 }
 
-                Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+                Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
                 using (var processor = new FileChangeEventProcessor(logger, taskScheduler, ProcessEvent, GetChangedFiles))
                 {
@@ -313,7 +313,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var processor = new FileChangeEventProcessor(
                 logger,
@@ -353,7 +353,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var processor = new FileChangeEventProcessor(
                 logger,
@@ -389,7 +389,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var processor = new FileChangeEventProcessor(
                 logger,
@@ -425,7 +425,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var processor = new FileChangeEventProcessor(
                 logger,
@@ -462,7 +462,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.CompletedTask;
             }
 
-            Task<List<string>> GetChangedFiles() => Task.FromResult(new List<string>());
+            Task<List<string>> GetChangedFiles(string baselineCommit) => Task.FromResult(new List<string>());
 
             using (var processor = new FileChangeEventProcessor(
                 logger,

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorChangedFilesTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorChangedFilesTests.cs
@@ -51,9 +51,9 @@ namespace Codescene.VSExtension.Core.Tests
             _fakeLogger.ClearDebugMessages();
 
             await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
             await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             var noMergeBaseLogs = _fakeLogger.SnapshotDebugMessages()
                 .Count(m => m.Contains("No merge base commit found, using working directory changes only"));
@@ -87,14 +87,14 @@ namespace Codescene.VSExtension.Core.Tests
             _fakeLogger.ClearDebugMessages();
 
             await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
             await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             _detector.ClearMainBranchCandidatesCache();
 
             await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             var noMergeBaseLogs = _fakeLogger.SnapshotDebugMessages()
                 .Count(m => m.Contains("No merge base commit found, using working directory changes only"));
@@ -114,7 +114,7 @@ namespace Codescene.VSExtension.Core.Tests
             CommitFile("feature.cs", "public class Feature {}", "Add feature");
 
             var changedFiles = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsTrue(
                 changedFiles.Any(f => f.EndsWith("feature.cs")),
@@ -155,7 +155,7 @@ namespace Codescene.VSExtension.Core.Tests
             CommitFile("feature.cs", "public class Feature {}", "Add feature");
 
             var changedFiles = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsTrue(
                 changedFiles.Any(f => f.EndsWith("feature.cs")),
@@ -177,7 +177,7 @@ namespace Codescene.VSExtension.Core.Tests
             File.WriteAllText(filePath, "public class Detached {}");
 
             var changedFiles = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(
                 changedFiles,
@@ -191,7 +191,7 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task GetChangedFilesVsBaselineAsync_NullGitRootPath_ReturnsEmptyList()
         {
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                null, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                null, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result);
             Assert.IsEmpty(result);
@@ -201,7 +201,7 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task GetChangedFilesVsBaselineAsync_EmptyGitRootPath_ReturnsEmptyList()
         {
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                string.Empty, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                string.Empty, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result);
             Assert.IsEmpty(result);
@@ -213,7 +213,7 @@ namespace Codescene.VSExtension.Core.Tests
             var nonExistentPath = Path.Combine(Path.GetTempPath(), $"nonexistent-{Guid.NewGuid()}");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                nonExistentPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                nonExistentPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result);
             Assert.IsEmpty(result);
@@ -228,7 +228,7 @@ namespace Codescene.VSExtension.Core.Tests
             try
             {
                 var result = await _detector.GetChangedFilesVsBaselineAsync(
-                    tempDir, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                    tempDir, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
                 Assert.IsNotNull(result);
                 Assert.IsEmpty(result);
@@ -261,7 +261,7 @@ namespace Codescene.VSExtension.Core.Tests
             }
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result);
             Assert.IsEmpty(result);
@@ -273,7 +273,7 @@ namespace Codescene.VSExtension.Core.Tests
             CommitFile("test.cs", "public class Test {}", "Add test file");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, null, _fakeOpenFilesObserver);
+                _testRepoPath, null, null, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result);
         }
@@ -284,7 +284,7 @@ namespace Codescene.VSExtension.Core.Tests
             CommitFile("test.cs", "public class Test {}", "Add test file");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, null);
+                _testRepoPath, null, _fakeSavedFilesTracker, null, string.Empty);
 
             Assert.IsNotNull(result);
         }
@@ -319,7 +319,7 @@ namespace Codescene.VSExtension.Core.Tests
             File.WriteAllText(testFilePath, "public class NewFile {}");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result);
             Assert.IsTrue(
@@ -340,7 +340,7 @@ namespace Codescene.VSExtension.Core.Tests
             CommitFile("test.cs", "public class Test {}", "Add cs file");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsTrue(
                 result.Any(f => f.EndsWith("test.cs")),
@@ -364,7 +364,7 @@ namespace Codescene.VSExtension.Core.Tests
             CommitFile("file3.py", "def test():\n    pass", "Add file3");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsTrue(result.Any(f => f.EndsWith("file1.cs")));
             Assert.IsTrue(result.Any(f => f.EndsWith("file2.js")));
@@ -378,7 +378,7 @@ namespace Codescene.VSExtension.Core.Tests
             File.WriteAllText(testFilePath, "public class NewFile {}");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result);
             Assert.IsTrue(
@@ -400,7 +400,7 @@ namespace Codescene.VSExtension.Core.Tests
             File.WriteAllText(testFilePath, "public class Test { /* modified */ }");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             var testFileCount = result.Count(f => f.EndsWith("test.cs"));
             Assert.AreEqual(1, testFileCount, "Should deduplicate files that appear in both committed and status changes");
@@ -435,7 +435,7 @@ namespace Codescene.VSExtension.Core.Tests
             File.WriteAllText(newFile, "public class Test {}");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotEmpty(result, "Should detect working directory changes");
             Assert.IsTrue(result.Any(f => f.Contains("test.cs")), "Should include new file");
@@ -450,7 +450,7 @@ namespace Codescene.VSExtension.Core.Tests
             File.WriteAllText(modifiedFile, "public class Modified {}");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsTrue(
                 result.Any(f => f.Contains("modified.cs")),
@@ -480,7 +480,7 @@ namespace Codescene.VSExtension.Core.Tests
             File.WriteAllText(normalFile, "public class Test {}");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsTrue(
                 result.Any(f => f.Contains("test.cs")),
@@ -511,7 +511,7 @@ namespace Codescene.VSExtension.Core.Tests
             File.WriteAllText(Path.Combine(_testRepoPath, "outside.cs"), "public class OutsideModified {}");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, new[] { workspaceSubdir }, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, new[] { workspaceSubdir }, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsTrue(
                 result.Any(f => f.Replace('\\', '/').Equals("workspace-subdir/inside.cs")),

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorExceptionTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorExceptionTests.cs
@@ -14,7 +14,7 @@ namespace Codescene.VSExtension.Core.Tests
             testableDetector.ThrowInGetChangedFilesFromRepository = true;
 
             var result = await testableDetector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsEmpty(result, "Should return empty list on exception");
             Assert.IsTrue(
@@ -29,7 +29,7 @@ namespace Codescene.VSExtension.Core.Tests
             testableDetector.ThrowFromMainBranchCandidates = true;
 
             var result = await testableDetector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsTrue(
                 _fakeLogger.SnapshotDebugMessages().Any(m => m.Contains("Could not determine merge base")),
@@ -40,7 +40,7 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task GetChangedFilesVsBaselineAsync_InvalidGitRootPath_ReturnsEmptyList()
         {
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                string.Empty, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                string.Empty, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsEmpty(result, "Should return empty list for invalid git root path");
         }
@@ -49,7 +49,7 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task GetChangedFilesVsBaselineAsync_NonexistentGitRootPath_ReturnsEmptyList()
         {
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                "C:\\nonexistent\\path", null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                "C:\\nonexistent\\path", null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsEmpty(result, "Should return empty list for nonexistent git root path");
         }
@@ -110,7 +110,7 @@ namespace Codescene.VSExtension.Core.Tests
             ExecGit($"checkout {originalBranch}");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle orphaned branches gracefully");
         }
@@ -132,7 +132,7 @@ namespace Codescene.VSExtension.Core.Tests
             ExecGit($"checkout {originalBranch}");
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle multiple orphaned branches gracefully");
         }
@@ -147,7 +147,7 @@ namespace Codescene.VSExtension.Core.Tests
             }
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle complex diff scenarios gracefully");
         }
@@ -161,7 +161,7 @@ namespace Codescene.VSExtension.Core.Tests
             }
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle many unstaged files gracefully");
         }
@@ -176,7 +176,7 @@ namespace Codescene.VSExtension.Core.Tests
             testableDetector.SimulateInvalidCurrentBranch = true;
 
             var result = await testableDetector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should return non-null result even with invalid branch");
         }
@@ -191,7 +191,7 @@ namespace Codescene.VSExtension.Core.Tests
             testableDetector.SimulateInvalidMainBranch = true;
 
             var result = await testableDetector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle invalid main branch gracefully");
         }
@@ -206,7 +206,7 @@ namespace Codescene.VSExtension.Core.Tests
             testableDetector.ThrowFromFindMergeBase = true;
 
             var result = await testableDetector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle FindMergeBase exception gracefully");
             Assert.IsTrue(
@@ -224,7 +224,7 @@ namespace Codescene.VSExtension.Core.Tests
             testableDetector.ThrowFromDiffCompare = true;
 
             var result = await testableDetector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle Diff.Compare exception gracefully");
             Assert.IsTrue(
@@ -242,7 +242,7 @@ namespace Codescene.VSExtension.Core.Tests
             testableDetector.ThrowFromRetrieveStatus = true;
 
             var result = await testableDetector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle RetrieveStatus exception gracefully");
             Assert.IsTrue(
@@ -265,7 +265,7 @@ namespace Codescene.VSExtension.Core.Tests
                 }
 
                 var result = await _detector.GetChangedFilesVsBaselineAsync(
-                    unbornRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                    unbornRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
                 Assert.IsEmpty(result, "Should return empty list for unborn HEAD");
             }
@@ -307,7 +307,7 @@ namespace Codescene.VSExtension.Core.Tests
             testableDetector.ForceBranchLookupFailure = "nonexistent-branch";
 
             var result = await testableDetector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle non-existent branch gracefully");
         }
@@ -336,7 +336,7 @@ namespace Codescene.VSExtension.Core.Tests
             }
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle corrupted repository gracefully");
         }
@@ -351,7 +351,7 @@ namespace Codescene.VSExtension.Core.Tests
             CorruptGitObjects();
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle corrupted objects gracefully");
         }
@@ -363,7 +363,7 @@ namespace Codescene.VSExtension.Core.Tests
             CorruptGitIndex();
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             Assert.IsNotNull(result, "Should handle corrupted index gracefully");
         }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorExclusionTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorExclusionTests.cs
@@ -24,7 +24,7 @@ namespace Codescene.VSExtension.Core.Tests
             _fakeSavedFilesTracker.AddSavedFile(testFilePath);
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             var normalizedResult = result.Select(f => f.Replace('/', '\\')).ToList();
             Assert.IsFalse(
@@ -49,7 +49,7 @@ namespace Codescene.VSExtension.Core.Tests
             _fakeOpenFilesObserver.SetActiveDocument(testFilePath);
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             var normalizedResult = result.Select(f => f.Replace('/', '\\')).ToList();
             Assert.IsTrue(
@@ -70,7 +70,7 @@ namespace Codescene.VSExtension.Core.Tests
             _fakeOpenFilesObserver.SetActiveDocument(committedFilePath);
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             var normalizedResult = result.Select(f => f.Replace('/', '\\')).ToList();
             Assert.IsTrue(
@@ -86,7 +86,7 @@ namespace Codescene.VSExtension.Core.Tests
             _fakeSavedFilesTracker.AddSavedFile(excludedPath);
 
             var result = await _detector.GetChangedFilesVsBaselineAsync(
-                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver);
+                _testRepoPath, null, _fakeSavedFilesTracker, _fakeOpenFilesObserver, string.Empty);
 
             var normalizedResult = result.Select(f => f.Replace('/', '\\')).ToList();
             Assert.IsFalse(

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorMainBranchTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorMainBranchTests.cs
@@ -270,7 +270,8 @@ namespace Codescene.VSExtension.Core.Tests
                 _testRepoPath,
                 new[] { _testRepoPath },
                 _fakeSavedFilesTracker,
-                _fakeOpenFilesObserver);
+                _fakeOpenFilesObserver,
+                string.Empty);
 
             Assert.Contains(
                 "test.cs",

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorTestBase.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeDetectorTestBase.cs
@@ -409,14 +409,14 @@ namespace Codescene.VSExtension.Core.Tests
                 return base.GetMergeBaseCommit(repo);
             }
 
-            protected override List<string> GetChangedFilesFromRepository(Repository repo, ChangeDetectionContext context)
+            protected override List<string> GetChangedFilesFromRepository(Repository repo, ChangeDetectionContext context, string baselineCommit)
             {
                 if (ThrowInGetChangedFilesFromRepository)
                 {
                     throw new LibGit2SharpException("Simulated LibGit2Sharp exception");
                 }
 
-                return base.GetChangedFilesFromRepository(repo, context);
+                return base.GetChangedFilesFromRepository(repo, context, baselineCommit);
             }
 
             protected override Commit? TryFindMergeBase(Repository repo, Branch currentBranch, string candidateName)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
@@ -219,27 +219,27 @@ namespace Codescene.VSExtension.Core.Tests
             return Task.FromResult(new FileReviewModel { FilePath = path, RawScore = "8.5" });
         }
 
-        public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
             var review = await ReviewAsync(path, currentCode, false, operationGeneration, cancellationToken);
-            var baselineRawScore = await GetOrComputeBaselineRawScoreAsync(path, string.Empty, operationGeneration, cancellationToken);
+            var baselineRawScore = await GetOrComputeBaselineRawScoreAsync(path, string.Empty, operationGeneration, cancellationToken, baselineCommit);
             return (review, baselineRawScore ?? string.Empty);
         }
 
-        public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
-            var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken);
-            var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken);
+            var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken, baselineCommit);
+            var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken, baselineCommit);
             return (review, delta);
         }
 
-        public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default) =>
+        public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null) =>
             Task.FromResult("8.0");
 
         public FileReviewModel Review(string path, string content) =>
             ReviewAsync(path, content).GetAwaiter().GetResult();
 
-        public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default) =>
+        public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null) =>
             Task.FromResult<DeltaResponseModel>(null);
 
         public DeltaResponseModel Delta(FileReviewModel review, string currentCode) =>
@@ -274,6 +274,11 @@ namespace Codescene.VSExtension.Core.Tests
             return string.Empty;
         }
 
+        public string GetFileContentForCommit(string path, string baselineCommit)
+        {
+            return string.Empty;
+        }
+
         public bool IsFileIgnored(string filePath)
         {
             return false;
@@ -304,6 +309,11 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         public string GetFileContentForCommit(string path)
+        {
+            return string.Empty;
+        }
+
+        public string GetFileContentForCommit(string path, string baselineCommit)
         {
             return string.Empty;
         }
@@ -347,6 +357,11 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         public string GetFileContentForCommit(string path)
+        {
+            return string.Empty;
+        }
+
+        public string GetFileContentForCommit(string path, string baselineCommit)
         {
             return string.Empty;
         }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
@@ -269,6 +269,11 @@ namespace Codescene.VSExtension.Core.Tests
 
     public class FakeGitService : IGitService
     {
+        public string GetBaselineCommit(string repoRootPath)
+        {
+            return string.Empty;
+        }
+
         public string GetFileContentForCommit(string path)
         {
             return string.Empty;
@@ -289,11 +294,6 @@ namespace Codescene.VSExtension.Core.Tests
             return new HashSet<string>(absolutePaths, StringComparer.OrdinalIgnoreCase);
         }
 
-        public string GetBranchCreationCommit(string path, LibGit2Sharp.Repository repository)
-        {
-            return string.Empty;
-        }
-
         public void Dispose()
         {
         }
@@ -306,6 +306,11 @@ namespace Codescene.VSExtension.Core.Tests
         public FakeGitServiceIgnorePath(string ignoredPath)
         {
             _ignoredPath = ignoredPath;
+        }
+
+        public string GetBaselineCommit(string repoRootPath)
+        {
+            return string.Empty;
         }
 
         public string GetFileContentForCommit(string path)
@@ -337,11 +342,6 @@ namespace Codescene.VSExtension.Core.Tests
             return result;
         }
 
-        public string GetBranchCreationCommit(string path, LibGit2Sharp.Repository repository)
-        {
-            return string.Empty;
-        }
-
         public void Dispose()
         {
         }
@@ -354,6 +354,11 @@ namespace Codescene.VSExtension.Core.Tests
         public FakeGitServiceWithGitignoreSupport(string repoPath)
         {
             _repoPath = repoPath;
+        }
+
+        public string GetBaselineCommit(string repoRootPath)
+        {
+            return string.Empty;
         }
 
         public string GetFileContentForCommit(string path)
@@ -405,11 +410,6 @@ namespace Codescene.VSExtension.Core.Tests
             }
 
             return result;
-        }
-
-        public string GetBranchCreationCommit(string path, LibGit2Sharp.Repository repository)
-        {
-            return string.Empty;
         }
 
         public void Dispose()

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
@@ -567,10 +567,10 @@ namespace Codescene.VSExtension.Core.Tests
             GetChangedFilesCallCount = 0;
         }
 
-        public override async Task<List<string>> GetChangedFilesVsBaselineAsync()
+        public override async Task<List<string>> GetChangedFilesVsBaselineAsync(string baselineCommit)
         {
             GetChangedFilesCallCount++;
-            return await base.GetChangedFilesVsBaselineAsync();
+            return await base.GetChangedFilesVsBaselineAsync(baselineCommit);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTests.cs
@@ -13,7 +13,7 @@ namespace Codescene.VSExtension.Core.Tests
         [TestMethod]
         public async Task GetChangedFilesVsBaseline_ReturnsEmptyArray_ForCleanRepository()
         {
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
 
             Assert.IsEmpty(changedFiles, "Should return empty list for clean repository");
         }
@@ -23,7 +23,7 @@ namespace Codescene.VSExtension.Core.Tests
         {
             CreateFile("test.ts", "console.log(\"test\");");
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
 
             AssertFileInChangedList(changedFiles, "test.ts");
         }
@@ -34,7 +34,7 @@ namespace Codescene.VSExtension.Core.Tests
             var testFile = CommitFile("index.js", "console.log(\"hello\");", "Add index.js");
             File.WriteAllText(testFile, "console.log(\"modified\");");
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
 
             AssertFileInChangedList(changedFiles, "index.js");
         }
@@ -49,7 +49,7 @@ namespace Codescene.VSExtension.Core.Tests
                 LibGit2Sharp.Commands.Stage(repo, "script.py");
             }
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
 
             AssertFileInChangedList(changedFiles, "script.py");
         }
@@ -66,7 +66,7 @@ namespace Codescene.VSExtension.Core.Tests
             CommitFile("committed.ts", "export const foo = 1;", "Add committed.ts");
             CreateFile("uncommitted.ts", "export const bar = 2;");
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
 
             AssertFileInChangedList(changedFiles, "committed.ts");
             AssertFileInChangedList(changedFiles, "uncommitted.ts");
@@ -80,7 +80,7 @@ namespace Codescene.VSExtension.Core.Tests
             var filePath = CreateFile(filename, content);
             _fakeSupportedFileChecker.SetSupported(filePath, expectedResult);
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             var result = _gitChangeObserverCore.ShouldProcessFileForTesting(filePath, changedFiles);
 
             Assert.AreEqual(
@@ -95,7 +95,7 @@ namespace Codescene.VSExtension.Core.Tests
             var changedFile = CreateFile("changed.ts", "export const x = 1;");
             var committedFile = CommitFile("committed.js", "console.log(\"committed\");", "Add committed.js");
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, "changed.ts");
             AssertFileInChangedList(changedFiles, "committed.js", false);
 
@@ -112,7 +112,7 @@ namespace Codescene.VSExtension.Core.Tests
             CreateFile("my file.ts", "console.log(\"has spaces\");");
             CreateFile("test file with spaces.js", "console.log(\"also has spaces\");");
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             var fileNames = changedFiles.Select(f => Path.GetFileName(f)).ToList();
 
             Assert.Contains("my file.ts", fileNames, "Should include file with spaces: my file.ts");
@@ -297,7 +297,7 @@ namespace Codescene.VSExtension.Core.Tests
                 _fakeTaskScheduler,
                 _fakeGitChangeLister,
                 _fakeGitService);
-            _gitChangeObserverCore.Initialize(_testRepoPath, _fakeSavedFilesTracker, _fakeOpenFilesObserver, getChangedFilesCallback: () => Task.FromException<List<string>>(new InvalidOperationException("simulated")));
+            _gitChangeObserverCore.Initialize(_testRepoPath, _fakeSavedFilesTracker, _fakeOpenFilesObserver, getChangedFilesCallback: (_) => Task.FromException<List<string>>(new InvalidOperationException("simulated")));
             _fakeLogger.ClearErrorMessages();
             _fakeGitChangeLister.SimulateFilesDetected(new HashSet<string> { Path.Combine(_testRepoPath, "x.cs") });
             Assert.IsTrue(
@@ -388,7 +388,7 @@ namespace Codescene.VSExtension.Core.Tests
                 _testRepoPath,
                 _fakeSavedFilesTracker,
                 _fakeOpenFilesObserver,
-                getChangedFilesCallback: () => Task.FromCanceled<List<string>>(new CancellationToken(canceled: true)));
+                getChangedFilesCallback: (_) => Task.FromCanceled<List<string>>(new CancellationToken(canceled: true)));
             _fakeLogger.ClearErrorMessages();
 
             var method = typeof(GitChangeObserverCore).GetMethod("ProcessDetectedFileQueueAsync", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -419,7 +419,7 @@ namespace Codescene.VSExtension.Core.Tests
                 _testRepoPath,
                 _fakeSavedFilesTracker,
                 _fakeOpenFilesObserver,
-                getChangedFilesCallback: () =>
+                getChangedFilesCallback: (_) =>
                 {
                     if (Interlocked.Increment(ref getChangedFilesCallCount) == 1)
                     {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTests.cs
@@ -392,7 +392,7 @@ namespace Codescene.VSExtension.Core.Tests
             _fakeLogger.ClearErrorMessages();
 
             var method = typeof(GitChangeObserverCore).GetMethod("ProcessDetectedFileQueueAsync", BindingFlags.NonPublic | BindingFlags.Instance);
-            var task = (Task)method.Invoke(_gitChangeObserverCore, new object[] { Path.Combine(_testRepoPath, "cancelled.ts"), CancellationToken.None });
+            var task = (Task)method.Invoke(_gitChangeObserverCore, new object[] { Path.Combine(_testRepoPath, "cancelled.ts"), CancellationToken.None, string.Empty });
 
             await task;
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverGitignoreTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverGitignoreTests.cs
@@ -31,7 +31,7 @@ namespace Codescene.VSExtension.Core.Tests
                 repo.Commit("Add to gitignore and remove file", signature, signature);
             }
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, fileName, false);
 
             var shouldProcess = _gitChangeObserverCore.ShouldProcessFileForTesting(filePath, changedFiles);
@@ -46,7 +46,7 @@ namespace Codescene.VSExtension.Core.Tests
 
             var ignoredFile = CreateFile("secret.ignored", "export const secret = \"hidden\";");
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, "secret.ignored", false);
 
             await TriggerFileChangeAsync(ignoredFile);
@@ -64,7 +64,7 @@ namespace Codescene.VSExtension.Core.Tests
 
             var ignoredFile = CreateFile("config.ts", "export const config = { secret: true };");
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, "config.ts", false);
 
             await TriggerFileChangeAsync(ignoredFile);
@@ -73,7 +73,7 @@ namespace Codescene.VSExtension.Core.Tests
             File.Delete(gitignorePath);
             await Task.Delay(100);
 
-            changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, "config.ts");
 
             await TriggerFileChangeAsync(ignoredFile);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverRaceConditionTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverRaceConditionTests.cs
@@ -169,7 +169,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.FromResult(new FileReviewModel { FilePath = path, RawScore = "8.5" });
             }
 
-            public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
                 _aboutToStore.Set();
                 _canProceed.Wait();
@@ -181,21 +181,21 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.FromResult(delta);
             }
 
-            public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
                 var review = await ReviewAsync(path, currentCode, false, operationGeneration, cancellationToken);
-                var baselineRawScore = await GetOrComputeBaselineRawScoreAsync(path, string.Empty, operationGeneration, cancellationToken);
+                var baselineRawScore = await GetOrComputeBaselineRawScoreAsync(path, string.Empty, operationGeneration, cancellationToken, baselineCommit);
                 return (review, baselineRawScore ?? string.Empty);
             }
 
-            public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
-                var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken);
-                var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken);
+                var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken, baselineCommit);
+                var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken, baselineCommit);
                 return (review, delta);
             }
 
-            public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
                 return Task.FromResult("8.0");
             }
@@ -220,7 +220,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.FromResult(new FileReviewModel { FilePath = path, RawScore = "8.5" });
             }
 
-            public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
                 _aboutToStore.Set();
                 _canProceed.Wait();
@@ -234,21 +234,21 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.FromResult(delta);
             }
 
-            public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
                 var review = await ReviewAsync(path, currentCode, false, operationGeneration, cancellationToken);
-                var baselineRawScore = await GetOrComputeBaselineRawScoreAsync(path, string.Empty, operationGeneration, cancellationToken);
+                var baselineRawScore = await GetOrComputeBaselineRawScoreAsync(path, string.Empty, operationGeneration, cancellationToken, baselineCommit);
                 return (review, baselineRawScore ?? string.Empty);
             }
 
-            public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
-                var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken);
-                var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken);
+                var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken, baselineCommit);
+                var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken, baselineCommit);
                 return (review, delta);
             }
 
-            public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
                 return Task.FromResult("8.0");
             }
@@ -277,7 +277,7 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.FromResult(new FileReviewModel { FilePath = path, RawScore = "8.5" });
             }
 
-            public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
                 Interlocked.Increment(ref _startedCount);
                 var currentActive = Interlocked.Increment(ref _activeCount);
@@ -300,21 +300,21 @@ namespace Codescene.VSExtension.Core.Tests
                 return Task.FromResult<DeltaResponseModel>(null);
             }
 
-            public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
                 var review = await ReviewAsync(path, currentCode, false, operationGeneration, cancellationToken);
-                var baselineRawScore = await GetOrComputeBaselineRawScoreAsync(path, string.Empty, operationGeneration, cancellationToken);
+                var baselineRawScore = await GetOrComputeBaselineRawScoreAsync(path, string.Empty, operationGeneration, cancellationToken, baselineCommit);
                 return (review, baselineRawScore ?? string.Empty);
             }
 
-            public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
-                var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken);
-                var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken);
+                var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken, baselineCommit);
+                var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken, baselineCommit);
                 return (review, delta);
             }
 
-            public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default)
+            public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
             {
                 return Task.FromResult("8.0");
             }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverRaceConditionTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverRaceConditionTests.cs
@@ -34,7 +34,7 @@ namespace Codescene.VSExtension.Core.Tests
             observer.Initialize(_testRepoPath, _fakeSavedFilesTracker, _fakeOpenFilesObserver, null);
 
             var testFile = CreateFile("test.cs", "public class Test {}");
-            var changedFiles = await observer.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await observer.GetChangedFilesVsBaselineAsync(string.Empty);
 
             await observer.HandleFileChangeForTestingAsync(testFile, changedFiles);
 
@@ -61,7 +61,7 @@ namespace Codescene.VSExtension.Core.Tests
             observer.Initialize(_testRepoPath, _fakeSavedFilesTracker, _fakeOpenFilesObserver, null);
 
             var testFile = CreateFile("test.cs", "public class Test {}");
-            var changedFiles = await observer.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await observer.GetChangedFilesVsBaselineAsync(string.Empty);
 
             var changeTask = Task.Run(async () =>
                 await observer.HandleFileChangeForTestingAsync(testFile, changedFiles));

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverTestBase.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverTestBase.cs
@@ -187,7 +187,7 @@ namespace Codescene.VSExtension.Core.Tests
 
         protected async Task TriggerFileChangeAsync(string filePath)
         {
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             await _gitChangeObserverCore.HandleFileChangeForTestingAsync(filePath, changedFiles);
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverTrackerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverTrackerTests.cs
@@ -41,7 +41,7 @@ namespace Codescene.VSExtension.Core.Tests
             AssertFileInTracker(newFile);
 
             File.Delete(newFile);
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
 
             await _gitChangeObserverCore.HandleFileDeleteForTestingAsync(newFile, changedFiles);
 
@@ -61,7 +61,7 @@ namespace Codescene.VSExtension.Core.Tests
             AssertFileInTracker(newFile);
 
             File.Delete(newFile);
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
 
             await _gitChangeObserverCore.HandleFileDeleteForTestingAsync(newFile, changedFiles);
 
@@ -86,7 +86,7 @@ namespace Codescene.VSExtension.Core.Tests
             AssertFileInTracker(file2);
 
             Directory.Delete(subDir, true);
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
 
             await _gitChangeObserverCore.HandleFileDeleteForTestingAsync(subDir, changedFiles);
 
@@ -113,7 +113,7 @@ namespace Codescene.VSExtension.Core.Tests
             _gitChangeObserverCore.ViewUpdateRequested += (sender, e) => eventRaised = true;
 
             File.Delete(testFile);
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             CollectionAssert.AreEqual(new List<string>(), changedFiles, "Changed list should be empty after git stash");
 
             await _gitChangeObserverCore.HandleFileDeleteForTestingAsync(testFile, changedFiles);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverWorkflowTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverWorkflowTests.cs
@@ -17,7 +17,7 @@ namespace Codescene.VSExtension.Core.Tests
                 LibGit2Sharp.Commands.Stage(repo, "staging-test.ts");
             }
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, "staging-test.ts");
 
             using (var repo = new Repository(_testRepoPath))
@@ -25,11 +25,11 @@ namespace Codescene.VSExtension.Core.Tests
                 LibGit2Sharp.Commands.Unstage(repo, "staging-test.ts");
             }
 
-            changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, "staging-test.ts");
 
             File.Delete(file);
-            changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, "staging-test.ts", false);
         }
 
@@ -46,7 +46,7 @@ namespace Codescene.VSExtension.Core.Tests
 
             var file = CreateFile("detached.ts", "export const detached = 1;");
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, "detached.ts");
 
             Assert.IsNotNull(changedFiles, "Should return results even in detached HEAD state");
@@ -72,7 +72,7 @@ namespace Codescene.VSExtension.Core.Tests
 
             ExecGit("merge merge-feature --no-ff --no-edit");
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
 
             AssertFileInChangedList(changedFiles, "merge1.ts", false);
             AssertFileInChangedList(changedFiles, "merge2.ts", false);
@@ -85,20 +85,20 @@ namespace Codescene.VSExtension.Core.Tests
             var originalContent = "export function hello() { return \"world\"; }";
             var filePath = CommitFile(fileName, originalContent, "Add healthy file");
 
-            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            var changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, fileName, false);
 
             var modifiedContent = "export function hello() { return \"modified\"; }";
             File.WriteAllText(filePath, modifiedContent);
 
             await TriggerFileChangeAsync(filePath);
-            changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, fileName, true);
             AssertFileInTracker(filePath, true);
 
             File.WriteAllText(filePath, originalContent);
 
-            changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync();
+            changedFiles = await _gitChangeObserverCore.GetChangedFilesVsBaselineAsync(string.Empty);
             AssertFileInChangedList(changedFiles, fileName, false);
 
             await TriggerFileChangeAsync(filePath);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ReviewWithDeltaAsync_NullRawScore_ReturnsNullDeltaTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ReviewWithDeltaAsync_NullRawScore_ReturnsNullDeltaTests.cs
@@ -47,7 +47,7 @@ namespace Codescene.VSExtension.Core.Tests
             var reviewWithNullRawScore = new FileReviewModel { FilePath = path, RawScore = null, Score = 8.0f };
             var cliReview = new CliReviewModel { RawScore = null };
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(path)).Returns("old code");
+            _mockGitService.Setup(x => x.GetFileContentForCommit(path, It.IsAny<string>())).Returns("old code");
             _mockExecutor.Setup(x => x.ReviewContentAsync("test.cs", content, false, It.IsAny<CancellationToken>())).ReturnsAsync(cliReview);
             _mockMapper.Setup(x => x.Map(path, cliReview)).Returns(reviewWithNullRawScore);
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ReviewWithDeltaAsync_ValidRawScore_ReturnsDeltaTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/ReviewWithDeltaAsync_ValidRawScore_ReturnsDeltaTests.cs
@@ -50,7 +50,7 @@ namespace Codescene.VSExtension.Core.Tests
             var baselineCliReview = new CliReviewModel { RawScore = "baseline-raw" };
             var expectedDelta = new DeltaResponseModel { ScoreChange = 0.5m };
 
-            _mockGitService.Setup(x => x.GetFileContentForCommit(path)).Returns(oldCode);
+            _mockGitService.Setup(x => x.GetFileContentForCommit(path, It.IsAny<string>())).Returns(oldCode);
             _mockExecutor.Setup(x => x.ReviewContentAsync("test.cs", content, false, It.IsAny<CancellationToken>())).ReturnsAsync(cliReview);
             _mockExecutor.Setup(x => x.ReviewContentAsync("test.cs", oldCode, true, It.IsAny<CancellationToken>())).ReturnsAsync(baselineCliReview);
             _mockMapper.Setup(x => x.Map(path, cliReview)).Returns(review);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CachingCodeReviewer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CachingCodeReviewer.cs
@@ -165,9 +165,10 @@ namespace Codescene.VSExtension.Core.Application.Cli
             }
 
             var pendingKey = GetPendingDeltaKey(path, oldCode, currentCode, precomputedBaselineRawScore);
+            var input = new DeltaComputationInput(currentCode, oldCode, precomputedBaselineRawScore, baselineCommit);
             var lazyTask = _pendingDeltas.GetOrAdd(pendingKey, _ =>
                 new Lazy<Task<DeltaResponseModel>>(() =>
-                    ComputeDeltaWithLifecycleAsync(review, currentCode, oldCode, precomputedBaselineRawScore, operationGeneration, CancellationToken.None)));
+                    ComputeDeltaWithLifecycleAsync(review, input, operationGeneration, CancellationToken.None)));
             var pendingTask = lazyTask.Value;
             try
             {
@@ -216,7 +217,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
             var currentRawScore = review.RawScore ?? string.Empty;
 
             var oldRawScore = input.PrecomputedBaselineRawScore
-                ?? await GetOrComputeBaselineRawScoreAsync(path, input.OldCode, operationGeneration, cancellationToken);
+                ?? await GetOrComputeBaselineRawScoreAsync(path, input.OldCode, operationGeneration, cancellationToken, input.BaselineCommit);
 
             if (oldRawScore == currentRawScore)
             {
@@ -259,9 +260,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
 
         private async Task<DeltaResponseModel> ComputeDeltaWithLifecycleAsync(
             FileReviewModel review,
-            string currentCode,
-            string oldCode,
-            string precomputedBaselineRawScore,
+            DeltaComputationInput input,
             long? operationGeneration = null,
             CancellationToken cancellationToken = default)
         {
@@ -271,8 +270,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
             {
                 try
                 {
-                    var computationParams = new DeltaComputationInput(currentCode, oldCode, precomputedBaselineRawScore);
-                    return await ComputeDeltaInternalAsync(review, computationParams, operationGeneration, cancellationToken);
+                    return await ComputeDeltaInternalAsync(review, input, operationGeneration, cancellationToken);
                 }
                 catch (OperationCanceledException)
                 {
@@ -335,11 +333,12 @@ namespace Codescene.VSExtension.Core.Application.Cli
 
         private class DeltaComputationInput
         {
-            public DeltaComputationInput(string currentCode, string oldCode, string precomputedBaselineRawScore)
+            public DeltaComputationInput(string currentCode, string oldCode, string precomputedBaselineRawScore, string baselineCommit = null)
             {
                 CurrentCode = currentCode;
                 OldCode = oldCode;
                 PrecomputedBaselineRawScore = precomputedBaselineRawScore;
+                BaselineCommit = baselineCommit;
             }
 
             public string CurrentCode { get; }
@@ -347,6 +346,8 @@ namespace Codescene.VSExtension.Core.Application.Cli
             public string OldCode { get; }
 
             public string PrecomputedBaselineRawScore { get; }
+
+            public string BaselineCommit { get; }
         }
 
         private class DeltaComputationParameters

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CachingCodeReviewer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CachingCodeReviewer.cs
@@ -234,7 +234,8 @@ namespace Codescene.VSExtension.Core.Application.Cli
             var parameters = new DeltaComputationParameters(
                 currentCode: input.CurrentCode,
                 oldCode: input.OldCode,
-                oldRawScore: oldRawScore);
+                oldRawScore: oldRawScore,
+                baselineCommit: input.BaselineCommit);
             return await ComputeAndCacheDeltaAsync(review, parameters, operationGeneration, cancellationToken);
         }
 
@@ -242,7 +243,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
         {
             var path = review.FilePath;
             _logger?.Debug($"CachingCodeReviewer: Delta cache miss for '{path}', calling inner reviewer.");
-            var delta = await _innerReviewer.DeltaAsync(review, parameters.CurrentCode, parameters.OldRawScore, operationGeneration, cancellationToken);
+            var delta = await _innerReviewer.DeltaAsync(review, parameters.CurrentCode, parameters.OldRawScore, operationGeneration, cancellationToken, parameters.BaselineCommit);
             cancellationToken.ThrowIfCancellationRequested();
 
             var cacheSnapshot = new Dictionary<string, DeltaResponseModel>(_deltaCache.GetAll());
@@ -352,11 +353,12 @@ namespace Codescene.VSExtension.Core.Application.Cli
 
         private class DeltaComputationParameters
         {
-            public DeltaComputationParameters(string currentCode, string oldCode, string oldRawScore)
+            public DeltaComputationParameters(string currentCode, string oldCode, string oldRawScore, string baselineCommit = null)
             {
                 CurrentCode = currentCode;
                 OldCode = oldCode;
                 OldRawScore = oldRawScore;
+                BaselineCommit = baselineCommit;
             }
 
             public string CurrentCode { get; }
@@ -364,6 +366,8 @@ namespace Codescene.VSExtension.Core.Application.Cli
             public string OldCode { get; }
 
             public string OldRawScore { get; }
+
+            public string BaselineCommit { get; }
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CachingCodeReviewer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CachingCodeReviewer.cs
@@ -91,29 +91,29 @@ namespace Codescene.VSExtension.Core.Application.Cli
             }
         }
 
-        public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
             var review = await this.ReviewAsync(path, currentCode, isBaseline: false, operationGeneration, cancellationToken);
-            var baselineRawScore = await GetOrComputeBaselineRawScoreAsync(path, null, operationGeneration, cancellationToken);
+            var baselineRawScore = await GetOrComputeBaselineRawScoreAsync(path, null, operationGeneration, cancellationToken, baselineCommit);
 
             return (review, baselineRawScore ?? string.Empty);
         }
 
-        public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
-            var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken);
+            var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken, baselineCommit);
             if (review?.RawScore == null)
             {
                 return (review, null);
             }
 
-            var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken);
+            var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken, baselineCommit);
             return (review, delta);
         }
 
-        public async Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
-            var oldCode = GetBaselineContent(path, baselineContent);
+            var oldCode = GetBaselineContent(path, baselineContent, baselineCommit);
 
             if (string.IsNullOrEmpty(oldCode))
             {
@@ -130,7 +130,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
             return await ComputeAndCacheBaselineAsync(path, oldCode, operationGeneration, cancellationToken);
         }
 
-        public async Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
             var path = review.FilePath;
 
@@ -140,7 +140,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
                 return null;
             }
 
-            var oldCode = _git?.GetFileContentForCommit(path) ?? string.Empty;
+            var oldCode = _git?.GetFileContentForCommit(path, baselineCommit) ?? string.Empty;
 
             if (oldCode == currentCode)
             {
@@ -181,7 +181,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
             }
         }
 
-        private string GetBaselineContent(string path, string baselineContent)
+        private string GetBaselineContent(string path, string baselineContent, string baselineCommit = null)
         {
             if (!string.IsNullOrEmpty(baselineContent))
             {
@@ -190,7 +190,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
 
             if (_git != null)
             {
-                return _git.GetFileContentForCommit(path) ?? string.Empty;
+                return _git.GetFileContentForCommit(path, baselineCommit) ?? string.Empty;
             }
 
             return string.Empty;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CodeReviewer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CodeReviewer.cs
@@ -138,7 +138,16 @@ namespace Codescene.VSExtension.Core.Application.Cli
 
         public async Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
-            return await GetOrComputeBaselineRawScoreInternalAsync(path, baselineContent, operationGeneration, cancellationToken);
+            var oldCode = !string.IsNullOrEmpty(baselineContent)
+                ? baselineContent
+                : (_git?.GetFileContentForCommit(path, baselineCommit) ?? string.Empty);
+
+            if (string.IsNullOrEmpty(oldCode))
+            {
+                return string.Empty;
+            }
+
+            return await GetOrComputeBaselineRawScoreInternalAsync(path, oldCode, operationGeneration, cancellationToken);
         }
 
         private async Task<string> GetOrComputeBaselineRawScoreInternalAsync(string path, string oldCode, long? operationGeneration = null, CancellationToken cancellationToken = default)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CodeReviewer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CodeReviewer.cs
@@ -60,9 +60,9 @@ namespace Codescene.VSExtension.Core.Application.Cli
             return _mapper.Map(path, review);
         }
 
-        public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
-            var oldCode = _git.GetFileContentForCommit(path) ?? string.Empty;
+            var oldCode = _git.GetFileContentForCommit(path, baselineCommit) ?? string.Empty;
             var reviewTask = ReviewAsync(path, currentCode, false, operationGeneration, cancellationToken);
             var baselineTask = GetOrComputeBaselineRawScoreInternalAsync(path, oldCode, operationGeneration, cancellationToken);
             await Task.WhenAll(reviewTask, baselineTask).ConfigureAwait(false);
@@ -71,19 +71,19 @@ namespace Codescene.VSExtension.Core.Application.Cli
             return (review, baselineRawScore);
         }
 
-        public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
-            var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken);
+            var (review, baselineRawScore) = await ReviewAndBaselineAsync(path, content, operationGeneration, cancellationToken, baselineCommit);
             if (review?.RawScore == null)
             {
                 return (review, null);
             }
 
-            var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken);
+            var delta = await DeltaAsync(review, content, baselineRawScore, operationGeneration, cancellationToken, baselineCommit);
             return (review, delta);
         }
 
-        public async Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
             var path = review.FilePath;
             var currentRawScore = review.RawScore ?? string.Empty;
@@ -96,7 +96,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
 
             try
             {
-                var oldCode = _git.GetFileContentForCommit(path);
+                var oldCode = _git.GetFileContentForCommit(path, baselineCommit);
                 var oldRawScore = precomputedBaselineRawScore ?? await GetOrComputeBaselineRawScoreInternalAsync(path, oldCode, operationGeneration, cancellationToken);
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -136,7 +136,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
             }
         }
 
-        public async Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
             return await GetOrComputeBaselineRawScoreInternalAsync(path, baselineContent, operationGeneration, cancellationToken);
         }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeEventProcessor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeEventProcessor.cs
@@ -139,7 +139,6 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
 
             var operationGeneration = CacheGeneration.Current;
-
             var events = DrainQueue();
 
             if (events.Count == 0)
@@ -148,10 +147,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
 
             var coalesced = CoalesceByPath(events);
-
-#if FEATURE_INITIAL_GIT_OBSERVER
-            _logger?.Info($">>> GitChangeObserverCore: Processing {coalesced.Count} coalesced file change events (from {events.Count} raw)");
-#endif
+            LogCoalescedEvents(coalesced.Count, events.Count);
 
             if (_cancellationToken.IsCancellationRequested)
             {
@@ -160,9 +156,8 @@ namespace Codescene.VSExtension.Core.Application.Git
 
             var shouldSkipNonDeletes = _shouldSkipNonDeletesCallback?.Invoke() ?? false;
 
-            if (shouldSkipNonDeletes && !HasDeleteEvents(coalesced))
+            if (ShouldSkipAllEvents(shouldSkipNonDeletes, coalesced))
             {
-                _logger?.Debug("FileChangeEventProcessor: Skipping all events - current branch matches default branch and no deletes pending");
                 return;
             }
 
@@ -175,6 +170,24 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
 
             ScheduleCoalescedEvents(coalesced, changedFiles, operationGeneration, shouldSkipNonDeletes, baselineCommit);
+        }
+
+        private bool ShouldSkipAllEvents(bool shouldSkipNonDeletes, List<FileChangeEvent> coalesced)
+        {
+            if (shouldSkipNonDeletes && !HasDeleteEvents(coalesced))
+            {
+                _logger?.Debug("FileChangeEventProcessor: Skipping all events - current branch matches default branch and no deletes pending");
+                return true;
+            }
+
+            return false;
+        }
+
+        private void LogCoalescedEvents(int coalescedCount, int rawCount)
+        {
+#if FEATURE_INITIAL_GIT_OBSERVER
+            _logger?.Info($">>> GitChangeObserverCore: Processing {coalescedCount} coalesced file change events (from {rawCount} raw)");
+#endif
         }
 
         private List<FileChangeEvent> DrainQueue()

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeEventProcessor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeEventProcessor.cs
@@ -18,7 +18,7 @@ namespace Codescene.VSExtension.Core.Application.Git
         private readonly SemaphoreSlim _concurrencySemaphore;
         private readonly ILogger _logger;
         private readonly Func<FileChangeEvent, List<string>, long?, CancellationToken, string, Task> _processEventCallback;
-        private readonly Func<Task<List<string>>> _getChangedFilesCallback;
+        private readonly Func<string, Task<List<string>>> _getChangedFilesCallback;
         private readonly Func<bool> _shouldSkipNonDeletesCallback;
         private readonly Func<string> _getBaselineCommitCallback;
         private readonly IAsyncTaskScheduler _taskScheduler;
@@ -29,7 +29,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             ILogger logger,
             IAsyncTaskScheduler taskScheduler,
             Func<FileChangeEvent, List<string>, long?, CancellationToken, string, Task> processEventCallback,
-            Func<Task<List<string>>> getChangedFilesCallback,
+            Func<string, Task<List<string>>> getChangedFilesCallback,
             Func<bool> shouldSkipNonDeletesCallback = null,
             Func<string> getBaselineCommitCallback = null)
         {
@@ -166,8 +166,8 @@ namespace Codescene.VSExtension.Core.Application.Git
                 return;
             }
 
-            var changedFiles = await _getChangedFilesCallback();
-            var baselineCommit = _getBaselineCommitCallback?.Invoke();
+            var baselineCommit = _getBaselineCommitCallback?.Invoke() ?? string.Empty;
+            var changedFiles = await _getChangedFilesCallback(baselineCommit);
 
             if (_cancellationToken.IsCancellationRequested)
             {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeEventProcessor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeEventProcessor.cs
@@ -17,9 +17,10 @@ namespace Codescene.VSExtension.Core.Application.Git
         private readonly ConcurrentQueue<FileChangeEvent> _eventQueue = new ConcurrentQueue<FileChangeEvent>();
         private readonly SemaphoreSlim _concurrencySemaphore;
         private readonly ILogger _logger;
-        private readonly Func<FileChangeEvent, List<string>, long?, CancellationToken, Task> _processEventCallback;
+        private readonly Func<FileChangeEvent, List<string>, long?, CancellationToken, string, Task> _processEventCallback;
         private readonly Func<Task<List<string>>> _getChangedFilesCallback;
         private readonly Func<bool> _shouldSkipNonDeletesCallback;
+        private readonly Func<string> _getBaselineCommitCallback;
         private readonly IAsyncTaskScheduler _taskScheduler;
         private Timer _scheduledTimer;
         private CancellationToken _cancellationToken;
@@ -27,15 +28,17 @@ namespace Codescene.VSExtension.Core.Application.Git
         public FileChangeEventProcessor(
             ILogger logger,
             IAsyncTaskScheduler taskScheduler,
-            Func<FileChangeEvent, List<string>, long?, CancellationToken, Task> processEventCallback,
+            Func<FileChangeEvent, List<string>, long?, CancellationToken, string, Task> processEventCallback,
             Func<Task<List<string>>> getChangedFilesCallback,
-            Func<bool> shouldSkipNonDeletesCallback = null)
+            Func<bool> shouldSkipNonDeletesCallback = null,
+            Func<string> getBaselineCommitCallback = null)
         {
             _logger = logger;
             _taskScheduler = taskScheduler;
             _processEventCallback = processEventCallback;
             _getChangedFilesCallback = getChangedFilesCallback;
             _shouldSkipNonDeletesCallback = shouldSkipNonDeletesCallback;
+            _getBaselineCommitCallback = getBaselineCommitCallback;
 
             var numberOfThreads = CoreCountUtils.GetParallelizationCountByCoreCount(Environment.ProcessorCount);
             _concurrencySemaphore = new SemaphoreSlim(numberOfThreads, numberOfThreads);
@@ -164,13 +167,14 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
 
             var changedFiles = await _getChangedFilesCallback();
+            var baselineCommit = _getBaselineCommitCallback?.Invoke();
 
             if (_cancellationToken.IsCancellationRequested)
             {
                 return;
             }
 
-            ScheduleCoalescedEvents(coalesced, changedFiles, operationGeneration, shouldSkipNonDeletes);
+            ScheduleCoalescedEvents(coalesced, changedFiles, operationGeneration, shouldSkipNonDeletes, baselineCommit);
         }
 
         private List<FileChangeEvent> DrainQueue()
@@ -184,7 +188,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             return events;
         }
 
-        private void ScheduleCoalescedEvents(List<FileChangeEvent> coalesced, List<string> changedFiles, long? operationGeneration, bool shouldSkipNonDeletes)
+        private void ScheduleCoalescedEvents(List<FileChangeEvent> coalesced, List<string> changedFiles, long? operationGeneration, bool shouldSkipNonDeletes, string baselineCommit)
         {
             var token = _cancellationToken;
             foreach (var evt in coalesced)
@@ -197,11 +201,11 @@ namespace Codescene.VSExtension.Core.Application.Git
 
                 var capturedEvt = evt;
                 var capturedChangedFiles = changedFiles;
-                _taskScheduler.Schedule(() => ProcessOneEventAsync(capturedEvt, capturedChangedFiles, operationGeneration, token));
+                _taskScheduler.Schedule(() => ProcessOneEventAsync(capturedEvt, capturedChangedFiles, operationGeneration, token, baselineCommit));
             }
         }
 
-        private async Task ProcessOneEventAsync(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken token)
+        private async Task ProcessOneEventAsync(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken token, string baselineCommit)
         {
             if (token.IsCancellationRequested)
             {
@@ -211,7 +215,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             await _concurrencySemaphore.WaitAsync(token);
             try
             {
-                await _processEventCallback(evt, changedFiles, operationGeneration, token);
+                await _processEventCallback(evt, changedFiles, operationGeneration, token, baselineCommit);
             }
             catch (OperationCanceledException)
             {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeHandler.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/FileChangeHandler.cs
@@ -55,7 +55,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             _workspacePaths = workspacePaths ?? Array.Empty<string>();
         }
 
-        public async Task HandleFileChangeAsync(string filePath, List<string> changedFiles, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task HandleFileChangeAsync(string filePath, List<string> changedFiles, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
             var isDirectory = !Path.HasExtension(filePath);
             if (isDirectory)
@@ -82,7 +82,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             #endif
             _trackerManager.Add(filePath);
 
-            await ReviewFileAsync(filePath, operationGeneration, cancellationToken);
+            await ReviewFileAsync(filePath, operationGeneration, cancellationToken, baselineCommit);
         }
 
         public async Task HandleFileDeleteAsync(string filePath, List<string> changedFiles, CancellationToken cancellationToken = default)
@@ -155,7 +155,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             return true;
         }
 
-        public async Task ReviewFileAsync(string filePath, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public async Task ReviewFileAsync(string filePath, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
             try
             {
@@ -187,7 +187,7 @@ namespace Codescene.VSExtension.Core.Application.Git
                 content ??= File.ReadAllText(filePath);
 
                 cancellationToken.ThrowIfCancellationRequested();
-                var (review, delta) = await _codeReviewer.ReviewWithDeltaAsync(filePath, content, operationGeneration, cancellationToken).ConfigureAwait(false);
+                var (review, delta) = await _codeReviewer.ReviewWithDeltaAsync(filePath, content, operationGeneration, cancellationToken, baselineCommit).ConfigureAwait(false);
 
                 if (review != null)
                 {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeDetector.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeDetector.cs
@@ -429,7 +429,7 @@ namespace Codescene.VSExtension.Core.Application.Git
 
         private bool ShouldIncludeStatusItem(StatusEntry item, HashSet<string> filesToExclude, string gitRootPath)
         {
-            if (item.State == FileStatus.Unaltered || item.State == FileStatus.Ignored)
+            if (IsUnalteredOrIgnored(item))
             {
                 #if FEATURE_INITIAL_GIT_OBSERVER
                 _logger?.Info($">>> GitChangeDetector: File excluded - unaltered or ignored: {item.FilePath}");
@@ -439,12 +439,7 @@ namespace Codescene.VSExtension.Core.Application.Git
 
             var fullPath = Path.Combine(gitRootPath, item.FilePath);
 
-            if (_gitService.IsFileIgnored(fullPath))
-            {
-                return false;
-            }
-
-            if (filesToExclude.Contains(fullPath))
+            if (IsExcluded(fullPath, filesToExclude))
             {
                 #if FEATURE_INITIAL_GIT_OBSERVER
                 _logger?.Info($">>> GitChangeDetector: File excluded - in exclusion set: {item.FilePath}");
@@ -461,6 +456,16 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
 
             return isSupported;
+        }
+
+        private bool IsUnalteredOrIgnored(StatusEntry item)
+        {
+            return item.State == FileStatus.Unaltered || item.State == FileStatus.Ignored;
+        }
+
+        private bool IsExcluded(string fullPath, HashSet<string> filesToExclude)
+        {
+            return _gitService.IsFileIgnored(fullPath) || filesToExclude.Contains(fullPath);
         }
 
         private bool IsFileInAnyWorkspace(string gitRelativePath, string gitRootPath, IReadOnlyCollection<string> workspacePaths)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeDetector.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeDetector.cs
@@ -57,7 +57,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             ClearNoMergeBaseLogState(gitRootPath);
         }
 
-        public virtual async Task<List<string>> GetChangedFilesVsBaselineAsync(string gitRootPath, IReadOnlyCollection<string> workspacePaths, ISavedFilesTracker savedFilesTracker, IOpenFilesObserver openFilesObserver, CancellationToken cancellationToken = default)
+        public virtual async Task<List<string>> GetChangedFilesVsBaselineAsync(string gitRootPath, IReadOnlyCollection<string> workspacePaths, ISavedFilesTracker savedFilesTracker, IOpenFilesObserver openFilesObserver, string baselineCommit, CancellationToken cancellationToken = default)
         {
             return await Task.Run(
                 () =>
@@ -82,7 +82,7 @@ namespace Codescene.VSExtension.Core.Application.Git
                     using (var repo = new Repository(repoPath))
                     {
                         var context = new ChangeDetectionContext(gitRootPath, effectivePaths, savedFilesTracker, openFilesObserver);
-                        var changedFiles = GetChangedFilesFromRepository(repo, context);
+                        var changedFiles = GetChangedFilesFromRepository(repo, context, baselineCommit);
                         #if FEATURE_INITIAL_GIT_OBSERVER
                         _logger?.Info($">>> GitChangeDetector: Found {changedFiles.Count} changed files vs baseline");
                         #endif
@@ -151,17 +151,27 @@ namespace Codescene.VSExtension.Core.Application.Git
             return candidates;
         }
 
-        protected virtual List<string> GetChangedFilesFromRepository(Repository repo, ChangeDetectionContext context)
+        protected virtual List<string> GetChangedFilesFromRepository(Repository repo, ChangeDetectionContext context, string baselineCommit)
         {
             var currentBranch = repo.Head?.FriendlyName ?? "unknown";
             #if FEATURE_INITIAL_GIT_OBSERVER
             _logger?.Info($">>> GitChangeDetector: Getting changed files from repository on branch '{currentBranch}'");
             #endif
 
-            var (baseCommit, noMergeBaseCandidates) = GetMergeBaseCommit(repo);
+            Commit baseCommit = null;
+            if (!string.IsNullOrEmpty(baselineCommit))
+            {
+                baseCommit = repo.Lookup<Commit>(baselineCommit);
+            }
+
             if (baseCommit == null)
             {
-                LogNoMergeBaseStateOnce(repo, noMergeBaseCandidates);
+                var (computedBase, noMergeBaseCandidates) = GetMergeBaseCommit(repo);
+                baseCommit = computedBase;
+                if (baseCommit == null)
+                {
+                    LogNoMergeBaseStateOnce(repo, noMergeBaseCandidates);
+                }
             }
 
             var filesToExclude = BuildExclusionSet(context.SavedFilesTracker, context.OpenFilesObserver);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.DetectedFiles.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.DetectedFiles.cs
@@ -8,7 +8,7 @@ namespace Codescene.VSExtension.Core.Application.Git
 {
     public partial class GitChangeObserverCore
     {
-        private async Task ProcessDetectedFileQueueAsync(string filePath, CancellationToken token)
+        private async Task ProcessDetectedFileQueueAsync(string filePath, CancellationToken token, string baselineCommit)
         {
             var currentRequest = filePath;
             while (true)
@@ -23,7 +23,7 @@ namespace Codescene.VSExtension.Core.Application.Git
 #if FEATURE_INITIAL_GIT_OBSERVER
                     _logger?.Info($">>> GitChangeObserverCore: GitChangeLister detected 1 file");
 #endif
-                    await ProcessFilesAsync(new[] { currentRequest }, token);
+                    await ProcessFilesAsync(new[] { currentRequest }, token, baselineCommit);
 #if FEATURE_INITIAL_GIT_OBSERVER
                     _logger?.Info($">>> GitChangeObserverCore: Processed detected files");
 #endif

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.DetectedFiles.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.DetectedFiles.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 
 namespace Codescene.VSExtension.Core.Application.Git
 {
@@ -41,6 +42,35 @@ namespace Codescene.VSExtension.Core.Application.Git
                 {
                     return;
                 }
+            }
+        }
+
+        private string GetBaselineCommit()
+        {
+            if (string.IsNullOrEmpty(_gitRootPath))
+            {
+                return null;
+            }
+
+            try
+            {
+                var repoPath = Repository.Discover(_gitRootPath);
+                if (string.IsNullOrEmpty(repoPath))
+                {
+                    return null;
+                }
+
+                using (var repo = new Repository(repoPath))
+                {
+                    var mergeBaseFinder = new MergeBaseFinder(_logger);
+                    var mergeBase = mergeBaseFinder.GetMergeBaseCommit(repo);
+                    return mergeBase?.Sha;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.Debug($"GitChangeObserver: Could not get baseline commit: {ex.Message}");
+                return null;
             }
         }
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.DetectedFiles.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.DetectedFiles.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using LibGit2Sharp;
 
 namespace Codescene.VSExtension.Core.Application.Git
 {
@@ -42,35 +41,6 @@ namespace Codescene.VSExtension.Core.Application.Git
                 {
                     return;
                 }
-            }
-        }
-
-        private string GetBaselineCommit()
-        {
-            if (string.IsNullOrEmpty(_gitRootPath))
-            {
-                return null;
-            }
-
-            try
-            {
-                var repoPath = Repository.Discover(_gitRootPath);
-                if (string.IsNullOrEmpty(repoPath))
-                {
-                    return null;
-                }
-
-                using (var repo = new Repository(repoPath))
-                {
-                    var mergeBaseFinder = new MergeBaseFinder(_logger);
-                    var mergeBase = mergeBaseFinder.GetMergeBaseCommit(repo);
-                    return mergeBase?.Sha;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger?.Debug($"GitChangeObserver: Could not get baseline commit: {ex.Message}");
-                return null;
             }
         }
     }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
@@ -539,7 +539,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             cancellationToken.ThrowIfCancellationRequested();
             var operationGeneration = CacheGeneration.Current;
             var changedFiles = await _getChangedFilesCallback();
-            var baselineCommit = GetBaselineCommit();
+            var baselineCommit = _gitService.GetBaselineCommit(_gitRootPath);
             await RemoveMissingTrackedFilesAsync(changedFiles, cancellationToken);
             foreach (var absolutePath in absolutePaths)
             {
@@ -658,7 +658,7 @@ namespace Codescene.VSExtension.Core.Application.Git
                 return;
             }
 
-            var baselineCommit = GetBaselineCommit();
+            var baselineCommit = _gitService.GetBaselineCommit(_gitRootPath);
             await ExecutePerFileAsync(
                 evt.FilePath,
                 cancellationToken,

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
@@ -44,7 +44,7 @@ namespace Codescene.VSExtension.Core.Application.Git
         private IOpenFilesObserver _openFilesObserver;
         private GitChangeDetector _gitChangeDetector;
         private FileChangeHandler _fileChangeHandler;
-        private Func<Task<List<string>>> _getChangedFilesCallback;
+        private Func<string, Task<List<string>>> _getChangedFilesCallback;
         private CodesceneFileWatcher _rulesFileWatcher;
         private CodesceneFileWatcher _configFileWatcher;
         private GitIgnoreWatcher _gitIgnoreWatcher;
@@ -80,7 +80,7 @@ namespace Codescene.VSExtension.Core.Application.Git
 
         public Timer ScheduledTimer => _eventProcessor?.ScheduledTimer;
 
-        public void Initialize(string solutionPath, ISavedFilesTracker savedFilesTracker, IOpenFilesObserver openFilesObserver, Func<Task<List<string>>> getChangedFilesCallback = null, IOpenDocumentContentProvider openDocumentContentProvider = null, IReadOnlyCollection<string> watchPaths = null)
+        public void Initialize(string solutionPath, ISavedFilesTracker savedFilesTracker, IOpenFilesObserver openFilesObserver, Func<string, Task<List<string>>> getChangedFilesCallback = null, IOpenDocumentContentProvider openDocumentContentProvider = null, IReadOnlyCollection<string> watchPaths = null)
         {
             if (savedFilesTracker == null)
             {
@@ -160,9 +160,9 @@ namespace Codescene.VSExtension.Core.Application.Git
             _taskScheduler.Schedule(ct => StartWatcherAfterInitializationAsync(ct));
         }
 
-        public virtual async Task<List<string>> GetChangedFilesVsBaselineAsync()
+        public virtual async Task<List<string>> GetChangedFilesVsBaselineAsync(string baselineCommit)
         {
-            return await _gitChangeDetector.GetChangedFilesVsBaselineAsync(_gitRootPath, _workspacePaths, _savedFilesTracker, _openFilesObserver);
+            return await _gitChangeDetector.GetChangedFilesVsBaselineAsync(_gitRootPath, _workspacePaths, _savedFilesTracker, _openFilesObserver, baselineCommit);
         }
 
         public void UpdateWorkspacePaths(IReadOnlyCollection<string> workspacePaths)
@@ -499,7 +499,8 @@ namespace Codescene.VSExtension.Core.Application.Git
                     token.ThrowIfCancellationRequested();
                     var absolutePaths = await _gitChangeLister.CollectFilesFromRepoStateAsync(_gitRootPath, _workspacePaths, token);
                     token.ThrowIfCancellationRequested();
-                    var changedFiles = await _getChangedFilesCallback();
+                    var baselineCommit = _gitService.GetBaselineCommit(_gitRootPath);
+                    var changedFiles = await _getChangedFilesCallback(baselineCommit);
                     token.ThrowIfCancellationRequested();
 
                     // Add all files to tracker unconditionally - this ensures HandleFileDelete works correctly.
@@ -538,8 +539,8 @@ namespace Codescene.VSExtension.Core.Application.Git
 
             cancellationToken.ThrowIfCancellationRequested();
             var operationGeneration = CacheGeneration.Current;
-            var changedFiles = await _getChangedFilesCallback();
             var baselineCommit = _gitService.GetBaselineCommit(_gitRootPath);
+            var changedFiles = await _getChangedFilesCallback(baselineCommit);
             await RemoveMissingTrackedFilesAsync(changedFiles, cancellationToken);
             foreach (var absolutePath in absolutePaths)
             {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
@@ -409,11 +409,12 @@ namespace Codescene.VSExtension.Core.Application.Git
                 }
 
                 var token = cts.Token;
+                var baselineCommit = _gitService.GetBaselineCommit(_gitRootPath);
                 foreach (var path in absolutePaths.Where(path => !string.IsNullOrWhiteSpace(path)))
                 {
                     if (_detectedFilesQueue.TryStart(path, path))
                     {
-                        _taskScheduler.Schedule(async () => await ProcessDetectedFileQueueAsync(path, token));
+                        _taskScheduler.Schedule(async () => await ProcessDetectedFileQueueAsync(path, token, baselineCommit));
                     }
                     else
                     {
@@ -529,7 +530,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             });
         }
 
-        private async Task ProcessFilesAsync(IEnumerable<string> absolutePaths, CancellationToken cancellationToken)
+        private async Task ProcessFilesAsync(IEnumerable<string> absolutePaths, CancellationToken cancellationToken, string baselineCommit)
         {
             if (absolutePaths.Contains("~~cleanup~~"))
             {
@@ -539,7 +540,6 @@ namespace Codescene.VSExtension.Core.Application.Git
 
             cancellationToken.ThrowIfCancellationRequested();
             var operationGeneration = CacheGeneration.Current;
-            var baselineCommit = _gitService.GetBaselineCommit(_gitRootPath);
             var changedFiles = await _getChangedFilesCallback(baselineCommit);
             await RemoveMissingTrackedFilesAsync(changedFiles, cancellationToken);
             foreach (var absolutePath in absolutePaths)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
@@ -103,7 +103,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             InitializeDefaultBranchGate();
             LogIdentifiedBaselineBranch();
 
-            _eventProcessor = new FileChangeEventProcessor(_logger, _taskScheduler, ProcessEventAsync, _getChangedFilesCallback, ShouldSkipBasedOnDefaultBranch);
+            _eventProcessor = new FileChangeEventProcessor(_logger, _taskScheduler, ProcessEventAsync, _getChangedFilesCallback, ShouldSkipBasedOnDefaultBranch, () => _gitService.GetBaselineCommit(_gitRootPath));
 
 #if FEATURE_INITIAL_GIT_OBSERVER
             _logger?.Info($">>> GitChangeObserverCore: Initialized with solution='{_solutionPath}', gitRoot='{_gitRootPath}', workspace='{_workspacePath}'");
@@ -650,7 +650,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             return GitPathHelper.IsPathUnderAnyRoot(e.FullPath, _workspacePaths);
         }
 
-        private async Task ProcessEventAsync(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        private async Task ProcessEventAsync(FileChangeEvent evt, List<string> changedFiles, long? operationGeneration, CancellationToken cancellationToken, string baselineCommit)
         {
             if (evt.Type == FileChangeType.Delete)
             {
@@ -658,7 +658,6 @@ namespace Codescene.VSExtension.Core.Application.Git
                 return;
             }
 
-            var baselineCommit = _gitService.GetBaselineCommit(_gitRootPath);
             await ExecutePerFileAsync(
                 evt.FilePath,
                 cancellationToken,

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
@@ -539,6 +539,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             cancellationToken.ThrowIfCancellationRequested();
             var operationGeneration = CacheGeneration.Current;
             var changedFiles = await _getChangedFilesCallback();
+            var baselineCommit = GetBaselineCommit();
             await RemoveMissingTrackedFilesAsync(changedFiles, cancellationToken);
             foreach (var absolutePath in absolutePaths)
             {
@@ -555,7 +556,7 @@ namespace Codescene.VSExtension.Core.Application.Git
                 await ExecutePerFileAsync(
                     absolutePath,
                     cancellationToken,
-                    () => _fileChangeHandler.HandleFileChangeAsync(absolutePath, changedFiles, operationGeneration, cancellationToken));
+                    () => _fileChangeHandler.HandleFileChangeAsync(absolutePath, changedFiles, operationGeneration, cancellationToken, baselineCommit));
             }
         }
 
@@ -657,10 +658,11 @@ namespace Codescene.VSExtension.Core.Application.Git
                 return;
             }
 
+            var baselineCommit = GetBaselineCommit();
             await ExecutePerFileAsync(
                 evt.FilePath,
                 cancellationToken,
-                () => _fileChangeHandler.HandleFileChangeAsync(evt.FilePath, changedFiles, operationGeneration, cancellationToken));
+                () => _fileChangeHandler.HandleFileChangeAsync(evt.FilePath, changedFiles, operationGeneration, cancellationToken, baselineCommit));
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/ICodeReviewer.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Cli/ICodeReviewer.cs
@@ -11,12 +11,12 @@ namespace Codescene.VSExtension.Core.Interfaces.Cli
     {
         Task<FileReviewModel> ReviewAsync(string path, string content, bool isBaseline = false, long? operationGeneration = null, CancellationToken cancellationToken = default);
 
-        Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default);
+        Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null);
 
-        Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default);
+        Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null);
 
-        Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default);
+        Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null);
 
-        Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default);
+        Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null);
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitService.cs
@@ -7,6 +7,8 @@ namespace Codescene.VSExtension.Core.Interfaces.Git
 {
     public interface IGitService : IDisposable
     {
+        string GetBaselineCommit(string repoRootPath);
+
         string GetFileContentForCommit(string path);
 
         string GetFileContentForCommit(string path, string baselineCommit);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitService.cs
@@ -9,6 +9,8 @@ namespace Codescene.VSExtension.Core.Interfaces.Git
     {
         string GetFileContentForCommit(string path);
 
+        string GetFileContentForCommit(string path, string baselineCommit);
+
         bool IsFileIgnored(string filePath);
 
         HashSet<string> FilterIgnoredFiles(IEnumerable<string> absolutePaths);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Cli/CachingCodeReviewerProvider.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Cli/CachingCodeReviewerProvider.cs
@@ -55,24 +55,24 @@ namespace Codescene.VSExtension.VS2022.Application.Cli
             return _inner.ReviewAsync(path, content, isBaseline, operationGeneration, cancellationToken);
         }
 
-        public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public Task<DeltaResponseModel> DeltaAsync(FileReviewModel review, string currentCode, string precomputedBaselineRawScore = null, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
-            return _inner.DeltaAsync(review, currentCode, precomputedBaselineRawScore, operationGeneration, cancellationToken);
+            return _inner.DeltaAsync(review, currentCode, precomputedBaselineRawScore, operationGeneration, cancellationToken, baselineCommit);
         }
 
-        public Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public Task<(FileReviewModel review, string baselineRawScore)> ReviewAndBaselineAsync(string path, string currentCode, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
-            return _inner.ReviewAndBaselineAsync(path, currentCode, operationGeneration, cancellationToken);
+            return _inner.ReviewAndBaselineAsync(path, currentCode, operationGeneration, cancellationToken, baselineCommit);
         }
 
-        public Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public Task<(FileReviewModel review, DeltaResponseModel delta)> ReviewWithDeltaAsync(string path, string content, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
-            return _inner.ReviewWithDeltaAsync(path, content, operationGeneration, cancellationToken);
+            return _inner.ReviewWithDeltaAsync(path, content, operationGeneration, cancellationToken, baselineCommit);
         }
 
-        public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default)
+        public Task<string> GetOrComputeBaselineRawScoreAsync(string path, string baselineContent, long? operationGeneration = null, CancellationToken cancellationToken = default, string baselineCommit = null)
         {
-            return _inner.GetOrComputeBaselineRawScoreAsync(path, baselineContent, operationGeneration, cancellationToken);
+            return _inner.GetOrComputeBaselineRawScoreAsync(path, baselineContent, operationGeneration, cancellationToken, baselineCommit);
         }
 
         private void OnViewUpdateRequested(object sender, EventArgs e)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitChangeObserver.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitChangeObserver.cs
@@ -80,7 +80,7 @@ namespace Codescene.VSExtension.VS2022.Application.Git
                 InitializeCore();
             }
 
-            _core.Initialize(solutionPath, savedFilesTracker, openFilesObserver, async () => await GetChangedFilesVsBaselineAsync(), _openDocumentContentProvider, workspacePaths);
+            _core.Initialize(solutionPath, savedFilesTracker, openFilesObserver, async (baselineCommit) => await GetChangedFilesVsBaselineAsync(baselineCommit), _openDocumentContentProvider, workspacePaths);
         }
 
         public void UpdateWorkspacePaths(IReadOnlyCollection<string> workspacePaths)
@@ -98,7 +98,7 @@ namespace Codescene.VSExtension.VS2022.Application.Git
             _core?.CancelAndReset();
         }
 
-        public virtual async Task<List<string>> GetChangedFilesVsBaselineAsync()
+        public virtual async Task<List<string>> GetChangedFilesVsBaselineAsync(string baselineCommit = null)
         {
             var core = _core;
             if (core == null)
@@ -106,7 +106,7 @@ namespace Codescene.VSExtension.VS2022.Application.Git
                 return new List<string>();
             }
 
-            return await core.GetChangedFilesVsBaselineAsync();
+            return await core.GetChangedFilesVsBaselineAsync(baselineCommit);
         }
 
         public void RemoveFromTracker(string filePath)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitService.cs
@@ -47,35 +47,25 @@ public class GitService : IGitService, IDisposable
     /// - If on a main branch: returns HEAD commit (compare against current committed state)
     /// - If on a feature branch: returns merge-base with main branch.
     /// </summary>
-    public string GetBaselineCommit(Repository repository)
+    public string GetBaselineCommit(string repoRootPath)
     {
+        if (string.IsNullOrEmpty(repoRootPath))
+        {
+            return string.Empty;
+        }
+
         try
         {
-            var currentBranchName = repository.Head?.FriendlyName;
-            if (string.IsNullOrEmpty(currentBranchName))
+            var repoPath = Repository.Discover(repoRootPath);
+            if (string.IsNullOrEmpty(repoPath))
             {
-                _logger.Warn("Could not determine current branch name.");
                 return string.Empty;
             }
 
-            // If on main branch, use HEAD commit as baseline
-            if (MainBranchNames.IsMainBranch(repository, currentBranchName))
+            using (var repo = new Repository(repoPath))
             {
-                var headCommit = repository.Head?.Tip?.Sha ?? string.Empty;
-                _logger.Debug($"On main branch '{currentBranchName}', using HEAD as baseline: {headCommit}");
-                return headCommit;
+                return GetBaselineCommitFromRepo(repo);
             }
-
-            // On feature branch, try to find merge-base with main
-            var mergeBase = MainBranchMergeBaseSelector.FindClosest(repository, _logger);
-            if (mergeBase != null)
-            {
-                _logger.Debug($"Using merge-base with main as baseline: {mergeBase.Sha}");
-                return mergeBase.Sha;
-            }
-
-            // Fallback: try reflog-based approach
-            return GetBranchCreationCommitFromReflog(repository);
         }
         catch (Exception e)
         {
@@ -102,7 +92,7 @@ public class GitService : IGitService, IDisposable
 
             using (var repo = new Repository(repoPath))
             {
-                var commitHash = string.IsNullOrEmpty(baselineCommit) ? GetBaselineCommit(repo) : baselineCommit;
+                var commitHash = string.IsNullOrEmpty(baselineCommit) ? GetBaselineCommitFromRepo(repo) : baselineCommit;
 
                 if (string.IsNullOrEmpty(commitHash))
                 {
@@ -201,6 +191,43 @@ public class GitService : IGitService, IDisposable
         }
 
         return path;
+    }
+
+    private string GetBaselineCommitFromRepo(Repository repository)
+    {
+        try
+        {
+            var currentBranchName = repository.Head?.FriendlyName;
+            if (string.IsNullOrEmpty(currentBranchName))
+            {
+                _logger.Warn("Could not determine current branch name.");
+                return string.Empty;
+            }
+
+            // If on main branch, use HEAD commit as baseline
+            if (MainBranchNames.IsMainBranch(repository, currentBranchName))
+            {
+                var headCommit = repository.Head?.Tip?.Sha ?? string.Empty;
+                _logger.Debug($"On main branch '{currentBranchName}', using HEAD as baseline: {headCommit}");
+                return headCommit;
+            }
+
+            // On feature branch, try to find merge-base with main
+            var mergeBase = MainBranchMergeBaseSelector.FindClosest(repository, _logger);
+            if (mergeBase != null)
+            {
+                _logger.Debug($"Using merge-base with main as baseline: {mergeBase.Sha}");
+                return mergeBase.Sha;
+            }
+
+            // Fallback: try reflog-based approach
+            return GetBranchCreationCommitFromReflog(repository);
+        }
+        catch (Exception e)
+        {
+            _logger.Error("Could not get baseline commit.", e);
+            return string.Empty;
+        }
     }
 
     private string GetBranchCreationCommitFromReflog(Repository repository)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitService.cs
@@ -86,6 +86,11 @@ public class GitService : IGitService, IDisposable
 
     public string GetFileContentForCommit(string path)
     {
+        return GetFileContentForCommit(path, null);
+    }
+
+    public string GetFileContentForCommit(string path, string baselineCommit)
+    {
         try
         {
             var repoPath = Repository.Discover(path);
@@ -95,34 +100,36 @@ public class GitService : IGitService, IDisposable
                 return string.Empty;
             }
 
-            using var repo = new Repository(repoPath);
-            var commitHash = GetBaselineCommit(repo);
-
-            if (string.IsNullOrEmpty(commitHash))
+            using (var repo = new Repository(repoPath))
             {
-                _logger.Debug("No baseline commit found, skipping file content retrieval.");
-                return string.Empty;
+                var commitHash = string.IsNullOrEmpty(baselineCommit) ? GetBaselineCommit(repo) : baselineCommit;
+
+                if (string.IsNullOrEmpty(commitHash))
+                {
+                    _logger.Debug("No baseline commit found, skipping file content retrieval.");
+                    return string.Empty;
+                }
+
+                var repoRoot = repo.Info.WorkingDirectory;
+                var relativePath = GetRelativePath(repoRoot, path).Replace("\\", "/");
+
+                var commit = repo.Lookup<Commit>(commitHash);
+                if (commit == null)
+                {
+                    _logger.Warn($"Could not find commit {commitHash}");
+                    return string.Empty;
+                }
+
+                var entry = commit[relativePath];
+                if (entry == null)
+                {
+                    _logger.Debug($"File {relativePath} not found in commit {commitHash}");
+                    return string.Empty;
+                }
+
+                var blob = (Blob)entry.Target;
+                return blob.GetContentText();
             }
-
-            var repoRoot = repo.Info.WorkingDirectory;
-            var relativePath = GetRelativePath(repoRoot, path).Replace("\\", "/");
-
-            var commit = repo.Lookup<Commit>(commitHash);
-            if (commit == null)
-            {
-                _logger.Warn($"Could not find commit {commitHash}");
-                return string.Empty;
-            }
-
-            var entry = commit[relativePath];
-            if (entry == null)
-            {
-                _logger.Debug($"File {relativePath} not found in commit {commitHash}");
-                return string.Empty;
-            }
-
-            var blob = (Blob)entry.Target;
-            return blob.GetContentText();
         }
         catch (Exception e)
         {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/IGitChangeObserver.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/IGitChangeObserver.cs
@@ -21,7 +21,7 @@ namespace Codescene.VSExtension.VS2022.Application.Git
 
         void CancelAndReset();
 
-        Task<List<string>> GetChangedFilesVsBaselineAsync();
+        Task<List<string>> GetChangedFilesVsBaselineAsync(string baselineCommit);
 
         void RemoveFromTracker(string filePath);
     }


### PR DESCRIPTION
When reviewing multiple files, the merge-base with the default branch is now computed once per batch and passed through the call chain via a `baselineCommit` parameter. This eliminates redundant `GetBaselineCommit` calls when processing batches of changed files.

Port of codescene-vscode commit c1cc6706ddcffe8be521c982c1b8ab99442cb313.

Verified manually. **Note**: 

FileChangeEventProcessor can compute the merge-base once per tick as long as there are files pending processing. This is a consequence of the FileChangeEventProcessor design. I'm considering a change, but that's orthogonal.