### PR TITLE
feat: remove stale files from Code Health Monitor after GitChangeLister runs

### DIFF
--- a/.claude/skills/coderabbit.md
+++ b/.claude/skills/coderabbit.md
@@ -1,0 +1,23 @@
+# coderabbit
+
+Evaluate a code review suggestion, then address it if warranted.
+
+## Arguments
+
+- The review suggestion (paste full text)
+
+## Instructions
+
+1. Locate the relevant code and understand its context
+
+2. Evaluate truthfulness and accuracy:
+   - Is the factual claim correct?
+   - Are there other facts or reasoning that would falsify the reviewer's claim?
+
+3. Evaluate whether it's worth addressing:
+   - Does severity justify a change?
+   - Could the fix introduce new problems?
+
+4. Decide without bias in either direction. State reasoning before acting.
+
+5. If valid and worth it: fix. If not: explain why so the user can respond.

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DeltaCacheServiceTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DeltaCacheServiceTests.cs
@@ -416,6 +416,75 @@ namespace Codescene.VSExtension.Core.Tests
             Assert.AreEqual(1.5m, newResult.Item2.ScoreChange);
         }
 
+        [TestMethod]
+        public void RemoveEntriesNotIn_EmptyCache_ReturnsZero()
+        {
+            var result = _cacheService.RemoveEntriesNotIn(new[] { _tempFile1 });
+
+            Assert.AreEqual(0, result);
+        }
+
+        [TestMethod]
+        public void RemoveEntriesNotIn_NullFilesToKeep_ReturnsZero()
+        {
+            PutCacheEntry(_tempFile1, "b1", "c1", CreateDelta(1.0m));
+
+            var result = _cacheService.RemoveEntriesNotIn(null);
+
+            Assert.AreEqual(0, result);
+            Assert.IsTrue(_cacheService.Contains(_tempFile1));
+        }
+
+        [TestMethod]
+        public void RemoveEntriesNotIn_FilesInKeepSet_AreKept()
+        {
+            PutCacheEntry(_tempFile1, "b1", "c1", CreateDelta(1.0m));
+            PutCacheEntry(_tempFile2, "b2", "c2", CreateDelta(2.0m));
+
+            var result = _cacheService.RemoveEntriesNotIn(new[] { _tempFile1, _tempFile2 });
+
+            Assert.AreEqual(0, result);
+            Assert.IsTrue(_cacheService.Contains(_tempFile1));
+            Assert.IsTrue(_cacheService.Contains(_tempFile2));
+        }
+
+        [TestMethod]
+        public void RemoveEntriesNotIn_FilesNotInKeepSet_AreRemoved()
+        {
+            PutCacheEntry(_tempFile1, "b1", "c1", CreateDelta(1.0m));
+            PutCacheEntry(_tempFile2, "b2", "c2", CreateDelta(2.0m));
+
+            var result = _cacheService.RemoveEntriesNotIn(new[] { _tempFile1 });
+
+            Assert.AreEqual(1, result);
+            Assert.IsTrue(_cacheService.Contains(_tempFile1));
+            Assert.IsFalse(_cacheService.Contains(_tempFile2));
+        }
+
+        [TestMethod]
+        public void RemoveEntriesNotIn_EmptyKeepSet_RemovesAll()
+        {
+            PutCacheEntry(_tempFile1, "b1", "c1", CreateDelta(1.0m));
+            PutCacheEntry(_tempFile2, "b2", "c2", CreateDelta(2.0m));
+
+            var result = _cacheService.RemoveEntriesNotIn(Enumerable.Empty<string>());
+
+            Assert.AreEqual(2, result);
+            Assert.IsFalse(_cacheService.Contains(_tempFile1));
+            Assert.IsFalse(_cacheService.Contains(_tempFile2));
+        }
+
+        [TestMethod]
+        public void RemoveEntriesNotIn_CaseInsensitivePathComparison()
+        {
+            PutCacheEntry(_tempFile1, "b1", "c1", CreateDelta(1.0m));
+
+            var result = _cacheService.RemoveEntriesNotIn(new[] { _tempFile1.ToUpperInvariant() });
+
+            Assert.AreEqual(0, result);
+            Assert.IsTrue(_cacheService.Contains(_tempFile1));
+        }
+
         private static DeltaResponseModel CreateDelta(decimal scoreChange)
         {
             return new DeltaResponseModel { ScoreChange = scoreChange };

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DeltaCacheServiceTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DeltaCacheServiceTests.cs
@@ -140,11 +140,12 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
-        public void RemoveEntriesOutsideRoot_NullOrEmptyRoot_DoesNothing()
+        [DataRow(null)]
+        [DataRow("")]
+        public void RemoveEntriesOutsideRoot_NullOrEmptyRoot_DoesNothing(string root)
         {
             PutCacheEntry(_tempFile, DefaultBaseline, DefaultCurrent, CreateDelta(1.0m));
-            _cacheService.RemoveEntriesOutsideRoot(null);
-            _cacheService.RemoveEntriesOutsideRoot(string.Empty);
+            _cacheService.RemoveEntriesOutsideRoot(root);
             Assert.IsTrue(_cacheService.Get(new DeltaCacheQuery(_tempFile, DefaultBaseline, DefaultCurrent)).Item1);
         }
 
@@ -284,17 +285,11 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
-        public void GetDeltaForFile_NullPath_ReturnsNull()
+        [DataRow(null)]
+        [DataRow("")]
+        public void GetDeltaForFile_NullOrEmptyPath_ReturnsNull(string path)
         {
-            var result = _cacheService.GetDeltaForFile(null);
-
-            Assert.IsNull(result);
-        }
-
-        [TestMethod]
-        public void GetDeltaForFile_EmptyPath_ReturnsNull()
-        {
-            var result = _cacheService.GetDeltaForFile(string.Empty);
+            var result = _cacheService.GetDeltaForFile(path);
 
             Assert.IsNull(result);
         }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DeltaCacheServiceTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/DeltaCacheServiceTests.cs
@@ -480,6 +480,17 @@ namespace Codescene.VSExtension.Core.Tests
             Assert.IsTrue(_cacheService.Contains(_tempFile1));
         }
 
+        [TestMethod]
+        public void RemoveEntriesNotIn_WithNullInKeepSet_ThrowsNullReferenceException()
+        {
+            PutCacheEntry(_tempFile1, "b1", "c1", CreateDelta(1.0m));
+
+            Assert.Throws<NullReferenceException>(() =>
+            {
+                _cacheService.RemoveEntriesNotIn(new[] { _tempFile1, null });
+            });
+        }
+
         private static DeltaResponseModel CreateDelta(decimal scoreChange)
         {
             return new DeltaResponseModel { ScoreChange = scoreChange };

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTests.cs
@@ -1,8 +1,12 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using System.Reflection;
+using Codescene.VSExtension.Core.Application.Cache.Review;
 using Codescene.VSExtension.Core.Application.Git;
 using Codescene.VSExtension.Core.Models;
+using Codescene.VSExtension.Core.Models.Cache.Delta;
+using Codescene.VSExtension.Core.Models.Cli.Delta;
+using Codescene.VSExtension.Core.Util;
 using LibGit2Sharp;
 
 namespace Codescene.VSExtension.Core.Tests
@@ -509,6 +513,46 @@ namespace Codescene.VSExtension.Core.Tests
             {
                 Codescene.VSExtension.Core.Util.DeltaJobTracker.JobStarted -= onJobStarted;
                 Codescene.VSExtension.Core.Util.DeltaJobTracker.JobFinished -= onJobFinished;
+            }
+        }
+
+        [TestMethod]
+        public void OnGitChangeListerFilesDetected_PreservesVisibleFilesInCache()
+        {
+            var visibleFile = CreateFile("visible.cs", "public class Visible {}");
+            var detectedFile = CreateFile("detected.cs", "public class Detected {}");
+
+            var cacheService = new DeltaCacheService();
+            cacheService.Put(new DeltaCacheEntry(visibleFile, "baseline", "current", new DeltaResponseModel { ScoreChange = 1.0m }));
+            Assert.IsTrue(cacheService.Contains(visibleFile), "Cache should contain visible file before test");
+
+            _fakeOpenFilesObserver.AddOpenFile(visibleFile);
+            _fakeGitChangeLister.SimulateFilesDetected(new HashSet<string> { detectedFile });
+
+            Assert.IsTrue(cacheService.Contains(visibleFile), "Visible file should be preserved in cache");
+        }
+
+        [TestMethod]
+        public void OnGitChangeListerFilesDetected_PreservesRunningJobFilesInCache()
+        {
+            var jobFile = CreateFile("running-job.cs", "public class RunningJob {}");
+            var detectedFile = CreateFile("detected.cs", "public class Detected {}");
+
+            var cacheService = new DeltaCacheService();
+            cacheService.Put(new DeltaCacheEntry(jobFile, "baseline", "current", new DeltaResponseModel { ScoreChange = 1.0m }));
+            Assert.IsTrue(cacheService.Contains(jobFile), "Cache should contain job file before test");
+
+            var job = new Job { File = new Codescene.VSExtension.Core.Models.WebComponent.Data.File { FileName = jobFile } };
+            DeltaJobTracker.Add(job);
+            try
+            {
+                _fakeGitChangeLister.SimulateFilesDetected(new HashSet<string> { detectedFile });
+
+                Assert.IsTrue(cacheService.Contains(jobFile), "Running job file should be preserved in cache");
+            }
+            finally
+            {
+                DeltaJobTracker.Remove(job);
             }
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cache/Review/DeltaCacheService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Cache/Review/DeltaCacheService.cs
@@ -156,6 +156,35 @@ namespace Codescene.VSExtension.Core.Application.Cache.Review
             return false;
         }
 
+        public int RemoveEntriesNotIn(IEnumerable<string> filesToKeep)
+        {
+            if (filesToKeep == null)
+            {
+                return 0;
+            }
+
+            var keepSet = new HashSet<string>(
+                filesToKeep.Select(f => GetCacheKey(f)),
+                StringComparer.OrdinalIgnoreCase);
+
+            var keysToRemove = new List<string>();
+
+            foreach (var pair in Cache)
+            {
+                if (!keepSet.Contains(pair.Key))
+                {
+                    keysToRemove.Add(pair.Key);
+                }
+            }
+
+            foreach (var key in keysToRemove)
+            {
+                Cache.TryRemove(key, out _);
+            }
+
+            return keysToRemove.Count;
+        }
+
         private string GetRootPrefix(string gitRootPath)
         {
             return Path.GetFullPath(gitRootPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.DetectedFiles.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.DetectedFiles.cs
@@ -1,13 +1,71 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Application.Cache.Review;
+using Codescene.VSExtension.Core.Util;
 
 namespace Codescene.VSExtension.Core.Application.Git
 {
     public partial class GitChangeObserverCore
     {
+        private void RemoveStaleFilesFromCache(HashSet<string> changedFiles)
+        {
+            try
+            {
+                var filesToKeep = BuildFilesToKeep(changedFiles);
+                var removedCount = new DeltaCacheService().RemoveEntriesNotIn(filesToKeep);
+
+                if (removedCount > 0)
+                {
+                    _logger?.Debug($"Removed {removedCount} stale files from delta cache");
+                    ViewUpdateRequested?.Invoke(this, EventArgs.Empty);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.Warn($"Error removing stale files: {ex.Message}");
+            }
+        }
+
+        private HashSet<string> BuildFilesToKeep(HashSet<string> changedFiles)
+        {
+            var filesToKeep = new HashSet<string>(changedFiles, StringComparer.OrdinalIgnoreCase);
+
+            AddVisibleFiles(filesToKeep);
+            AddRunningJobFiles(filesToKeep);
+
+            return filesToKeep;
+        }
+
+        private void AddVisibleFiles(HashSet<string> filesToKeep)
+        {
+            var visibleFiles = _openFilesObserver?.GetAllVisibleFileNames();
+            if (visibleFiles == null)
+            {
+                return;
+            }
+
+            foreach (var f in visibleFiles)
+            {
+                filesToKeep.Add(f);
+            }
+        }
+
+        private void AddRunningJobFiles(HashSet<string> filesToKeep)
+        {
+            foreach (var job in DeltaJobTracker.RunningJobs)
+            {
+                var fileName = job.File?.FileName;
+                if (!string.IsNullOrEmpty(fileName))
+                {
+                    filesToKeep.Add(fileName);
+                }
+            }
+        }
+
         private async Task ProcessDetectedFileQueueAsync(string filePath, CancellationToken token, string baselineCommit)
         {
             var currentRequest = filePath;

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
@@ -408,6 +408,8 @@ namespace Codescene.VSExtension.Core.Application.Git
                     throw new ArgumentNullException(nameof(absolutePaths));
                 }
 
+                RemoveStaleFilesFromCache(absolutePaths);
+
                 var token = cts.Token;
                 var baselineCommit = _gitService.GetBaselineCommit(_gitRootPath);
                 foreach (var path in absolutePaths.Where(path => !string.IsNullOrWhiteSpace(path)))

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
@@ -408,11 +408,12 @@ namespace Codescene.VSExtension.Core.Application.Git
                     throw new ArgumentNullException(nameof(absolutePaths));
                 }
 
-                RemoveStaleFilesFromCache(absolutePaths);
+                var validPaths = absolutePaths.Where(path => !string.IsNullOrWhiteSpace(path)).ToHashSet();
+                RemoveStaleFilesFromCache(validPaths);
 
                 var token = cts.Token;
                 var baselineCommit = _gitService.GetBaselineCommit(_gitRootPath);
-                foreach (var path in absolutePaths.Where(path => !string.IsNullOrWhiteSpace(path)))
+                foreach (var path in validPaths)
                 {
                     if (_detectedFilesQueue.TryStart(path, path))
                     {


### PR DESCRIPTION
After each periodic `GitChangeLister` scan, files are removed from `DeltaCacheService` if they are not in the changed files set, not currently visible in the editor, and not being actively analyzed.

This prevents the monitor from displaying outdated entries for files that are no longer relevant (deleted, reverted, etc.).

 Port of codescene-vscode commit 9846028bb31b3f.