### PR TITLE
feat: add CPU-based throttling to GitChangeLister periodic scan

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
@@ -113,6 +113,27 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
+        public void TakeSampleSync_ReturnsExpectedCpuUsage()
+        {
+            var callCount = 0;
+            CpuMonitor.SetCoreCountProvider(() => 8);
+            CpuMonitor.SetSnapshotProvider(() =>
+            {
+                callCount++;
+                return new CpuSnapshot
+                {
+                    IdleTime = callCount * 500,
+                    KernelTime = callCount * 1000,
+                    UserTime = callCount * 100,
+                };
+            });
+
+            var result = CpuMonitor.TakeSampleSync();
+
+            Assert.IsTrue(result >= 0 && result <= 100);
+        }
+
+        [TestMethod]
         [DataRow(8, 20, false, DisplayName = "8 cores at 20% usage - below 75% threshold")]
         [DataRow(8, 75, false, DisplayName = "8 cores at 75% usage - at 75% threshold")]
         [DataRow(8, 80, true, DisplayName = "8 cores at 80% usage - above 75% threshold")]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuMonitorTests.cs
@@ -131,6 +131,7 @@ namespace Codescene.VSExtension.Core.Tests
             var result = CpuMonitor.TakeSampleSync();
 
             Assert.IsTrue(result >= 0 && result <= 100);
+            Assert.AreEqual(54.54, result, 0.01);
         }
 
         [TestMethod]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuUsageCheckerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/CpuUsageCheckerTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Application.Util;
+using Moq;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class CpuUsageCheckerTests
+    {
+        private Mock<Codescene.VSExtension.Core.Interfaces.ILogger> _mockLogger;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _mockLogger = new Mock<Codescene.VSExtension.Core.Interfaces.ILogger>();
+        }
+
+        [TestMethod]
+        [DataRow(0, 75)]
+        [DataRow(1, 75)]
+        [DataRow(2, 75)]
+        [DataRow(3, 75)]
+        [DataRow(4, 80)]
+        [DataRow(5, 80)]
+        [DataRow(6, 80)]
+        [DataRow(7, 80)]
+        [DataRow(8, 85)]
+        [DataRow(9, 85)]
+        [DataRow(16, 85)]
+        public void GetThresholdForCoreCount_ReturnsCorrectThreshold_WithTenPercentHigherThanCpuMonitor(int coreCount, int expectedThreshold)
+        {
+            var result = CpuUsageChecker.GetThresholdForCoreCount(coreCount);
+            Assert.AreEqual(expectedThreshold, result);
+        }
+
+        [TestMethod]
+        public void GetThresholdForCoreCount_Is10PercentHigherThanCpuMonitor()
+        {
+            Assert.AreEqual(CpuMonitor.GetThresholdForCoreCount(2) + 10, CpuUsageChecker.GetThresholdForCoreCount(2));
+            Assert.AreEqual(CpuMonitor.GetThresholdForCoreCount(6) + 10, CpuUsageChecker.GetThresholdForCoreCount(6));
+            Assert.AreEqual(CpuMonitor.GetThresholdForCoreCount(8) + 10, CpuUsageChecker.GetThresholdForCoreCount(8));
+        }
+
+        [TestMethod]
+        public async Task IsCpuTooBusyAsync_WhenBelowThreshold_ReturnsFalse()
+        {
+            var sampleCallCount = 0;
+            var checker = new CpuUsageChecker(
+                _mockLogger.Object,
+                () =>
+                {
+                    sampleCallCount++;
+                    return Task.FromResult(50.0);
+                },
+                () => 8);
+
+            var result = await checker.IsCpuTooBusyAsync();
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(5, sampleCallCount);
+        }
+
+        [TestMethod]
+        public async Task IsCpuTooBusyAsync_WhenAboveThreshold_ReturnsTrue()
+        {
+            var checker = new CpuUsageChecker(
+                _mockLogger.Object,
+                () => Task.FromResult(90.0),
+                () => 8);
+
+            var result = await checker.IsCpuTooBusyAsync();
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        [DataRow(8, 50, false, DisplayName = "8 cores at 50% usage - below 85% threshold")]
+        [DataRow(8, 85, false, DisplayName = "8 cores at 85% usage - at 85% threshold")]
+        [DataRow(8, 90, true, DisplayName = "8 cores at 90% usage - above 85% threshold")]
+        [DataRow(6, 50, false, DisplayName = "6 cores at 50% usage - below 80% threshold")]
+        [DataRow(6, 80, false, DisplayName = "6 cores at 80% usage - at 80% threshold")]
+        [DataRow(6, 85, true, DisplayName = "6 cores at 85% usage - above 80% threshold")]
+        [DataRow(2, 50, false, DisplayName = "2 cores at 50% usage - below 75% threshold")]
+        [DataRow(2, 75, false, DisplayName = "2 cores at 75% usage - at 75% threshold")]
+        [DataRow(2, 80, true, DisplayName = "2 cores at 80% usage - above 75% threshold")]
+        public async Task IsCpuTooBusyAsync_WithMockedCoreCount_VerifiesHigherThresholdTiers(
+            int coreCount, int usagePercent, bool expectedTooBusy)
+        {
+            var checker = new CpuUsageChecker(
+                _mockLogger.Object,
+                () => Task.FromResult((double)usagePercent),
+                () => coreCount);
+
+            var result = await checker.IsCpuTooBusyAsync();
+
+            Assert.AreEqual(expectedTooBusy, result);
+        }
+
+        [TestMethod]
+        public async Task IsCpuTooBusyAsync_WhenExceptionOccurs_ReturnsFalseAndLogs()
+        {
+            var checker = new CpuUsageChecker(
+                _mockLogger.Object,
+                () => throw new System.InvalidOperationException("Test exception"),
+                () => 8);
+
+            var result = await checker.IsCpuTooBusyAsync();
+
+            Assert.IsFalse(result);
+            _mockLogger.Verify(x => x.Warn(It.Is<string>(s => s.Contains("CPU check failed"))), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task NoOpCpuUsageChecker_AlwaysReturnsFalse()
+        {
+            var checker = new NoOpCpuUsageChecker();
+
+            var result = await checker.IsCpuTooBusyAsync();
+
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerCpuThrottlingTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerCpuThrottlingTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Interfaces.Util;
+
+namespace Codescene.VSExtension.Core.Tests
+{
+    [TestClass]
+    public class GitChangeListerCpuThrottlingTests : GitChangeDetectorTestBase
+    {
+        [TestMethod]
+        public async Task PeriodicScan_WhenCpuTooBusy_SkipsRun()
+        {
+            var cpuChecker = new FakeCpuUsageChecker { IsBusy = true };
+            var testableLister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                pollingInterval: 5,
+                cpuUsageChecker: cpuChecker);
+
+            testableLister.Initialize(_testRepoPath, new[] { _testRepoPath });
+            testableLister.StartPeriodicScanning(CancellationToken.None);
+
+            CreateFile("test.cs", "content");
+
+            var filesDetected = new HashSet<string>();
+            testableLister.FilesDetected += (sender, files) => filesDetected = files;
+
+            await testableLister.InvokePeriodicScanAsync();
+
+            Assert.IsEmpty(filesDetected, "Should not detect files when CPU is too busy");
+            var infoMessages = _fakeLogger.SnapshotInfoMessages();
+            Assert.IsTrue(
+                infoMessages.Exists(m => m.Contains("CPU usage too high")),
+                "Should log that scan was skipped due to high CPU");
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_WhenCpuNotBusy_ProcessesFiles()
+        {
+            var cpuChecker = new FakeCpuUsageChecker { IsBusy = false };
+            var testableLister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                pollingInterval: 5,
+                cpuUsageChecker: cpuChecker);
+
+            testableLister.Initialize(_testRepoPath, new[] { _testRepoPath });
+            testableLister.StartPeriodicScanning(CancellationToken.None);
+
+            CreateFile("test.cs", "content");
+
+            var filesDetected = new HashSet<string>();
+            testableLister.FilesDetected += (sender, files) => filesDetected = files;
+
+            await testableLister.InvokePeriodicScanAsync();
+
+            Assert.IsNotEmpty(filesDetected, "Should detect files when CPU is not busy");
+            Assert.IsTrue(filesDetected.Any(f => f.Contains("test.cs")), "Should contain the test file");
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_WithNullCpuChecker_ProcessesFiles()
+        {
+            var testableLister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                pollingInterval: 5,
+                cpuUsageChecker: null);
+
+            testableLister.Initialize(_testRepoPath, new[] { _testRepoPath });
+            testableLister.StartPeriodicScanning(CancellationToken.None);
+
+            CreateFile("test.cs", "content");
+
+            var filesDetected = new HashSet<string>();
+            testableLister.FilesDetected += (sender, files) => filesDetected = files;
+
+            await testableLister.InvokePeriodicScanAsync();
+
+            Assert.IsNotEmpty(filesDetected, "Should detect files when no CPU checker is provided");
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_CpuCheckHappensAfterOtherChecks()
+        {
+            var cpuChecker = new FakeCpuUsageChecker { IsBusy = true };
+            var ideActivityTracker = new FakeIdeActivityTracker();
+            ideActivityTracker.SetActiveForTesting(false);
+
+            var testableLister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                pollingInterval: 5,
+                ideActivityTracker: ideActivityTracker,
+                cpuUsageChecker: cpuChecker);
+
+            testableLister.Initialize(_testRepoPath, new[] { _testRepoPath });
+            testableLister.StartPeriodicScanning(CancellationToken.None);
+
+            CreateFile("test.cs", "content");
+
+            await testableLister.InvokePeriodicScanAsync();
+
+            Assert.AreEqual(0, cpuChecker.CheckCount, "CPU checker should not be called if IDE is not active (earlier check fails first)");
+
+            testableLister.Dispose();
+        }
+
+        [TestMethod]
+        public async Task PeriodicScan_WhenCpuBusyThenNotBusy_SecondRunProcessesFiles()
+        {
+            var cpuChecker = new FakeCpuUsageChecker { IsBusy = true };
+            var testableLister = new TestableGitChangeLister(
+                _fakeSavedFilesTracker,
+                _fakeSupportedFileChecker,
+                _fakeLogger,
+                _fakeGitService,
+                pollingInterval: 5,
+                cpuUsageChecker: cpuChecker);
+
+            testableLister.Initialize(_testRepoPath, new[] { _testRepoPath });
+            testableLister.StartPeriodicScanning(CancellationToken.None);
+
+            CreateFile("test.cs", "content");
+
+            var filesDetected = new HashSet<string>();
+            testableLister.FilesDetected += (sender, files) => filesDetected = files;
+
+            await testableLister.InvokePeriodicScanAsync();
+            Assert.IsEmpty(filesDetected, "First run should be skipped due to high CPU");
+
+            cpuChecker.IsBusy = false;
+            filesDetected.Clear();
+
+            await testableLister.InvokePeriodicScanAsync();
+            Assert.IsNotEmpty(filesDetected, "Second run should process files when CPU is available");
+
+            testableLister.Dispose();
+        }
+
+        private class FakeCpuUsageChecker : ICpuUsageChecker
+        {
+            public bool IsBusy { get; set; }
+
+            public int CheckCount { get; private set; }
+
+            public Task<bool> IsCpuTooBusyAsync()
+            {
+                CheckCount++;
+                return Task.FromResult(IsBusy);
+            }
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TestableGitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/TestableGitChangeLister.cs
@@ -5,6 +5,7 @@ using Codescene.VSExtension.Core.Application.Util;
 using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Cli;
 using Codescene.VSExtension.Core.Interfaces.Git;
+using Codescene.VSExtension.Core.Interfaces.Util;
 
 namespace Codescene.VSExtension.Core.Tests
 {
@@ -26,8 +27,9 @@ namespace Codescene.VSExtension.Core.Tests
             ILogger logger,
             IGitService gitService,
             int? pollingInterval = null,
-            IIdeActivityTracker ideActivityTracker = null)
-            : base(savedFilesTracker, supportedFileChecker, logger, gitService, pollingInterval, ideActivityTracker)
+            IIdeActivityTracker ideActivityTracker = null,
+            ICpuUsageChecker cpuUsageChecker = null)
+            : base(savedFilesTracker, supportedFileChecker, logger, gitService, pollingInterval, ideActivityTracker, cpuUsageChecker)
         {
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
@@ -12,6 +12,7 @@ using Codescene.VSExtension.Core.Application.Util;
 using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Cli;
 using Codescene.VSExtension.Core.Interfaces.Git;
+using Codescene.VSExtension.Core.Interfaces.Util;
 using Codescene.VSExtension.Core.Util;
 using LibGit2Sharp;
 
@@ -26,6 +27,7 @@ namespace Codescene.VSExtension.Core.Application.Git
         private readonly ILogger _logger;
         private readonly IGitService _gitService;
         private readonly IIdeActivityTracker _ideActivityTracker;
+        private readonly ICpuUsageChecker _cpuUsageChecker;
         private readonly UntrackedFileProcessor _untrackedFileProcessor;
         private readonly MergeBaseFinder _mergeBaseFinder;
 
@@ -42,13 +44,15 @@ namespace Codescene.VSExtension.Core.Application.Git
             ILogger logger,
             IGitService gitService,
             int? pollingInterval = null,
-            IIdeActivityTracker ideActivityTracker = null)
+            IIdeActivityTracker ideActivityTracker = null,
+            ICpuUsageChecker cpuUsageChecker = null)
         {
             _savedFilesTracker = savedFilesTracker ?? throw new ArgumentNullException(nameof(savedFilesTracker));
             _supportedFileChecker = supportedFileChecker ?? throw new ArgumentNullException(nameof(supportedFileChecker));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _gitService = gitService ?? throw new ArgumentNullException(nameof(gitService));
             _ideActivityTracker = ideActivityTracker;
+            _cpuUsageChecker = cpuUsageChecker;
             _untrackedFileProcessor = new UntrackedFileProcessor(logger);
             _mergeBaseFinder = new MergeBaseFinder(logger);
             if (pollingInterval.HasValue && pollingInterval.Value <= 0)
@@ -320,7 +324,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             var startTime = DateTime.UtcNow;
             try
             {
-                if (!ShouldStartPeriodicScan())
+                if (!await ShouldStartPeriodicScanAsync())
                 {
                     return;
                 }
@@ -377,7 +381,7 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
         }
 
-        private bool ShouldStartPeriodicScan()
+        private async Task<bool> ShouldStartPeriodicScanAsync()
         {
             if (_ideActivityTracker != null && !_ideActivityTracker.IsIdeWindowActive())
             {
@@ -393,6 +397,12 @@ namespace Codescene.VSExtension.Core.Application.Git
             if (ShouldSkipBasedOnDefaultBranch())
             {
                 _logger?.Debug("GitChangeLister: Skipping processing - current branch matches default branch");
+                return false;
+            }
+
+            if (_cpuUsageChecker != null && await _cpuUsageChecker.IsCpuTooBusyAsync())
+            {
+                _logger?.Info("Skipping scheduled git change review: CPU usage too high");
                 return false;
             }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
@@ -100,6 +100,17 @@ namespace Codescene.VSExtension.Core.Application.Util
             return 65;
         }
 
+        internal static double TakeSampleSync()
+        {
+            int coreCount;
+            lock (_snapshotLock)
+            {
+                coreCount = _coreCountProvider();
+            }
+
+            return TakeSample(coreCount);
+        }
+
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool GetSystemTimes(

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuMonitor.cs
@@ -1,27 +1,16 @@
 // Copyright (c) CodeScene. All rights reserved.
 
 using System;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Codescene.VSExtension.Core.Application.Util
 {
     public static class CpuMonitor
     {
-        private const int Samples = 5;
-        private const int SampleDelayMs = 13;
-
-        private static readonly CpuThreshold[] CpuThresholds =
-        {
-            new CpuThreshold { MinCores = 8, Threshold = 75 },
-            new CpuThreshold { MinCores = 4, Threshold = 70 },
-            new CpuThreshold { MinCores = 0, Threshold = 65 },
-        };
-
-        private static readonly object _snapshotLock = new object();
-        private static Func<CpuSnapshot> _snapshotProvider = DefaultSnapshotProvider;
-        private static CpuSnapshot _previousSnapshot = DefaultSnapshotProvider();
-        private static Func<int> _coreCountProvider = () => Environment.ProcessorCount;
+        private static readonly object _samplerLock = new object();
+        private static CpuSampler _sampler = new CpuSampler();
+        private static Func<CpuSnapshot> _customSnapshotProvider;
+        private static Func<int> _customCoreCountProvider;
 
         static CpuMonitor()
         {
@@ -29,153 +18,76 @@ namespace Codescene.VSExtension.Core.Application.Util
 
         public static void SetSnapshotProvider(Func<CpuSnapshot> provider)
         {
-            lock (_snapshotLock)
+            lock (_samplerLock)
             {
-                _snapshotProvider = provider ?? DefaultSnapshotProvider;
-                _previousSnapshot = _snapshotProvider();
+                _customSnapshotProvider = provider;
+                RecreateSampler();
             }
         }
 
         public static void ResetSnapshotProvider()
         {
-            lock (_snapshotLock)
+            lock (_samplerLock)
             {
-                _snapshotProvider = DefaultSnapshotProvider;
-                _previousSnapshot = _snapshotProvider();
+                _customSnapshotProvider = null;
+                RecreateSampler();
             }
         }
 
         public static void SetCoreCountProvider(Func<int> provider)
         {
-            lock (_snapshotLock)
+            lock (_samplerLock)
             {
-                _coreCountProvider = provider ?? (() => Environment.ProcessorCount);
+                _customCoreCountProvider = provider;
+                RecreateSampler();
             }
         }
 
         public static void ResetCoreCountProvider()
         {
-            lock (_snapshotLock)
+            lock (_samplerLock)
             {
-                _coreCountProvider = () => Environment.ProcessorCount;
+                _customCoreCountProvider = null;
+                RecreateSampler();
             }
         }
 
         public static async Task<bool> IsCpuTooBusyAsync()
         {
-            int coreCount;
-            lock (_snapshotLock)
+            CpuSampler sampler;
+            lock (_samplerLock)
             {
-                coreCount = _coreCountProvider();
+                sampler = _sampler;
             }
 
-            double usageSum = 0;
-
-            for (int i = 0; i < Samples; i++)
-            {
-                if (i > 0)
-                {
-                    await Task.Delay(SampleDelayMs);
-                }
-
-                usageSum += TakeSample(coreCount);
-            }
-
-            var averageUsage = usageSum / Samples;
-            var threshold = GetThresholdForCoreCount(coreCount);
-
-            return averageUsage > threshold;
+            return await sampler.IsCpuTooBusyAsync();
         }
 
         internal static int GetThresholdForCoreCount(int coreCount)
         {
-            foreach (var t in CpuThresholds)
+            CpuSampler sampler;
+            lock (_samplerLock)
             {
-                if (coreCount >= t.MinCores)
-                {
-                    return t.Threshold;
-                }
+                sampler = _sampler;
             }
 
-            return 65;
+            return sampler.GetThresholdForCoreCount(coreCount);
         }
 
         internal static double TakeSampleSync()
         {
-            int coreCount;
-            lock (_snapshotLock)
+            CpuSampler sampler;
+            lock (_samplerLock)
             {
-                coreCount = _coreCountProvider();
+                sampler = _sampler;
             }
 
-            return TakeSample(coreCount);
+            return sampler.TakeSampleSync();
         }
 
-        [DllImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool GetSystemTimes(
-            out long idleTime,
-            out long kernelTime,
-            out long userTime);
-
-        private static double TakeSample(int coreCount)
+        private static void RecreateSampler()
         {
-            lock (_snapshotLock)
-            {
-                try
-                {
-                    var current = _snapshotProvider();
-                    var previous = _previousSnapshot;
-                    _previousSnapshot = current;
-
-                    if (previous == null)
-                    {
-                        return 0;
-                    }
-
-                    var idleDiff = current.IdleTime - previous.IdleTime;
-                    var kernelDiff = current.KernelTime - previous.KernelTime;
-                    var userDiff = current.UserTime - previous.UserTime;
-
-                    var totalDiff = kernelDiff + userDiff;
-
-                    if (totalDiff <= 0)
-                    {
-                        return 0;
-                    }
-
-                    var usage = 100.0 - ((100.0 * idleDiff) / totalDiff);
-                    return Math.Min(100, Math.Max(0, usage));
-                }
-                catch
-                {
-                    // Return 0 (not busy) on any error - better to allow CLI operations
-                    // than to block them due to monitoring failures.
-                    return 0;
-                }
-            }
-        }
-
-        private static CpuSnapshot DefaultSnapshotProvider()
-        {
-            if (!GetSystemTimes(out long idleTime, out long kernelTime, out long userTime))
-            {
-                return new CpuSnapshot { IdleTime = 0, KernelTime = 0, UserTime = 0 };
-            }
-
-            return new CpuSnapshot
-            {
-                IdleTime = idleTime,
-                KernelTime = kernelTime,
-                UserTime = userTime,
-            };
-        }
-
-        private class CpuThreshold
-        {
-            public int MinCores { get; set; }
-
-            public int Threshold { get; set; }
+            _sampler = new CpuSampler(0, _customSnapshotProvider, _customCoreCountProvider);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuSampler.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuSampler.cs
@@ -8,8 +8,8 @@ namespace Codescene.VSExtension.Core.Application.Util
 {
     public class CpuSampler
     {
-        private const int DefaultSamples = 5;
-        private const int DefaultSampleDelayMs = 13;
+        internal const int DefaultSamples = 5;
+        internal const int DefaultSampleDelayMs = 13;
 
         private static readonly CpuThreshold[] BaseThresholds =
         {
@@ -54,12 +54,12 @@ namespace Codescene.VSExtension.Core.Application.Util
             int sampleDelayMs)
         {
             _thresholdOffset = thresholdOffset;
-            _snapshotProvider = snapshotProvider ?? DefaultSnapshotProvider;
-            _coreCountProvider = coreCountProvider ?? (() => Environment.ProcessorCount);
             _samples = samples;
             _sampleDelayMs = sampleDelayMs;
-            _usageProvider = null;
+            _coreCountProvider = coreCountProvider ?? (() => Environment.ProcessorCount);
+            _snapshotProvider = snapshotProvider ?? DefaultSnapshotProvider;
             _previousSnapshot = _snapshotProvider();
+            _usageProvider = null;
         }
 
         internal CpuSampler(
@@ -69,22 +69,31 @@ namespace Codescene.VSExtension.Core.Application.Util
             int samples,
             int sampleDelayMs)
         {
-            _thresholdOffset = thresholdOffset;
             _usageProvider = usageProvider;
-            _coreCountProvider = coreCountProvider ?? (() => Environment.ProcessorCount);
-            _samples = samples;
-            _sampleDelayMs = sampleDelayMs;
             _snapshotProvider = null;
             _previousSnapshot = null;
+            _thresholdOffset = thresholdOffset;
+            _samples = samples;
+            _sampleDelayMs = sampleDelayMs;
+            _coreCountProvider = coreCountProvider ?? (() => Environment.ProcessorCount);
+        }
+
+        public static int GetThresholdForCoreCount(int coreCount, int thresholdOffset)
+        {
+            foreach (var t in BaseThresholds)
+            {
+                if (coreCount >= t.MinCores)
+                {
+                    return t.Threshold + thresholdOffset;
+                }
+            }
+
+            return 65 + thresholdOffset;
         }
 
         public async Task<bool> IsCpuTooBusyAsync()
         {
-            int coreCount;
-            lock (_snapshotLock)
-            {
-                coreCount = _coreCountProvider();
-            }
+            var coreCount = _coreCountProvider();
 
             double usageSum = 0;
 
@@ -113,26 +122,19 @@ namespace Codescene.VSExtension.Core.Application.Util
 
         public double TakeSampleSync()
         {
-            int coreCount;
-            lock (_snapshotLock)
+            if (_snapshotProvider == null)
             {
-                coreCount = _coreCountProvider();
+                throw new InvalidOperationException(
+                    "TakeSampleSync is not supported when CpuSampler is constructed with a usageProvider.");
             }
 
+            var coreCount = _coreCountProvider();
             return TakeSample(coreCount);
         }
 
         public int GetThresholdForCoreCount(int coreCount)
         {
-            foreach (var t in BaseThresholds)
-            {
-                if (coreCount >= t.MinCores)
-                {
-                    return t.Threshold + _thresholdOffset;
-                }
-            }
-
-            return 65 + _thresholdOffset;
+            return GetThresholdForCoreCount(coreCount, _thresholdOffset);
         }
 
         [DllImport("kernel32.dll", SetLastError = true)]

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuSampler.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuSampler.cs
@@ -1,0 +1,203 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Codescene.VSExtension.Core.Application.Util
+{
+    public class CpuSampler
+    {
+        private const int DefaultSamples = 5;
+        private const int DefaultSampleDelayMs = 13;
+
+        private static readonly CpuThreshold[] BaseThresholds =
+        {
+            new CpuThreshold { MinCores = 8, Threshold = 75 },
+            new CpuThreshold { MinCores = 4, Threshold = 70 },
+            new CpuThreshold { MinCores = 0, Threshold = 65 },
+        };
+
+        private readonly int _samples;
+        private readonly int _sampleDelayMs;
+        private readonly int _thresholdOffset;
+        private readonly Func<CpuSnapshot> _snapshotProvider;
+        private readonly Func<int> _coreCountProvider;
+        private readonly Func<Task<double>> _usageProvider;
+
+        private readonly object _snapshotLock = new object();
+        private CpuSnapshot _previousSnapshot;
+
+        public CpuSampler()
+            : this(0, null, null)
+        {
+        }
+
+        public CpuSampler(int thresholdOffset)
+            : this(thresholdOffset, null, null)
+        {
+        }
+
+        internal CpuSampler(
+            int thresholdOffset,
+            Func<CpuSnapshot> snapshotProvider,
+            Func<int> coreCountProvider)
+            : this(thresholdOffset, snapshotProvider, coreCountProvider, DefaultSamples, DefaultSampleDelayMs)
+        {
+        }
+
+        internal CpuSampler(
+            int thresholdOffset,
+            Func<CpuSnapshot> snapshotProvider,
+            Func<int> coreCountProvider,
+            int samples,
+            int sampleDelayMs)
+        {
+            _thresholdOffset = thresholdOffset;
+            _snapshotProvider = snapshotProvider ?? DefaultSnapshotProvider;
+            _coreCountProvider = coreCountProvider ?? (() => Environment.ProcessorCount);
+            _samples = samples;
+            _sampleDelayMs = sampleDelayMs;
+            _usageProvider = null;
+            _previousSnapshot = _snapshotProvider();
+        }
+
+        internal CpuSampler(
+            int thresholdOffset,
+            Func<Task<double>> usageProvider,
+            Func<int> coreCountProvider,
+            int samples,
+            int sampleDelayMs)
+        {
+            _thresholdOffset = thresholdOffset;
+            _usageProvider = usageProvider;
+            _coreCountProvider = coreCountProvider ?? (() => Environment.ProcessorCount);
+            _samples = samples;
+            _sampleDelayMs = sampleDelayMs;
+            _snapshotProvider = null;
+            _previousSnapshot = null;
+        }
+
+        public async Task<bool> IsCpuTooBusyAsync()
+        {
+            int coreCount;
+            lock (_snapshotLock)
+            {
+                coreCount = _coreCountProvider();
+            }
+
+            double usageSum = 0;
+
+            for (int i = 0; i < _samples; i++)
+            {
+                if (i > 0)
+                {
+                    await Task.Delay(_sampleDelayMs);
+                }
+
+                if (_usageProvider != null)
+                {
+                    usageSum += await _usageProvider();
+                }
+                else
+                {
+                    usageSum += TakeSample(coreCount);
+                }
+            }
+
+            var averageUsage = usageSum / _samples;
+            var threshold = GetThresholdForCoreCount(coreCount);
+
+            return averageUsage > threshold;
+        }
+
+        public double TakeSampleSync()
+        {
+            int coreCount;
+            lock (_snapshotLock)
+            {
+                coreCount = _coreCountProvider();
+            }
+
+            return TakeSample(coreCount);
+        }
+
+        public int GetThresholdForCoreCount(int coreCount)
+        {
+            foreach (var t in BaseThresholds)
+            {
+                if (coreCount >= t.MinCores)
+                {
+                    return t.Threshold + _thresholdOffset;
+                }
+            }
+
+            return 65 + _thresholdOffset;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetSystemTimes(
+            out long idleTime,
+            out long kernelTime,
+            out long userTime);
+
+        private static CpuSnapshot DefaultSnapshotProvider()
+        {
+            if (!GetSystemTimes(out long idleTime, out long kernelTime, out long userTime))
+            {
+                return new CpuSnapshot { IdleTime = 0, KernelTime = 0, UserTime = 0 };
+            }
+
+            return new CpuSnapshot
+            {
+                IdleTime = idleTime,
+                KernelTime = kernelTime,
+                UserTime = userTime,
+            };
+        }
+
+        private double TakeSample(int coreCount)
+        {
+            lock (_snapshotLock)
+            {
+                try
+                {
+                    var current = _snapshotProvider();
+                    var previous = _previousSnapshot;
+                    _previousSnapshot = current;
+
+                    if (previous == null)
+                    {
+                        return 0;
+                    }
+
+                    var idleDiff = current.IdleTime - previous.IdleTime;
+                    var kernelDiff = current.KernelTime - previous.KernelTime;
+                    var userDiff = current.UserTime - previous.UserTime;
+
+                    var totalDiff = kernelDiff + userDiff;
+
+                    if (totalDiff <= 0)
+                    {
+                        return 0;
+                    }
+
+                    var usage = 100.0 - ((100.0 * idleDiff) / totalDiff);
+                    return Math.Min(100, Math.Max(0, usage));
+                }
+                catch
+                {
+                    return 0;
+                }
+            }
+        }
+
+        private class CpuThreshold
+        {
+            public int MinCores { get; set; }
+
+            public int Threshold { get; set; }
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuUsageChecker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuUsageChecker.cs
@@ -13,8 +13,6 @@ namespace Codescene.VSExtension.Core.Application.Util
     public class CpuUsageChecker : ICpuUsageChecker
     {
         private const int ThresholdOffset = 10;
-        private const int Samples = 5;
-        private const int SampleDelayMs = 13;
 
         private readonly ILogger _logger;
         private readonly CpuSampler _sampler;
@@ -29,7 +27,7 @@ namespace Codescene.VSExtension.Core.Application.Util
             ILogger logger,
             Func<Task<double>> sampleFn,
             Func<int> coreCountProvider)
-            : this(logger, new CpuSampler(ThresholdOffset, sampleFn, coreCountProvider, Samples, SampleDelayMs))
+            : this(logger, new CpuSampler(ThresholdOffset, sampleFn, coreCountProvider, CpuSampler.DefaultSamples, CpuSampler.DefaultSampleDelayMs))
         {
         }
 
@@ -54,8 +52,7 @@ namespace Codescene.VSExtension.Core.Application.Util
 
         internal static int GetThresholdForCoreCount(int coreCount)
         {
-            var sampler = new CpuSampler(ThresholdOffset);
-            return sampler.GetThresholdForCoreCount(coreCount);
+            return CpuSampler.GetThresholdForCoreCount(coreCount, ThresholdOffset);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuUsageChecker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuUsageChecker.cs
@@ -12,23 +12,16 @@ namespace Codescene.VSExtension.Core.Application.Util
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class CpuUsageChecker : ICpuUsageChecker
     {
+        private const int ThresholdOffset = 10;
         private const int Samples = 5;
         private const int SampleDelayMs = 13;
 
-        private static readonly CpuThreshold[] CpuThresholds =
-        {
-            new CpuThreshold { MinCores = 8, Threshold = 85 },
-            new CpuThreshold { MinCores = 4, Threshold = 80 },
-            new CpuThreshold { MinCores = 0, Threshold = 75 },
-        };
-
         private readonly ILogger _logger;
-        private readonly Func<Task<double>> _sampleFn;
-        private readonly Func<int> _coreCountProvider;
+        private readonly CpuSampler _sampler;
 
         [ImportingConstructor]
         public CpuUsageChecker(ILogger logger)
-            : this(logger, null, null)
+            : this(logger, new CpuSampler(ThresholdOffset))
         {
         }
 
@@ -36,33 +29,21 @@ namespace Codescene.VSExtension.Core.Application.Util
             ILogger logger,
             Func<Task<double>> sampleFn,
             Func<int> coreCountProvider)
+            : this(logger, new CpuSampler(ThresholdOffset, sampleFn, coreCountProvider, Samples, SampleDelayMs))
+        {
+        }
+
+        internal CpuUsageChecker(ILogger logger, CpuSampler sampler)
         {
             _logger = logger;
-            _sampleFn = sampleFn ?? DefaultSampleAsync;
-            _coreCountProvider = coreCountProvider ?? (() => Environment.ProcessorCount);
+            _sampler = sampler;
         }
 
         public async Task<bool> IsCpuTooBusyAsync()
         {
             try
             {
-                var coreCount = _coreCountProvider();
-                double usageSum = 0;
-
-                for (int i = 0; i < Samples; i++)
-                {
-                    if (i > 0)
-                    {
-                        await Task.Delay(SampleDelayMs);
-                    }
-
-                    usageSum += await _sampleFn();
-                }
-
-                var averageUsage = usageSum / Samples;
-                var threshold = GetThresholdForCoreCount(coreCount);
-
-                return averageUsage > threshold;
+                return await _sampler.IsCpuTooBusyAsync();
             }
             catch (Exception ex)
             {
@@ -73,27 +54,8 @@ namespace Codescene.VSExtension.Core.Application.Util
 
         internal static int GetThresholdForCoreCount(int coreCount)
         {
-            foreach (var t in CpuThresholds)
-            {
-                if (coreCount >= t.MinCores)
-                {
-                    return t.Threshold;
-                }
-            }
-
-            return 75;
-        }
-
-        private static async Task<double> DefaultSampleAsync()
-        {
-            return await Task.Run(() => CpuMonitor.TakeSampleSync());
-        }
-
-        private class CpuThreshold
-        {
-            public int MinCores { get; set; }
-
-            public int Threshold { get; set; }
+            var sampler = new CpuSampler(ThresholdOffset);
+            return sampler.GetThresholdForCoreCount(coreCount);
         }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuUsageChecker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/CpuUsageChecker.cs
@@ -1,0 +1,99 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Interfaces;
+using Codescene.VSExtension.Core.Interfaces.Util;
+
+namespace Codescene.VSExtension.Core.Application.Util
+{
+    [Export(typeof(ICpuUsageChecker))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public class CpuUsageChecker : ICpuUsageChecker
+    {
+        private const int Samples = 5;
+        private const int SampleDelayMs = 13;
+
+        private static readonly CpuThreshold[] CpuThresholds =
+        {
+            new CpuThreshold { MinCores = 8, Threshold = 85 },
+            new CpuThreshold { MinCores = 4, Threshold = 80 },
+            new CpuThreshold { MinCores = 0, Threshold = 75 },
+        };
+
+        private readonly ILogger _logger;
+        private readonly Func<Task<double>> _sampleFn;
+        private readonly Func<int> _coreCountProvider;
+
+        [ImportingConstructor]
+        public CpuUsageChecker(ILogger logger)
+            : this(logger, null, null)
+        {
+        }
+
+        internal CpuUsageChecker(
+            ILogger logger,
+            Func<Task<double>> sampleFn,
+            Func<int> coreCountProvider)
+        {
+            _logger = logger;
+            _sampleFn = sampleFn ?? DefaultSampleAsync;
+            _coreCountProvider = coreCountProvider ?? (() => Environment.ProcessorCount);
+        }
+
+        public async Task<bool> IsCpuTooBusyAsync()
+        {
+            try
+            {
+                var coreCount = _coreCountProvider();
+                double usageSum = 0;
+
+                for (int i = 0; i < Samples; i++)
+                {
+                    if (i > 0)
+                    {
+                        await Task.Delay(SampleDelayMs);
+                    }
+
+                    usageSum += await _sampleFn();
+                }
+
+                var averageUsage = usageSum / Samples;
+                var threshold = GetThresholdForCoreCount(coreCount);
+
+                return averageUsage > threshold;
+            }
+            catch (Exception ex)
+            {
+                _logger?.Warn($"CPU check failed: {ex.Message}");
+                return false;
+            }
+        }
+
+        internal static int GetThresholdForCoreCount(int coreCount)
+        {
+            foreach (var t in CpuThresholds)
+            {
+                if (coreCount >= t.MinCores)
+                {
+                    return t.Threshold;
+                }
+            }
+
+            return 75;
+        }
+
+        private static async Task<double> DefaultSampleAsync()
+        {
+            return await Task.Run(() => CpuMonitor.TakeSampleSync());
+        }
+
+        private class CpuThreshold
+        {
+            public int MinCores { get; set; }
+
+            public int Threshold { get; set; }
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/NoOpCpuUsageChecker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Util/NoOpCpuUsageChecker.cs
@@ -1,0 +1,15 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Threading.Tasks;
+using Codescene.VSExtension.Core.Interfaces.Util;
+
+namespace Codescene.VSExtension.Core.Application.Util
+{
+    public class NoOpCpuUsageChecker : ICpuUsageChecker
+    {
+        public Task<bool> IsCpuTooBusyAsync()
+        {
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Util/ICpuUsageChecker.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Util/ICpuUsageChecker.cs
@@ -1,0 +1,11 @@
+// Copyright (c) CodeScene. All rights reserved.
+
+using System.Threading.Tasks;
+
+namespace Codescene.VSExtension.Core.Interfaces.Util
+{
+    public interface ICpuUsageChecker
+    {
+        Task<bool> IsCpuTooBusyAsync();
+    }
+}

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitChangeListerService.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.VS2022/Application/Git/GitChangeListerService.cs
@@ -5,6 +5,7 @@ using Codescene.VSExtension.Core.Application.Git;
 using Codescene.VSExtension.Core.Interfaces;
 using Codescene.VSExtension.Core.Interfaces.Cli;
 using Codescene.VSExtension.Core.Interfaces.Git;
+using Codescene.VSExtension.Core.Interfaces.Util;
 
 namespace Codescene.VSExtension.VS2022.Application.Git
 {
@@ -18,8 +19,9 @@ namespace Codescene.VSExtension.VS2022.Application.Git
             ISupportedFileChecker supportedFileChecker,
             ILogger logger,
             IGitService gitService,
-            IIdeActivityTracker ideActivityTracker)
-            : base(savedFilesTracker, supportedFileChecker, logger, gitService, ideActivityTracker: ideActivityTracker)
+            IIdeActivityTracker ideActivityTracker,
+            ICpuUsageChecker cpuUsageChecker)
+            : base(savedFilesTracker, supportedFileChecker, logger, gitService, ideActivityTracker: ideActivityTracker, cpuUsageChecker: cpuUsageChecker)
         {
         }
     }


### PR DESCRIPTION
This is a less important optimization aimed at reducing internal activity whenever we predict that most triggered reviews would be throttled. 

Skip periodic git change scans when CPU usage is too high. Uses higher thresholds than CLI throttling (+10% per tier: 75%/80%/85% vs 65%/70%/75%) so the periodic scan is harder to throttle. (We want it to be less likely because it's less important)

Unlike CLI throttling which waits and retries, the GitChangeLister simply skips the specific run when CPU is busy. 

Verified manually.