### PR TITLE
feat: add CPU monitoring to throttle CLI commands during high load

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
@@ -7,6 +7,7 @@ using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Cli;
 using Codescene.VSExtension.Core.Interfaces.Extension;
 using Codescene.VSExtension.Core.Interfaces.Telemetry;
+using Codescene.VSExtension.Core.Interfaces.Util;
 using Codescene.VSExtension.Core.Models.Cli.Delta;
 using Codescene.VSExtension.Core.Models.Cli.Refactor;
 using Codescene.VSExtension.Core.Models.Cli.Review;
@@ -547,6 +548,47 @@ namespace Codescene.VSExtension.Core.Tests
                     Directory.Delete(bad, true);
                 }
             }
+        }
+
+        [TestMethod]
+        public async Task ExecuteOnChannelAsync_WaitsForCpuBeforeAcquiringSemaphore()
+        {
+            var cpuWaitSignal = new TaskCompletionSource<bool>();
+            var cpuWaitCount = 0;
+            var mockThrottler = new Mock<ICpuUsageThrottler>();
+            mockThrottler.Setup(x => x.WaitForCpuAsync(It.IsAny<CancellationToken>()))
+                .Returns(async () =>
+                {
+                    Interlocked.Increment(ref cpuWaitCount);
+                    await cpuWaitSignal.Task;
+                });
+
+            var executor = new CliExecutor(
+                _mockLogger.Object,
+                _mockCliServices.Object,
+                _mockSettingsProvider.Object,
+                _lazyTelemetryManager,
+                mockThrottler.Object,
+                cliCommandConcurrencyLimit: 1);
+
+            _mockCommandProvider.Setup(x => x.ReviewFileContentCommand).Returns("review");
+            _mockCommandProvider.Setup(x => x.GetReviewFileContentPayload(It.IsAny<string>(), It.IsAny<string>(), TestCachePath))
+                .Returns("payload");
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .ReturnsAsync(JsonConvert.SerializeObject(new CliReviewModel { Score = 1 }));
+
+            var task1 = executor.ReviewContentAsync("/file1.cs", "content1");
+            var task2 = executor.ReviewContentAsync("/file2.cs", "content2");
+
+            await Task.Delay(100);
+
+            Assert.AreEqual(
+                2,
+                cpuWaitCount,
+                "Both operations should wait for CPU in parallel before acquiring semaphore");
+
+            cpuWaitSignal.SetResult(true);
+            await Task.WhenAll(task1, task2);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
@@ -590,5 +590,39 @@ namespace Codescene.VSExtension.Core.Tests
             cpuWaitSignal.SetResult(true);
             await Task.WhenAll(task1, task2);
         }
+
+        [TestMethod]
+        public async Task ReviewDeltaAsync_WaitsForCpuBeforeAcquiringSemaphore()
+        {
+            var cpuWaitCalled = false;
+            var mockThrottler = new Mock<ICpuUsageThrottler>();
+            mockThrottler.Setup(x => x.WaitForCpuAsync(It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    cpuWaitCalled = true;
+                    return Task.CompletedTask;
+                });
+
+            var executor = new CliExecutor(
+                _mockLogger.Object,
+                _mockCliServices.Object,
+                _mockSettingsProvider.Object,
+                _lazyTelemetryManager,
+                mockThrottler.Object,
+                cliCommandConcurrencyLimit: 1);
+
+            var expectedDelta = new DeltaResponseModel { NewScore = 8.5m, OldScore = 7.0m };
+            var jsonResponse = JsonConvert.SerializeObject(expectedDelta);
+            _mockCommandProvider.Setup(x => x.GetReviewDeltaCommand(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns("delta command");
+            _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .ReturnsAsync(jsonResponse);
+
+            var result = await executor.ReviewDeltaAsync(new ReviewDeltaRequest { OldScore = "old", NewScore = "new", FilePath = TestFilePath });
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(cpuWaitCalled, "ReviewDeltaAsync should call WaitForCpuAsync before executing");
+            mockThrottler.Verify(x => x.WaitForCpuAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CliExecutorTests.cs
@@ -551,16 +551,23 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
-        public async Task ExecuteOnChannelAsync_WaitsForCpuBeforeAcquiringSemaphore()
+        public async Task ExecuteOnChannelAsync_AcquiresSemaphoreBeforeWaitingForCpu()
         {
-            var cpuWaitSignal = new TaskCompletionSource<bool>();
-            var cpuWaitCount = 0;
+            var operationLog = new List<string>();
+            var semaphoreAcquiredSignal = new TaskCompletionSource<bool>();
+            var cpuCheckSignal = new TaskCompletionSource<bool>();
+
             var mockThrottler = new Mock<ICpuUsageThrottler>();
             mockThrottler.Setup(x => x.WaitForCpuAsync(It.IsAny<CancellationToken>()))
                 .Returns(async () =>
                 {
-                    Interlocked.Increment(ref cpuWaitCount);
-                    await cpuWaitSignal.Task;
+                    lock (operationLog)
+                    {
+                        operationLog.Add("cpu_wait");
+                    }
+
+                    semaphoreAcquiredSignal.TrySetResult(true);
+                    await cpuCheckSignal.Task;
                 });
 
             var executor = new CliExecutor(
@@ -580,27 +587,42 @@ namespace Codescene.VSExtension.Core.Tests
             var task1 = executor.ReviewContentAsync("/file1.cs", "content1");
             var task2 = executor.ReviewContentAsync("/file2.cs", "content2");
 
-            await Task.Delay(100);
+            await semaphoreAcquiredSignal.Task;
+            await Task.Delay(50);
+
+            int cpuWaitCount;
+            lock (operationLog)
+            {
+                cpuWaitCount = operationLog.Count(x => x == "cpu_wait");
+            }
 
             Assert.AreEqual(
-                2,
+                1,
                 cpuWaitCount,
-                "Both operations should wait for CPU in parallel before acquiring semaphore");
+                "Only the operation that acquired the semaphore should check CPU; the other should be blocked waiting for the semaphore");
 
-            cpuWaitSignal.SetResult(true);
+            cpuCheckSignal.SetResult(true);
             await Task.WhenAll(task1, task2);
         }
 
         [TestMethod]
-        public async Task ReviewDeltaAsync_WaitsForCpuBeforeAcquiringSemaphore()
+        public async Task ReviewDeltaAsync_AcquiresSemaphoreBeforeWaitingForCpu()
         {
-            var cpuWaitCalled = false;
+            var operationLog = new List<string>();
+            var semaphoreAcquiredSignal = new TaskCompletionSource<bool>();
+            var cpuCheckSignal = new TaskCompletionSource<bool>();
+
             var mockThrottler = new Mock<ICpuUsageThrottler>();
             mockThrottler.Setup(x => x.WaitForCpuAsync(It.IsAny<CancellationToken>()))
-                .Returns(() =>
+                .Returns(async () =>
                 {
-                    cpuWaitCalled = true;
-                    return Task.CompletedTask;
+                    lock (operationLog)
+                    {
+                        operationLog.Add("cpu_wait");
+                    }
+
+                    semaphoreAcquiredSignal.TrySetResult(true);
+                    await cpuCheckSignal.Task;
                 });
 
             var executor = new CliExecutor(
@@ -618,11 +640,25 @@ namespace Codescene.VSExtension.Core.Tests
             _mockProcessExecutor.Setup(x => x.ExecuteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
                 .ReturnsAsync(jsonResponse);
 
-            var result = await executor.ReviewDeltaAsync(new ReviewDeltaRequest { OldScore = "old", NewScore = "new", FilePath = TestFilePath });
+            var task1 = executor.ReviewDeltaAsync(new ReviewDeltaRequest { OldScore = "old1", NewScore = "new1", FilePath = "/file1.cs" });
+            var task2 = executor.ReviewDeltaAsync(new ReviewDeltaRequest { OldScore = "old2", NewScore = "new2", FilePath = "/file2.cs" });
 
-            Assert.IsNotNull(result);
-            Assert.IsTrue(cpuWaitCalled, "ReviewDeltaAsync should call WaitForCpuAsync before executing");
-            mockThrottler.Verify(x => x.WaitForCpuAsync(It.IsAny<CancellationToken>()), Times.Once);
+            await semaphoreAcquiredSignal.Task;
+            await Task.Delay(50);
+
+            int cpuWaitCount;
+            lock (operationLog)
+            {
+                cpuWaitCount = operationLog.Count(x => x == "cpu_wait");
+            }
+
+            Assert.AreEqual(
+                1,
+                cpuWaitCount,
+                "Only the operation that acquired the delta semaphore should check CPU; the other should be blocked waiting for the semaphore");
+
+            cpuCheckSignal.SetResult(true);
+            await Task.WhenAll(task1, task2);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
@@ -15,6 +15,7 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        [DataRow(0, 65)]
         [DataRow(1, 65)]
         [DataRow(2, 65)]
         [DataRow(3, 65)]
@@ -91,6 +92,26 @@ namespace Codescene.VSExtension.Core.Tests
             await CpuMonitor.IsCpuTooBusyAsync();
 
             Assert.IsGreaterThanOrEqualTo(callCount, 5);
+        }
+
+        [TestMethod]
+        public async Task IsCpuTooBusyAsync_WhenWallTimeDiffIsZeroOrNegative_ReturnsFalse()
+        {
+            var callCount = 0;
+            var baseTime = DateTime.UtcNow;
+            CpuMonitor.SetSnapshotProvider(() =>
+            {
+                callCount++;
+                return new CpuSnapshot
+                {
+                    TotalProcessorTime = TimeSpan.FromMilliseconds(callCount * 1000),
+                    Timestamp = baseTime,
+                };
+            });
+
+            var result = await CpuMonitor.IsCpuTooBusyAsync();
+
+            Assert.IsFalse(result);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
@@ -37,14 +37,14 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task IsCpuTooBusyAsync_WhenCpuBelowThreshold_ReturnsFalse()
         {
             var callCount = 0;
-            var baseTime = DateTime.UtcNow;
             CpuMonitor.SetSnapshotProvider(() =>
             {
                 callCount++;
                 return new CpuSnapshot
                 {
-                    TotalProcessorTime = TimeSpan.FromMilliseconds(callCount * 10),
-                    Timestamp = baseTime.AddMilliseconds(callCount * 100),
+                    IdleTime = callCount * 900,
+                    KernelTime = callCount * 1000,
+                    UserTime = callCount * 100,
                 };
             });
 
@@ -57,15 +57,14 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task IsCpuTooBusyAsync_WhenCpuAboveThreshold_ReturnsTrue()
         {
             var callCount = 0;
-            var baseTime = DateTime.UtcNow;
-            var coreCount = Environment.ProcessorCount;
             CpuMonitor.SetSnapshotProvider(() =>
             {
                 callCount++;
                 return new CpuSnapshot
                 {
-                    TotalProcessorTime = TimeSpan.FromMilliseconds(callCount * 100 * coreCount),
-                    Timestamp = baseTime.AddMilliseconds(callCount * 100),
+                    IdleTime = callCount * 100,
+                    KernelTime = callCount * 1000,
+                    UserTime = callCount * 100,
                 };
             });
 
@@ -78,14 +77,14 @@ namespace Codescene.VSExtension.Core.Tests
         public async Task IsCpuTooBusyAsync_TakesMultipleSamples()
         {
             var callCount = 0;
-            var baseTime = DateTime.UtcNow;
             CpuMonitor.SetSnapshotProvider(() =>
             {
                 callCount++;
                 return new CpuSnapshot
                 {
-                    TotalProcessorTime = TimeSpan.FromMilliseconds(callCount * 5),
-                    Timestamp = baseTime.AddMilliseconds(callCount * 50),
+                    IdleTime = callCount * 500,
+                    KernelTime = callCount * 1000,
+                    UserTime = callCount * 100,
                 };
             });
 
@@ -96,17 +95,15 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
-        public async Task IsCpuTooBusyAsync_WhenWallTimeDiffIsZeroOrNegative_ReturnsFalse()
+        public async Task IsCpuTooBusyAsync_WhenTotalTimeDiffIsZeroOrNegative_ReturnsFalse()
         {
-            var callCount = 0;
-            var baseTime = DateTime.UtcNow;
             CpuMonitor.SetSnapshotProvider(() =>
             {
-                callCount++;
                 return new CpuSnapshot
                 {
-                    TotalProcessorTime = TimeSpan.FromMilliseconds(callCount * 1000),
-                    Timestamp = baseTime,
+                    IdleTime = 0,
+                    KernelTime = 0,
+                    UserTime = 0,
                 };
             });
 
@@ -129,18 +126,18 @@ namespace Codescene.VSExtension.Core.Tests
             int coreCount, int usagePercent, bool expectedTooBusy)
         {
             var callCount = 0;
-            var baseTime = DateTime.UtcNow;
 
             CpuMonitor.SetCoreCountProvider(() => coreCount);
 
             CpuMonitor.SetSnapshotProvider(() =>
             {
                 callCount++;
-                var cpuTimeMs = callCount * 100 * usagePercent / 100.0 * coreCount;
+                var idlePercent = 100 - usagePercent;
                 return new CpuSnapshot
                 {
-                    TotalProcessorTime = TimeSpan.FromMilliseconds(cpuTimeMs),
-                    Timestamp = baseTime.AddMilliseconds(callCount * 100),
+                    IdleTime = callCount * 1000 * idlePercent,
+                    KernelTime = callCount * 1000 * 100,
+                    UserTime = 0,
                 };
             });
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using Codescene.VSExtension.Core.Application.Util;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class CpuMonitorTests
+    {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            CpuMonitor.ResetSnapshotProvider();
+        }
+
+        [TestMethod]
+        [DataRow(1, 65)]
+        [DataRow(2, 65)]
+        [DataRow(3, 65)]
+        [DataRow(4, 70)]
+        [DataRow(5, 70)]
+        [DataRow(6, 70)]
+        [DataRow(7, 70)]
+        [DataRow(8, 75)]
+        [DataRow(9, 75)]
+        [DataRow(16, 75)]
+        public void GetThresholdForCoreCount_ReturnsCorrectThreshold(int coreCount, int expectedThreshold)
+        {
+            var result = CpuMonitor.GetThresholdForCoreCount(coreCount);
+            Assert.AreEqual(expectedThreshold, result);
+        }
+
+        [TestMethod]
+        public async Task IsCpuTooBusyAsync_WhenCpuBelowThreshold_ReturnsFalse()
+        {
+            var callCount = 0;
+            var baseTime = DateTime.UtcNow;
+            CpuMonitor.SetSnapshotProvider(() =>
+            {
+                callCount++;
+                return new CpuSnapshot
+                {
+                    TotalProcessorTime = TimeSpan.FromMilliseconds(callCount * 10),
+                    Timestamp = baseTime.AddMilliseconds(callCount * 100),
+                };
+            });
+
+            var result = await CpuMonitor.IsCpuTooBusyAsync();
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public async Task IsCpuTooBusyAsync_WhenCpuAboveThreshold_ReturnsTrue()
+        {
+            var callCount = 0;
+            var baseTime = DateTime.UtcNow;
+            var coreCount = Environment.ProcessorCount;
+            CpuMonitor.SetSnapshotProvider(() =>
+            {
+                callCount++;
+                return new CpuSnapshot
+                {
+                    TotalProcessorTime = TimeSpan.FromMilliseconds(callCount * 100 * coreCount),
+                    Timestamp = baseTime.AddMilliseconds(callCount * 100),
+                };
+            });
+
+            var result = await CpuMonitor.IsCpuTooBusyAsync();
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public async Task IsCpuTooBusyAsync_TakesMultipleSamples()
+        {
+            var callCount = 0;
+            var baseTime = DateTime.UtcNow;
+            CpuMonitor.SetSnapshotProvider(() =>
+            {
+                callCount++;
+                return new CpuSnapshot
+                {
+                    TotalProcessorTime = TimeSpan.FromMilliseconds(callCount * 5),
+                    Timestamp = baseTime.AddMilliseconds(callCount * 50),
+                };
+            });
+
+            callCount = 0;
+            await CpuMonitor.IsCpuTooBusyAsync();
+
+            Assert.IsGreaterThanOrEqualTo(callCount, 5);
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
@@ -12,6 +12,7 @@ namespace Codescene.VSExtension.Core.Tests
         public void Cleanup()
         {
             CpuMonitor.ResetSnapshotProvider();
+            CpuMonitor.ResetCoreCountProvider();
         }
 
         [TestMethod]
@@ -112,6 +113,40 @@ namespace Codescene.VSExtension.Core.Tests
             var result = await CpuMonitor.IsCpuTooBusyAsync();
 
             Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        [DataRow(8, 20, false, DisplayName = "8 cores at 20% usage - below 75% threshold")]
+        [DataRow(8, 75, false, DisplayName = "8 cores at 75% usage - at 75% threshold")]
+        [DataRow(8, 80, true, DisplayName = "8 cores at 80% usage - above 75% threshold")]
+        [DataRow(6, 20, false, DisplayName = "6 cores at 20% usage - below 70% threshold")]
+        [DataRow(6, 70, false, DisplayName = "6 cores at 70% usage - at 70% threshold")]
+        [DataRow(6, 75, true, DisplayName = "6 cores at 75% usage - above 70% threshold")]
+        [DataRow(2, 20, false, DisplayName = "2 cores at 20% usage - below 65% threshold")]
+        [DataRow(2, 65, false, DisplayName = "2 cores at 65% usage - at 65% threshold")]
+        [DataRow(2, 70, true, DisplayName = "2 cores at 70% usage - above 65% threshold")]
+        public async Task IsCpuTooBusyAsync_WithMockedCoreCount_VerifiesThresholdTiers(
+            int coreCount, int usagePercent, bool expectedTooBusy)
+        {
+            var callCount = 0;
+            var baseTime = DateTime.UtcNow;
+
+            CpuMonitor.SetCoreCountProvider(() => coreCount);
+
+            CpuMonitor.SetSnapshotProvider(() =>
+            {
+                callCount++;
+                var cpuTimeMs = callCount * 100 * usagePercent / 100.0 * coreCount;
+                return new CpuSnapshot
+                {
+                    TotalProcessorTime = TimeSpan.FromMilliseconds(cpuTimeMs),
+                    Timestamp = baseTime.AddMilliseconds(callCount * 100),
+                };
+            });
+
+            var result = await CpuMonitor.IsCpuTooBusyAsync();
+
+            Assert.AreEqual(expectedTooBusy, result);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuUsageThrottlerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuUsageThrottlerTests.cs
@@ -102,6 +102,39 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public async Task WaitForCpuAsync_WhenCpuCheckThrowsException_LogsAndCompletes()
+        {
+            var callCount = 0;
+            var throttler = new CpuUsageThrottler(
+                _mockLogger.Object,
+                () =>
+                {
+                    callCount++;
+                    throw new InvalidOperationException("CPU check failed");
+                },
+                (ms, ct) => Task.Delay(ms, ct));
+
+            await throttler.WaitForCpuAsync(CancellationToken.None);
+
+            Assert.AreEqual(1, callCount);
+            _mockLogger.Verify(x => x.Warn(It.Is<string>(s => s.Contains("CPU check failed"))), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task WaitForCpuAsync_WhenCpuCheckThrowsOperationCanceledException_PropagatesException()
+        {
+            var throttler = new CpuUsageThrottler(
+                _mockLogger.Object,
+                () => throw new OperationCanceledException(),
+                (ms, ct) => Task.Delay(ms, ct));
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => throttler.WaitForCpuAsync(CancellationToken.None));
+
+            _mockLogger.Verify(x => x.Warn(It.IsAny<string>()), Times.Never);
+        }
+
+        [TestMethod]
         public async Task NoOpCpuUsageThrottler_CompletesImmediately()
         {
             var throttler = new NoOpCpuUsageThrottler();

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuUsageThrottlerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuUsageThrottlerTests.cs
@@ -144,5 +144,65 @@ namespace Codescene.VSExtension.Core.Tests
             Assert.IsTrue(task.IsCompleted);
             await task;
         }
+
+        [TestMethod]
+        public async Task WaitForCpuAsync_WhenCpuBecomesBusyAfterFirstCheck_ExecutesImmediately()
+        {
+            var responses = new Queue<bool>(new[] { false, true });
+            var delayCallCount = 0;
+            var throttler = new CpuUsageThrottler(
+                _mockLogger.Object,
+                () => Task.FromResult(responses.Dequeue()),
+                (ms, ct) =>
+                {
+                    delayCallCount++;
+                    return Task.CompletedTask;
+                });
+
+            await throttler.WaitForCpuAsync(CancellationToken.None);
+
+            Assert.AreEqual(0, delayCallCount);
+            _mockLogger.Verify(x => x.Info(It.IsAny<string>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task WaitForCpuAsync_WhenCpuBusyThenFreeTheBusyAgain_WaitsOnce()
+        {
+            var responses = new Queue<bool>(new[] { true, false, true });
+            var delayCallCount = 0;
+            var throttler = new CpuUsageThrottler(
+                _mockLogger.Object,
+                () => Task.FromResult(responses.Dequeue()),
+                (ms, ct) =>
+                {
+                    delayCallCount++;
+                    return Task.CompletedTask;
+                });
+
+            await throttler.WaitForCpuAsync(CancellationToken.None);
+
+            Assert.AreEqual(1, delayCallCount);
+            _mockLogger.Verify(x => x.Info(It.Is<string>(s => s.Contains("CPU too busy"))), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task WaitForCpuAsync_WhenCpuFreeThenBusyThenFree_ExecutesImmediately()
+        {
+            var responses = new Queue<bool>(new[] { false, true, false });
+            var delayCallCount = 0;
+            var throttler = new CpuUsageThrottler(
+                _mockLogger.Object,
+                () => Task.FromResult(responses.Dequeue()),
+                (ms, ct) =>
+                {
+                    delayCallCount++;
+                    return Task.CompletedTask;
+                });
+
+            await throttler.WaitForCpuAsync(CancellationToken.None);
+
+            Assert.AreEqual(0, delayCallCount);
+            _mockLogger.Verify(x => x.Info(It.IsAny<string>()), Times.Never);
+        }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuUsageThrottlerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuUsageThrottlerTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Application.Util;
+using Codescene.VSExtension.Core.Interfaces;
+using Moq;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class CpuUsageThrottlerTests
+    {
+        private Mock<ILogger> _mockLogger;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _mockLogger = new Mock<ILogger>();
+        }
+
+        [TestMethod]
+        public async Task WaitForCpuAsync_WhenCpuNotBusy_CompletesImmediately()
+        {
+            var cpuCheckCalls = 0;
+            var throttler = new CpuUsageThrottler(
+                _mockLogger.Object,
+                () =>
+                {
+                    cpuCheckCalls++;
+                    return Task.FromResult(false);
+                },
+                (ms, ct) => Task.Delay(ms, ct));
+
+            await throttler.WaitForCpuAsync(CancellationToken.None);
+
+            Assert.AreEqual(1, cpuCheckCalls);
+            _mockLogger.Verify(x => x.Info(It.IsAny<string>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task WaitForCpuAsync_WhenCpuBusyThenFree_WaitsAndRetries()
+        {
+            var responses = new Queue<bool>(new[] { true, false });
+            var delayCallCount = 0;
+            var delayMs = new List<int>();
+            var throttler = new CpuUsageThrottler(
+                _mockLogger.Object,
+                () => Task.FromResult(responses.Dequeue()),
+                (ms, ct) =>
+                {
+                    delayCallCount++;
+                    delayMs.Add(ms);
+                    return Task.CompletedTask;
+                });
+
+            await throttler.WaitForCpuAsync(CancellationToken.None);
+
+            Assert.AreEqual(1, delayCallCount);
+            Assert.AreEqual(9000, delayMs[0]);
+            _mockLogger.Verify(x => x.Info(It.Is<string>(s => s.Contains("CPU too busy"))), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task WaitForCpuAsync_WhenCpuBusyMultipleTimes_WaitsMultipleTimes()
+        {
+            var responses = new Queue<bool>(new[] { true, true, true, false });
+            var delayCallCount = 0;
+            var throttler = new CpuUsageThrottler(
+                _mockLogger.Object,
+                () => Task.FromResult(responses.Dequeue()),
+                (ms, ct) =>
+                {
+                    delayCallCount++;
+                    return Task.CompletedTask;
+                });
+
+            await throttler.WaitForCpuAsync(CancellationToken.None);
+
+            Assert.AreEqual(3, delayCallCount);
+            _mockLogger.Verify(x => x.Info(It.Is<string>(s => s.Contains("CPU too busy"))), Times.Exactly(3));
+        }
+
+        [TestMethod]
+        public async Task WaitForCpuAsync_WhenCancelled_ThrowsOperationCanceledException()
+        {
+            var responses = new Queue<bool>(new[] { true, true, true, false });
+            var cts = new CancellationTokenSource();
+            var throttler = new CpuUsageThrottler(
+                _mockLogger.Object,
+                () => Task.FromResult(responses.Dequeue()),
+                (ms, ct) =>
+                {
+                    cts.Cancel();
+                    return Task.CompletedTask;
+                });
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => throttler.WaitForCpuAsync(cts.Token));
+        }
+
+        [TestMethod]
+        public async Task NoOpCpuUsageThrottler_CompletesImmediately()
+        {
+            var throttler = new NoOpCpuUsageThrottler();
+
+            var task = throttler.WaitForCpuAsync(CancellationToken.None);
+
+            Assert.IsTrue(task.IsCompleted);
+            await task;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
@@ -158,6 +158,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
                 return null;
             }
 
+            await _cpuUsageThrottler.WaitForCpuAsync(cancellationToken);
             await _deltaChannel.WaitAsync(cancellationToken);
             try
             {
@@ -233,13 +234,10 @@ namespace Codescene.VSExtension.Core.Application.Cli
                 return null;
             }
 
-            var (result, elapsedMs) = await ExecuteOnChannelAsync(
-                _cliCommandChannel,
-                cancellationToken,
-                () => ExecuteWithTimingAndLoggingAsync<RefactorResponseModel>(
-                    "ACE refactoring",
-                    () => _cliServices.ProcessExecutor.ExecuteAsync(arguments, payload, null, cancellationToken),
-                    "Refactoring failed."));
+            var (result, elapsedMs) = await ExecuteWithTimingAndLoggingAsync<RefactorResponseModel>(
+                "ACE refactoring",
+                () => _cliServices.ProcessExecutor.ExecuteAsync(arguments, payload, null, cancellationToken),
+                "Refactoring failed.");
 
             if (result != null && fnToRefactor != null)
             {
@@ -401,13 +399,10 @@ namespace Codescene.VSExtension.Core.Application.Cli
 
             var command = _cliServices.CommandProvider.RefactorCommand;
 
-            var (result, _) = await ExecuteOnChannelAsync(
-                _cliCommandChannel,
-                cancellationToken,
-                () => ExecuteWithTimingAndLoggingAsync<IList<FnToRefactorModel>>(
-                    operationLabel,
-                    () => _cliServices.ProcessExecutor.ExecuteAsync(command, payloadContent, null, cancellationToken),
-                    errorMessage));
+            var (result, _) = await ExecuteWithTimingAndLoggingAsync<IList<FnToRefactorModel>>(
+                operationLabel,
+                () => _cliServices.ProcessExecutor.ExecuteAsync(command, payloadContent, null, cancellationToken),
+                errorMessage);
             return result;
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
@@ -10,11 +10,13 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Application.Util;
 using Codescene.VSExtension.Core.Exceptions;
 using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Cli;
 using Codescene.VSExtension.Core.Interfaces.Extension;
 using Codescene.VSExtension.Core.Interfaces.Telemetry;
+using Codescene.VSExtension.Core.Interfaces.Util;
 using Codescene.VSExtension.Core.Models;
 using Codescene.VSExtension.Core.Models.Cli.Delta;
 using Codescene.VSExtension.Core.Models.Cli.Refactor;
@@ -38,14 +40,16 @@ namespace Codescene.VSExtension.Core.Application.Cli
         private readonly ConcurrentDictionary<string, Lazy<Task<IList<FnToRefactorModel>>>> _pendingRefactorRequests = new ConcurrentDictionary<string, Lazy<Task<IList<FnToRefactorModel>>>>();
         private readonly SemaphoreSlim _cliCommandChannel;
         private readonly SemaphoreSlim _deltaChannel = new SemaphoreSlim(1, 1);
+        private readonly ICpuUsageThrottler _cpuUsageThrottler;
 
         [ImportingConstructor]
         public CliExecutor(
             ILogger logger,
             ICliServices cliServices,
             ISettingsProvider settingsProvider,
-            [Import(AllowDefault = true)] Lazy<ITelemetryManager> telemetryManagerLazy = null)
-            : this(logger, cliServices, settingsProvider, telemetryManagerLazy, 1)
+            [Import(AllowDefault = true)] Lazy<ITelemetryManager> telemetryManagerLazy = null,
+            [Import(AllowDefault = true)] ICpuUsageThrottler cpuUsageThrottler = null)
+            : this(logger, cliServices, settingsProvider, telemetryManagerLazy, cpuUsageThrottler, 1)
         {
         }
 
@@ -54,12 +58,14 @@ namespace Codescene.VSExtension.Core.Application.Cli
             ICliServices cliServices,
             ISettingsProvider settingsProvider,
             Lazy<ITelemetryManager> telemetryManagerLazy,
+            ICpuUsageThrottler cpuUsageThrottler,
             int cliCommandConcurrencyLimit)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _cliServices = cliServices ?? throw new ArgumentNullException(nameof(cliServices));
             _settingsProvider = settingsProvider ?? throw new ArgumentNullException(nameof(settingsProvider));
             _telemetryManagerLazy = telemetryManagerLazy;
+            _cpuUsageThrottler = cpuUsageThrottler ?? new NoOpCpuUsageThrottler();
             var effectiveLimit = Math.Max(1, cliCommandConcurrencyLimit);
             _cliCommandChannel = new SemaphoreSlim(effectiveLimit, effectiveLimit);
         }
@@ -421,6 +427,7 @@ namespace Codescene.VSExtension.Core.Application.Cli
             await channel.WaitAsync(cancellationToken);
             try
             {
+                await _cpuUsageThrottler.WaitForCpuAsync(cancellationToken);
                 return await operation();
             }
             finally

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
@@ -158,10 +158,10 @@ namespace Codescene.VSExtension.Core.Application.Cli
                 return null;
             }
 
-            await _cpuUsageThrottler.WaitForCpuAsync(cancellationToken);
             await _deltaChannel.WaitAsync(cancellationToken);
             try
             {
+                await _cpuUsageThrottler.WaitForCpuAsync(cancellationToken);
                 var workingDirectory = GetCliWorkingDirectoryForFile(request.FilePath);
                 var (result, elapsedMs) = await ExecuteWithTimingAndLoggingAsync<DeltaResponseModel>(
                     "CLI file delta review",
@@ -419,10 +419,10 @@ namespace Codescene.VSExtension.Core.Application.Cli
 
         private async Task<T> ExecuteOnChannelAsync<T>(SemaphoreSlim channel, CancellationToken cancellationToken, Func<Task<T>> operation)
         {
-            await _cpuUsageThrottler.WaitForCpuAsync(cancellationToken);
             await channel.WaitAsync(cancellationToken);
             try
             {
+                await _cpuUsageThrottler.WaitForCpuAsync(cancellationToken);
                 return await operation();
             }
             finally

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cli/CliExecutor.cs
@@ -424,10 +424,10 @@ namespace Codescene.VSExtension.Core.Application.Cli
 
         private async Task<T> ExecuteOnChannelAsync<T>(SemaphoreSlim channel, CancellationToken cancellationToken, Func<Task<T>> operation)
         {
+            await _cpuUsageThrottler.WaitForCpuAsync(cancellationToken);
             await channel.WaitAsync(cancellationToken);
             try
             {
-                await _cpuUsageThrottler.WaitForCpuAsync(cancellationToken);
                 return await operation();
             }
             finally

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
@@ -18,6 +18,7 @@ namespace Codescene.VSExtension.Core.Application.Util
             new CpuThreshold { MinCores = 0, Threshold = 65 },
         };
 
+        private static readonly object _snapshotLock = new object();
         private static Func<CpuSnapshot> _snapshotProvider = DefaultSnapshotProvider;
         private static CpuSnapshot _previousSnapshot = DefaultSnapshotProvider();
 
@@ -27,14 +28,20 @@ namespace Codescene.VSExtension.Core.Application.Util
 
         public static void SetSnapshotProvider(Func<CpuSnapshot> provider)
         {
-            _snapshotProvider = provider ?? DefaultSnapshotProvider;
-            _previousSnapshot = _snapshotProvider();
+            lock (_snapshotLock)
+            {
+                _snapshotProvider = provider ?? DefaultSnapshotProvider;
+                _previousSnapshot = _snapshotProvider();
+            }
         }
 
         public static void ResetSnapshotProvider()
         {
-            _snapshotProvider = DefaultSnapshotProvider;
-            _previousSnapshot = _snapshotProvider();
+            lock (_snapshotLock)
+            {
+                _snapshotProvider = DefaultSnapshotProvider;
+                _previousSnapshot = _snapshotProvider();
+            }
         }
 
         public static async Task<bool> IsCpuTooBusyAsync()
@@ -49,21 +56,7 @@ namespace Codescene.VSExtension.Core.Application.Util
                     await Task.Delay(SampleDelayMs);
                 }
 
-                var currentSnapshot = _snapshotProvider();
-
-                if (_previousSnapshot != null)
-                {
-                    var cpuTimeDiff = currentSnapshot.TotalProcessorTime - _previousSnapshot.TotalProcessorTime;
-                    var wallTimeDiff = currentSnapshot.Timestamp - _previousSnapshot.Timestamp;
-
-                    if (wallTimeDiff.TotalMilliseconds > 0)
-                    {
-                        var usage = (cpuTimeDiff.TotalMilliseconds / wallTimeDiff.TotalMilliseconds) * 100.0 / coreCount;
-                        usageSum += Math.Min(100, Math.Max(0, usage));
-                    }
-                }
-
-                _previousSnapshot = currentSnapshot;
+                usageSum += TakeSample(coreCount);
             }
 
             var averageUsage = usageSum / Samples;
@@ -83,6 +76,32 @@ namespace Codescene.VSExtension.Core.Application.Util
             }
 
             return 65;
+        }
+
+        private static double TakeSample(int coreCount)
+        {
+            lock (_snapshotLock)
+            {
+                var currentSnapshot = _snapshotProvider();
+                var previous = _previousSnapshot;
+                _previousSnapshot = currentSnapshot;
+
+                if (previous == null)
+                {
+                    return 0;
+                }
+
+                var cpuTimeDiff = currentSnapshot.TotalProcessorTime - previous.TotalProcessorTime;
+                var wallTimeDiff = currentSnapshot.Timestamp - previous.Timestamp;
+
+                if (wallTimeDiff.TotalMilliseconds <= 0)
+                {
+                    return 0;
+                }
+
+                var usage = (cpuTimeDiff.TotalMilliseconds / wallTimeDiff.TotalMilliseconds) * 100.0 / coreCount;
+                return Math.Min(100, Math.Max(0, usage));
+            }
         }
 
         private static CpuSnapshot DefaultSnapshotProvider()

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
@@ -1,7 +1,7 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using System;
-using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Codescene.VSExtension.Core.Application.Util
@@ -100,42 +100,55 @@ namespace Codescene.VSExtension.Core.Application.Util
             return 65;
         }
 
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetSystemTimes(
+            out long idleTime,
+            out long kernelTime,
+            out long userTime);
+
         private static double TakeSample(int coreCount)
         {
             lock (_snapshotLock)
             {
-                var currentSnapshot = _snapshotProvider();
+                var current = _snapshotProvider();
                 var previous = _previousSnapshot;
-                _previousSnapshot = currentSnapshot;
+                _previousSnapshot = current;
 
                 if (previous == null)
                 {
                     return 0;
                 }
 
-                var cpuTimeDiff = currentSnapshot.TotalProcessorTime - previous.TotalProcessorTime;
-                var wallTimeDiff = currentSnapshot.Timestamp - previous.Timestamp;
+                var idleDiff = current.IdleTime - previous.IdleTime;
+                var kernelDiff = current.KernelTime - previous.KernelTime;
+                var userDiff = current.UserTime - previous.UserTime;
 
-                if (wallTimeDiff.TotalMilliseconds <= 0)
+                var totalDiff = kernelDiff + userDiff;
+
+                if (totalDiff <= 0)
                 {
                     return 0;
                 }
 
-                var usage = (cpuTimeDiff.TotalMilliseconds / wallTimeDiff.TotalMilliseconds) * 100.0 / coreCount;
+                var usage = 100.0 - ((100.0 * idleDiff) / totalDiff);
                 return Math.Min(100, Math.Max(0, usage));
             }
         }
 
         private static CpuSnapshot DefaultSnapshotProvider()
         {
-            using (var process = Process.GetCurrentProcess())
+            if (!GetSystemTimes(out long idleTime, out long kernelTime, out long userTime))
             {
-                return new CpuSnapshot
-                {
-                    TotalProcessorTime = process.TotalProcessorTime,
-                    Timestamp = DateTime.UtcNow,
-                };
+                return new CpuSnapshot { IdleTime = 0, KernelTime = 0, UserTime = 0 };
             }
+
+            return new CpuSnapshot
+            {
+                IdleTime = idleTime,
+                KernelTime = kernelTime,
+                UserTime = userTime,
+            };
         }
 
         private class CpuThreshold

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
@@ -21,6 +21,7 @@ namespace Codescene.VSExtension.Core.Application.Util
         private static readonly object _snapshotLock = new object();
         private static Func<CpuSnapshot> _snapshotProvider = DefaultSnapshotProvider;
         private static CpuSnapshot _previousSnapshot = DefaultSnapshotProvider();
+        private static Func<int> _coreCountProvider = () => Environment.ProcessorCount;
 
         static CpuMonitor()
         {
@@ -44,9 +45,30 @@ namespace Codescene.VSExtension.Core.Application.Util
             }
         }
 
+        public static void SetCoreCountProvider(Func<int> provider)
+        {
+            lock (_snapshotLock)
+            {
+                _coreCountProvider = provider ?? (() => Environment.ProcessorCount);
+            }
+        }
+
+        public static void ResetCoreCountProvider()
+        {
+            lock (_snapshotLock)
+            {
+                _coreCountProvider = () => Environment.ProcessorCount;
+            }
+        }
+
         public static async Task<bool> IsCpuTooBusyAsync()
         {
-            var coreCount = Environment.ProcessorCount;
+            int coreCount;
+            lock (_snapshotLock)
+            {
+                coreCount = _coreCountProvider();
+            }
+
             double usageSum = 0;
 
             for (int i = 0; i < Samples; i++)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
@@ -1,0 +1,107 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Codescene.VSExtension.Core.Application.Util
+{
+    public static class CpuMonitor
+    {
+        private const int Samples = 5;
+        private const int SampleDelayMs = 13;
+
+        private static readonly CpuThreshold[] CpuThresholds =
+        {
+            new CpuThreshold { MinCores = 8, Threshold = 75 },
+            new CpuThreshold { MinCores = 4, Threshold = 70 },
+            new CpuThreshold { MinCores = 0, Threshold = 65 },
+        };
+
+        private static Func<CpuSnapshot> _snapshotProvider = DefaultSnapshotProvider;
+        private static CpuSnapshot _previousSnapshot = DefaultSnapshotProvider();
+
+        static CpuMonitor()
+        {
+        }
+
+        public static void SetSnapshotProvider(Func<CpuSnapshot> provider)
+        {
+            _snapshotProvider = provider ?? DefaultSnapshotProvider;
+            _previousSnapshot = _snapshotProvider();
+        }
+
+        public static void ResetSnapshotProvider()
+        {
+            _snapshotProvider = DefaultSnapshotProvider;
+            _previousSnapshot = _snapshotProvider();
+        }
+
+        public static async Task<bool> IsCpuTooBusyAsync()
+        {
+            var coreCount = Environment.ProcessorCount;
+            double usageSum = 0;
+
+            for (int i = 0; i < Samples; i++)
+            {
+                if (i > 0)
+                {
+                    await Task.Delay(SampleDelayMs);
+                }
+
+                var currentSnapshot = _snapshotProvider();
+
+                if (_previousSnapshot != null)
+                {
+                    var cpuTimeDiff = currentSnapshot.TotalProcessorTime - _previousSnapshot.TotalProcessorTime;
+                    var wallTimeDiff = currentSnapshot.Timestamp - _previousSnapshot.Timestamp;
+
+                    if (wallTimeDiff.TotalMilliseconds > 0)
+                    {
+                        var usage = (cpuTimeDiff.TotalMilliseconds / wallTimeDiff.TotalMilliseconds) * 100.0 / coreCount;
+                        usageSum += Math.Min(100, Math.Max(0, usage));
+                    }
+                }
+
+                _previousSnapshot = currentSnapshot;
+            }
+
+            var averageUsage = usageSum / Samples;
+            var threshold = GetThresholdForCoreCount(coreCount);
+
+            return averageUsage > threshold;
+        }
+
+        internal static int GetThresholdForCoreCount(int coreCount)
+        {
+            foreach (var t in CpuThresholds)
+            {
+                if (coreCount >= t.MinCores)
+                {
+                    return t.Threshold;
+                }
+            }
+
+            return 65;
+        }
+
+        private static CpuSnapshot DefaultSnapshotProvider()
+        {
+            using (var process = Process.GetCurrentProcess())
+            {
+                return new CpuSnapshot
+                {
+                    TotalProcessorTime = process.TotalProcessorTime,
+                    Timestamp = DateTime.UtcNow,
+                };
+            }
+        }
+
+        private class CpuThreshold
+        {
+            public int MinCores { get; set; }
+
+            public int Threshold { get; set; }
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
@@ -111,28 +111,37 @@ namespace Codescene.VSExtension.Core.Application.Util
         {
             lock (_snapshotLock)
             {
-                var current = _snapshotProvider();
-                var previous = _previousSnapshot;
-                _previousSnapshot = current;
-
-                if (previous == null)
+                try
                 {
+                    var current = _snapshotProvider();
+                    var previous = _previousSnapshot;
+                    _previousSnapshot = current;
+
+                    if (previous == null)
+                    {
+                        return 0;
+                    }
+
+                    var idleDiff = current.IdleTime - previous.IdleTime;
+                    var kernelDiff = current.KernelTime - previous.KernelTime;
+                    var userDiff = current.UserTime - previous.UserTime;
+
+                    var totalDiff = kernelDiff + userDiff;
+
+                    if (totalDiff <= 0)
+                    {
+                        return 0;
+                    }
+
+                    var usage = 100.0 - ((100.0 * idleDiff) / totalDiff);
+                    return Math.Min(100, Math.Max(0, usage));
+                }
+                catch
+                {
+                    // Return 0 (not busy) on any error - better to allow CLI operations
+                    // than to block them due to monitoring failures.
                     return 0;
                 }
-
-                var idleDiff = current.IdleTime - previous.IdleTime;
-                var kernelDiff = current.KernelTime - previous.KernelTime;
-                var userDiff = current.UserTime - previous.UserTime;
-
-                var totalDiff = kernelDiff + userDiff;
-
-                if (totalDiff <= 0)
-                {
-                    return 0;
-                }
-
-                var usage = 100.0 - ((100.0 * idleDiff) / totalDiff);
-                return Math.Min(100, Math.Max(0, usage));
             }
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuSnapshot.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuSnapshot.cs
@@ -1,0 +1,13 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+
+namespace Codescene.VSExtension.Core.Application.Util
+{
+    public class CpuSnapshot
+    {
+        public TimeSpan TotalProcessorTime { get; set; }
+
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuSnapshot.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuSnapshot.cs
@@ -1,13 +1,13 @@
 // Copyright (c) CodeScene. All rights reserved.
 
-using System;
-
 namespace Codescene.VSExtension.Core.Application.Util
 {
     public class CpuSnapshot
     {
-        public TimeSpan TotalProcessorTime { get; set; }
+        public long IdleTime { get; set; }
 
-        public DateTime Timestamp { get; set; }
+        public long KernelTime { get; set; }
+
+        public long UserTime { get; set; }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuUsageThrottler.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuUsageThrottler.cs
@@ -37,8 +37,28 @@ namespace Codescene.VSExtension.Core.Application.Util
 
         public async Task WaitForCpuAsync(CancellationToken cancellationToken)
         {
-            while (await _isCpuTooBusyFn())
+            while (true)
             {
+                bool isBusy;
+                try
+                {
+                    isBusy = await _isCpuTooBusyFn();
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger?.Warn($"CPU check failed: {ex.Message}");
+                    return;
+                }
+
+                if (!isBusy)
+                {
+                    return;
+                }
+
                 cancellationToken.ThrowIfCancellationRequested();
                 _logger?.Info($"CPU too busy, waiting {RetryDelayMs}ms before retry");
                 await _delayFn(RetryDelayMs, cancellationToken);

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuUsageThrottler.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuUsageThrottler.cs
@@ -1,0 +1,53 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Interfaces;
+using Codescene.VSExtension.Core.Interfaces.Util;
+
+namespace Codescene.VSExtension.Core.Application.Util
+{
+    [Export(typeof(ICpuUsageThrottler))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public class CpuUsageThrottler : ICpuUsageThrottler
+    {
+        private const int RetryDelayMs = 9000;
+
+        private readonly ILogger _logger;
+        private readonly Func<Task<bool>> _isCpuTooBusyFn;
+        private readonly Func<int, CancellationToken, Task> _delayFn;
+
+        [ImportingConstructor]
+        public CpuUsageThrottler(ILogger logger)
+            : this(logger, CpuMonitor.IsCpuTooBusyAsync, DefaultDelay)
+        {
+        }
+
+        internal CpuUsageThrottler(
+            ILogger logger,
+            Func<Task<bool>> isCpuTooBusyFn,
+            Func<int, CancellationToken, Task> delayFn)
+        {
+            _logger = logger;
+            _isCpuTooBusyFn = isCpuTooBusyFn ?? CpuMonitor.IsCpuTooBusyAsync;
+            _delayFn = delayFn ?? DefaultDelay;
+        }
+
+        public async Task WaitForCpuAsync(CancellationToken cancellationToken)
+        {
+            while (await _isCpuTooBusyFn())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                _logger?.Info($"CPU too busy, waiting {RetryDelayMs}ms before retry");
+                await _delayFn(RetryDelayMs, cancellationToken);
+            }
+        }
+
+        private static Task DefaultDelay(int ms, CancellationToken cancellationToken)
+        {
+            return Task.Delay(ms, cancellationToken);
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/NoOpCpuUsageThrottler.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/NoOpCpuUsageThrottler.cs
@@ -1,0 +1,16 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Interfaces.Util;
+
+namespace Codescene.VSExtension.Core.Application.Util
+{
+    public class NoOpCpuUsageThrottler : ICpuUsageThrottler
+    {
+        public Task WaitForCpuAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Util/ICpuUsageThrottler.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Util/ICpuUsageThrottler.cs
@@ -1,0 +1,12 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Codescene.VSExtension.Core.Interfaces.Util
+{
+    public interface ICpuUsageThrottler
+    {
+        Task WaitForCpuAsync(CancellationToken cancellationToken);
+    }
+}


### PR DESCRIPTION
**feat: add CPU monitoring to throttle CLI commands during high load**

Port the CPU monitoring feature from the VS Code extension (d8bf20f).
When CPU usage exceeds adaptive thresholds (65% for <4 cores, 70% for
4-7 cores, 75% for 8+ cores), CLI operations wait with a 9-second retry
delay.

The throttler is injected into `CliExecutor` and waits after acquiring
the semaphore, so queued requests don't all poll CPU simultaneously.
Defaults to no-op when not injected, preserving existing test behavior.

I made sure that the CPU querying facility is equivalent to that used by Node.js.

Verified manually.