### PR TITLE
refactor: remove default branch skipping from GitChangeLister

### DIFF
--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingGitObservers.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.SubcutaneousTests/RecordingGitObservers.cs
@@ -34,10 +34,10 @@ public sealed class RecordingGitChangeLister : IGitChangeLister, IDisposable
         return _inner.GetChangedFilesVsMergeBaseAsync(gitRootPath, workspacePath, cancellationToken);
     }
 
-    public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths, DefaultBranchGate? defaultBranchGate = null)
+    public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths)
     {
         _journal.Record("lister.initialize", gitRootPath, $"workspaceCount={workspacePaths.Count}");
-        _inner.Initialize(gitRootPath, workspacePaths, defaultBranchGate);
+        _inner.Initialize(gitRootPath, workspacePaths);
     }
 
     public void SetWorkspacePaths(IReadOnlyCollection<string> workspacePaths)
@@ -63,11 +63,6 @@ public sealed class RecordingGitChangeLister : IGitChangeLister, IDisposable
         var files = await _inner.CollectFilesFromRepoStateAsync(gitRootPath, workspacePaths, cancellationToken);
         _journal.Record("lister.collect.completed", detail: $"count={files.Count}");
         return files;
-    }
-
-    public void InvalidateDefaultBranchCache()
-    {
-        _inner.InvalidateDefaultBranchCache();
     }
 
     public void Dispose()

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerEdgeCasesTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerEdgeCasesTests.cs
@@ -308,7 +308,7 @@ namespace Codescene.VSExtension.Core.Tests
         }
 
         [TestMethod]
-        public async Task PeriodicScanAsync_SkipsWhenOnDefaultBranch()
+        public async Task PeriodicScanAsync_ProceedsEvenWhenOnDefaultBranch()
         {
             using (var repo = new Repository(_testRepoPath))
             {
@@ -316,8 +316,6 @@ namespace Codescene.VSExtension.Core.Tests
                 repo.Refs.Add($"refs/remotes/origin/{currentBranch}", repo.Head.Tip.Id);
                 repo.Refs.Add("refs/remotes/origin/HEAD", repo.Refs[$"refs/remotes/origin/{currentBranch}"]);
             }
-
-            var defaultBranchGate = new DefaultBranchGate(_testRepoPath);
 
             var testableInstance = new TestableGitChangeLister(
                 _fakeSavedFilesTracker,
@@ -327,9 +325,9 @@ namespace Codescene.VSExtension.Core.Tests
 
             try
             {
-                testableInstance.Initialize(_testRepoPath, new[] { _testRepoPath }, defaultBranchGate);
+                testableInstance.Initialize(_testRepoPath, new[] { _testRepoPath });
 
-                var newFile = Path.Combine(_testRepoPath, "should-not-scan-on-main.cs");
+                var newFile = Path.Combine(_testRepoPath, "should-scan-on-main.cs");
                 File.WriteAllText(newFile, "content");
 
                 var eventFired = false;
@@ -337,7 +335,7 @@ namespace Codescene.VSExtension.Core.Tests
 
                 await testableInstance.InvokePeriodicScanAsync();
 
-                Assert.IsFalse(eventFired, "Should not fire event when on default branch");
+                Assert.IsTrue(eventFired, "Should fire event even when on default branch");
             }
             finally
             {

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeListerTests.cs
@@ -492,20 +492,5 @@ namespace Codescene.VSExtension.Core.Tests
                 Assert.IsTrue(result.All(f => f.Contains("real")), "All returned files should be non-ignored files");
             }
         }
-
-        [TestMethod]
-        public async Task GetAllChangedFilesAsync_NullDefaultBranchGate_DoesNotSkip()
-        {
-            var listerWithoutGate = new GitChangeLister(_fakeSavedFilesTracker, _fakeSupportedFileChecker, _fakeLogger, _fakeGitService);
-            listerWithoutGate.Initialize(null, new[] { _testRepoPath });
-
-            var newFile = Path.Combine(_testRepoPath, "new-file.cs");
-            File.WriteAllText(newFile, "public class NewClass { }");
-
-            var result = await listerWithoutGate.GetAllChangedFilesAsync(_testRepoPath, _testRepoPath);
-
-            Assert.HasCount(1, result, "Should detect file even when _defaultBranchGate is null");
-            Assert.Contains(newFile, result, "Should contain the new file");
-        }
     }
 }

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core.Tests/GitChangeObserverCoreTestHelpers.cs
@@ -511,7 +511,7 @@ namespace Codescene.VSExtension.Core.Tests
             return Task.FromResult(new HashSet<string>());
         }
 
-        public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths, DefaultBranchGate defaultBranchGate = null)
+        public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths)
         {
         }
 
@@ -535,10 +535,6 @@ namespace Codescene.VSExtension.Core.Tests
             }
 
             return Task.FromResult(FilesToReturn);
-        }
-
-        public void InvalidateDefaultBranchCache()
-        {
         }
 
         public void SimulateFilesDetected(HashSet<string> files)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeLister.cs
@@ -31,7 +31,6 @@ namespace Codescene.VSExtension.Core.Application.Git
         private readonly UntrackedFileProcessor _untrackedFileProcessor;
         private readonly MergeBaseFinder _mergeBaseFinder;
 
-        private DefaultBranchGate _defaultBranchGate;
         private string _gitRootPath;
         private IReadOnlyCollection<string> _workspacePaths;
         private DroppingScheduledExecutor _scheduledExecutor;
@@ -99,11 +98,10 @@ namespace Codescene.VSExtension.Core.Application.Git
             return ExecuteAndLogAsync(gitRootPath, workspacePaths, "getting changed files vs merge base", "GetChangedFilesVsMergeBaseAsync found", GetChangedFilesVsMergeBase, cancellationToken);
         }
 
-        public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths, DefaultBranchGate defaultBranchGate = null)
+        public void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths)
         {
             _gitRootPath = gitRootPath;
             _workspacePaths = workspacePaths ?? Array.Empty<string>();
-            _defaultBranchGate = defaultBranchGate ?? (!string.IsNullOrEmpty(gitRootPath) ? new DefaultBranchGate(gitRootPath) : null);
 #if FEATURE_INITIAL_GIT_OBSERVER
             _logger?.Info($">>> GitChangeLister: Initialized with gitRoot='{gitRootPath}', workspacePaths count={_workspacePaths.Count}");
 #endif
@@ -151,11 +149,6 @@ namespace Codescene.VSExtension.Core.Application.Git
         public virtual Task<HashSet<string>> CollectFilesFromRepoStateAsync(string gitRootPath, IReadOnlyCollection<string> workspacePaths, CancellationToken cancellationToken = default)
         {
             return ExecuteAndLogAsync(gitRootPath, workspacePaths, "collecting files from repo state", "CollectFilesFromRepoStateAsync collected", CollectFilesFromRepoState, cancellationToken);
-        }
-
-        public void InvalidateDefaultBranchCache()
-        {
-            _defaultBranchGate?.InvalidateCache();
         }
 
         public void Dispose()
@@ -394,12 +387,6 @@ namespace Codescene.VSExtension.Core.Application.Git
                 return false;
             }
 
-            if (ShouldSkipBasedOnDefaultBranch())
-            {
-                _logger?.Debug("GitChangeLister: Skipping processing - current branch matches default branch");
-                return false;
-            }
-
             if (_cpuUsageChecker != null && await _cpuUsageChecker.IsCpuTooBusyAsync())
             {
                 _logger?.Info("Skipping scheduled git change review: CPU usage too high");
@@ -407,11 +394,6 @@ namespace Codescene.VSExtension.Core.Application.Git
             }
 
             return true;
-        }
-
-        private bool ShouldSkipBasedOnDefaultBranch()
-        {
-            return _defaultBranchGate?.ShouldSkipForCurrentBranch() ?? false;
         }
 
         private bool IsValidGitRoot(string gitRootPath)

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Application/Git/GitChangeObserverCore.cs
@@ -110,7 +110,7 @@ namespace Codescene.VSExtension.Core.Application.Git
 #endif
 
             _workspacePaths = watchPaths != null && watchPaths.Count > 0 ? watchPaths : new[] { _workspacePath };
-            _gitChangeLister.Initialize(_gitRootPath, _workspacePaths, _defaultBranchGate);
+            _gitChangeLister.Initialize(_gitRootPath, _workspacePaths);
             _gitChangeLister.FilesDetected += OnGitChangeListerFilesDetected;
 
             _fileChangeHandler = new FileChangeHandler(_logger, _codeReviewer, _supportedFileChecker, _workspacePaths, _trackerManager, _gitService, _gitRootPath, OnFileDeleted, openDocumentContentProvider);
@@ -359,7 +359,6 @@ namespace Codescene.VSExtension.Core.Application.Git
         {
             _gitChangeDetector?.ClearMainBranchCandidatesCache(_gitRootPath);
             _defaultBranchGate?.InvalidateCache();
-            _gitChangeLister?.InvalidateDefaultBranchCache();
             InvalidateTrackedFiles(onlyIgnored: false);
         }
 

--- a/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitChangeLister.cs
+++ b/Codescene.VSExtension.VS2022/Codescene.VSExtension.Core/Interfaces/Git/IGitChangeLister.cs
@@ -16,7 +16,7 @@ namespace Codescene.VSExtension.Core.Interfaces.Git
 
         Task<HashSet<string>> GetChangedFilesVsMergeBaseAsync(string gitRootPath, string workspacePath, CancellationToken cancellationToken = default);
 
-        void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths, DefaultBranchGate defaultBranchGate = null);
+        void Initialize(string gitRootPath, IReadOnlyCollection<string> workspacePaths);
 
         void SetWorkspacePaths(IReadOnlyCollection<string> workspacePaths);
 
@@ -25,7 +25,5 @@ namespace Codescene.VSExtension.Core.Interfaces.Git
         void StopPeriodicScanning();
 
         Task<HashSet<string>> CollectFilesFromRepoStateAsync(string gitRootPath, IReadOnlyCollection<string> workspacePaths, CancellationToken cancellationToken = default);
-
-        void InvalidateDefaultBranchCache();
     }
 }


### PR DESCRIPTION
Removes default branch detection and skip logic from `GitChangeLister` periodic scanning to ensure git-based reviews run even when the user is on the main/master branch. This allows developers working on the default branch to receive code reviews for their changes.

The `GitChangeObserverCore` filesystem watcher continues to skip non-delete events on the default branch, maintaining the original behavior for file system change events while enabling periodic git scans on all branches.

Changes:
- Remove `_defaultBranchGate` field and related skip logic from `GitChangeLister.ShouldStartPeriodicScanAsync()`
- Remove `defaultBranchGate` parameter from `IGitChangeLister.Initialize()`
- Remove `InvalidateDefaultBranchCache()` method from interface and implementations
- Update test `PeriodicScanAsync_SkipsWhenOnDefaultBranch` to verify scanning now proceeds on default branch
- Remove obsolete test `GetAllChangedFilesAsync_NullDefaultBranchGate_DoesNotSkip`