### PR TITLE
fix(release): ensure tags are pushed to remote

### DIFF
--- a/release.ps1
+++ b/release.ps1
@@ -131,10 +131,13 @@ function Commit-And-Tag {
     git add -- $manifest $vsix $changelog | Out-Null
     $commitMsg = "chore(release): v$version"
     git commit -m $commitMsg
-    git tag "v$version"
+    git tag -a "v$version" -m "Release v$version"
     Write-Host ""
-    Write-Host "✔ Release v$version created."
-    Write-Host "   Push with: git push --follow-tags"
+    Write-Host "Release v$version created."
+    Write-Host "Pushing to remote..."
+    git push
+    git push origin "v$version"
+    Write-Host "Pushed successfully."
 }
 
 function Main {


### PR DESCRIPTION
Changes the release script to create annotated tags and automatically push them to the remote repository. Previously, lightweight tags were created and `git push --follow-tags` was suggested but didn't work reliably.

Now uses `git tag -a` to create proper annotated release tags, followed by explicit push commands to ensure both the commit and tag reach the remote.

Also removes emoji character from output message to ensure compatibility across different terminal environments.